### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -264,6 +264,7 @@ let
     "ocamlformat-rpc"
 
     "metapp"
+    "lambdapi"
   ];
 
   darwinIgnores = [

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662859662,
-        "narHash": "sha256-RA7sErkXxEqU7vspxKnquDSQ6zUAlmXFrlNoYLpu64U=",
+        "lastModified": 1662940775,
+        "narHash": "sha256-SIgHTMjM+PqXWaXDzXsy/XmrDuTu7zpPvizgS7C9n+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c00a58c5a8ee11941dbf91c82d254c1992d12806",
+        "rev": "faa93c4e19e79e7a6de31d6d3492b8f00760ca82",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c00a58c5a8ee11941dbf91c82d254c1992d12806",
+        "rev": "faa93c4e19e79e7a6de31d6d3492b8f00760ca82",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=c00a58c5a8ee11941dbf91c82d254c1992d12806";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=faa93c4e19e79e7a6de31d6d3492b8f00760ca82";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/4fe8af2162f6e0068ba8c87364a44e98b9f5ab84><pre>ocamlPackages.timed: init at 1.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/4f742d45353d8aebad90095c4d3cba39e7721a9c><pre>ocamlPackages.bindlib: init at 6.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b361e1895f4be7837fe34f023af5fc38b31cba58><pre>ocamlPackages.dedukti: init at 2.7</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/1b327858f9034590e8e039f601f538ed364dde2d><pre>ocamlPackages.pratter: init at 2.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/d10610180692407be0a7e457f8d2b029fd9f705b><pre>ocamlPackages.lambdapi: init at 2.2.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/faa93c4e19e79e7a6de31d6d3492b8f00760ca82><pre>Merge pull request #190856 from r-ryantm/auto-update/nerdctl

nerdctl: 0.22.2 -> 0.23.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/faa93c4e19e79e7a6de31d6d3492b8f00760ca82><pre>Merge pull request #190856 from r-ryantm/auto-update/nerdctl

nerdctl: 0.22.2 -> 0.23.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/faa93c4e19e79e7a6de31d6d3492b8f00760ca82><pre>Merge pull request #190856 from r-ryantm/auto-update/nerdctl

nerdctl: 0.22.2 -> 0.23.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/faa93c4e19e79e7a6de31d6d3492b8f00760ca82><pre>Merge pull request #190856 from r-ryantm/auto-update/nerdctl

nerdctl: 0.22.2 -> 0.23.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/faa93c4e19e79e7a6de31d6d3492b8f00760ca82><pre>Merge pull request #190856 from r-ryantm/auto-update/nerdctl

nerdctl: 0.22.2 -> 0.23.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/faa93c4e19e79e7a6de31d6d3492b8f00760ca82><pre>Merge pull request #190856 from r-ryantm/auto-update/nerdctl

nerdctl: 0.22.2 -> 0.23.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/c00a58c5a8ee11941dbf91c82d254c1992d12806...faa93c4e19e79e7a6de31d6d3492b8f00760ca82