### PR TITLE
Remove flake-utils dependency + cache setup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1662027324,
@@ -33,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,71 +1,80 @@
 {
   description = "ocaml-packages-overlay";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=37d145eafc8023e0b46c94a50fa3f5a9f2ec4b48";
-    flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs?rev=37d145eafc8023e0b46c94a50fa3f5a9f2ec4b48";
+
+  nixConfig = {
+    extra-substituters = ["https://anmonteiro.nix-cache.workers.dev"];
+    extra-trusted-public-keys = ["ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY="];
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    let
-      patchChannel = { system, channel }:
-        let
-          patches = [ ];
-        in
-        if patches == [ ]
-        then channel
-        else
-          (import channel { inherit system; }).pkgs.applyPatches {
-            name = "nixpkgs-patched";
-            src = channel;
-            patches = patches;
-          };
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+    patchChannel = {
+      system,
+      channel,
+    }: let
+      patches = [];
     in
+      if patches == []
+      then channel
+      else
+        (import channel {inherit system;}).pkgs.applyPatches {
+          name = "nixpkgs-patched";
+          src = channel;
+          patches = patches;
+        };
+  in {
+    lib = nixpkgs.lib;
 
-    {
-      lib = nixpkgs.lib;
+    hydraJobs = builtins.listToAttrs (map
+      (system: {
+        name = system;
+        value = import ./ci/hydra.nix {
+          inherit system;
+          pkgs = self.packages.${system};
+        };
+      })
+      ["x86_64-linux" "aarch64-darwin"]);
 
-      hydraJobs = builtins.listToAttrs (map
-        (system: {
-          name = system;
-          value = (import ./ci/hydra.nix {
-            inherit system;
-            pkgs = self.packages.${system};
-          });
-        })
-        [ "x86_64-linux" "aarch64-darwin" ]);
+    makePkgs = {
+      system,
+      extraOverlays ? [],
+      ...
+    } @ attrs: let
+      pkgs = import nixpkgs ({
+          inherit system;
+          overlays = [self.overlays.default.${system}];
+          config.allowUnfree = true;
+        }
+        // attrs);
+    in
+      /*
+      You might read https://nixos.org/manual/nixpkgs/stable/#sec-overlays-argument and want to change this
+      but because of how we're doing overlays we will be overriding any extraOverlays if we don't use `appendOverlays`
+      */
+      pkgs.appendOverlays extraOverlays;
 
-      makePkgs = { system, extraOverlays ? [ ], ... }@attrs:
-        let
-          pkgs = import nixpkgs ({
-            inherit system;
-            overlays = [ self.overlays.${system}.default ];
-            config.allowUnfree = true;
-          } // attrs);
-        in
-          /*
-            You might read https://nixos.org/manual/nixpkgs/stable/#sec-overlays-argument and want to change this
-            but because of how we're doing overlays we will be overriding any extraOverlays if we don't use `appendOverlays`
-          */
-        pkgs.appendOverlays extraOverlays;
-    } // flake-utils.lib.eachDefaultSystem (system:
-      {
-        packages = self.makePkgs { inherit system; };
-        legacyPackages = self.packages.${system};
+    packages = forAllSystems (system: self.makePkgs {inherit system;});
+    legacyPackages = forAllSystems (system: self.packages.${system});
 
-        overlays.default = (final: prev:
-          let
-            channel = patchChannel {
-              inherit system;
-              channel = nixpkgs;
-            };
-          in
-
-          import channel {
-            inherit system;
-            overlays = [ (import ./overlay channel) ];
-            config.allowUnfree = true;
-          }
-        );
-      });
+    overlays.default = forAllSystems (system: (
+      final: prev: let
+        channel = patchChannel {
+          inherit system;
+          channel = nixpkgs;
+        };
+      in
+        import channel {
+          inherit system;
+          overlays = [(import ./overlay channel)];
+          config.allowUnfree = true;
+        }
+    ));
+  };
 }


### PR DESCRIPTION
Do note that it is `overlays.default.${system}` now as opposed to overlays.${system}.default 

It's essentially an incorrect use of overlays to add a system attribute to overlays, but to keep the PR simple I had no choice here.

If you want to maintain compatibility you could pass default inside the forAllSystems

 I'll leave that decision to the maintainers.