### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663469789,
-        "narHash": "sha256-gRit+N7yxig0pJ+2XwVA4cBFmeHtIYp5XsJv3TOds+Y=",
+        "lastModified": 1663551482,
+        "narHash": "sha256-FzXELLczlFzt8+HMsGo1upHl7/0j2z2cWw9NwmtMJcU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2b03570d0cfaad53227318bcafd889087e648bc5",
+        "rev": "5cd66a72e8698e49b89d5df66365215470eea295",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2b03570d0cfaad53227318bcafd889087e648bc5",
+        "rev": "5cd66a72e8698e49b89d5df66365215470eea295",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=2b03570d0cfaad53227318bcafd889087e648bc5";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=5cd66a72e8698e49b89d5df66365215470eea295";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/conan/default.nix
+++ b/ocaml/conan/default.nix
@@ -9,8 +9,6 @@
 , mirage-console-unix
 , mirage-clock-unix
 , mirage-logs
-, mirage-types
-, mirage-types-lwt
 , mirage-runtime
 , re
 , uutf
@@ -21,8 +19,8 @@ buildDunePackage {
   pname = "conan";
   version = "0.0.1";
   src = builtins.fetchurl {
-    url = https://github.com/mirage/conan/releases/download/v0.0.1/conan-cli-v0.0.1.tbz;
-    sha256 = "1xrg238bzqj0gk2i49va9nqzq7yl917awpi41nwkc1lq7k98alb2";
+    url = https://github.com/mirage/conan/releases/download/v0.0.2/conan-cli-0.0.2.tbz;
+    sha256 = "11d35nrapldwbr1qmxj50y560jhp3qyyh9iaxkcqhq0r4im4r5r7";
   };
 
   doCheck = false;
@@ -38,8 +36,6 @@ buildDunePackage {
     mirage-console-unix
     mirage-clock-unix
     mirage-logs
-    mirage-types
-    mirage-types-lwt
     mirage-runtime
   ];
 }

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -47,9 +47,6 @@ in
 with oself;
 
 {
-  # A snapshot test is failing because of the cmdliner upgrade.
-  alcotest = disableTests osuper.alcotest;
-
   ansiterminal = disableTests osuper.ansiterminal;
 
   apron = osuper.apron.overrideAttrs (_: {
@@ -271,8 +268,6 @@ with oself;
 
   carton = disableTests osuper.carton;
 
-  cmdliner = cmdliner_1_1;
-
   cohttp = osuper.cohttp.overrideAttrs (_: {
     postPatch = ''
       substituteInPlace ./cohttp/src/dune --replace "bytes" ""
@@ -358,8 +353,6 @@ with oself;
       rev = "0cbe3ea7e990a7d233360e6a74b1cb5e712501ad";
       sha256 = "+92SFFI24HEZe2By990wQKGaR6McggSR711tQHTpiis=";
     };
-
-    patches = [ ];
 
     doCheck = lib.versionAtLeast ocaml.version "5.0";
   });
@@ -501,7 +494,6 @@ with oself;
       sha256 = "11m2zxra43ag2xsmc6mnaq36hnq3g2kql15d6dik4hw0jq7f2dz8";
     };
     doCheck = false;
-    patches = [ ];
   });
 
   eio =
@@ -580,13 +572,6 @@ with oself;
     postPatch = ''
       substituteInPlace "src/lib/fileutils/dune" --replace "(libraries " "(libraries camlp-streams "
     '';
-  });
-
-  functoria = osuper.functoria.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/functoria/releases/download/v3.1.2/functoria-3.1.2.tbz;
-      sha256 = "1yh0gkf6f2g960mcnrpilhj3xrszr98hy4zkav078f6amxcmwyl4";
-    };
   });
 
   gen = buildDunePackage {
@@ -1160,7 +1145,7 @@ with oself;
     };
   };
 
-  ocp-build = (osuper.ocp-build.override { cmdliner = cmdliner_1_0; }).overrideDerivation (o: {
+  ocp-build = osuper.ocp-build.overrideDerivation (o: {
     preConfigure = "";
   });
 

--- a/ocaml/esy/default.nix
+++ b/ocaml/esy/default.nix
@@ -30,6 +30,15 @@ let
         url = https://github.com/mirage/alcotest/releases/download/1.4.0/alcotest-mirage-1.4.0.tbz;
         sha256 = "1h9yp44snb6sgm5g1x3wg4gwjscic7i56jf0j8jr07355pxwrami";
       };
+      propagatedBuildInputs = with self; [
+        astring
+        cmdliner
+        fmt
+        uuidm
+        re
+        stdlib-shims
+        uutf
+      ];
     });
 
     cmdliner =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/6260b4f4285cefd8106bb9e21a9d9f8d6fba7fe0><pre>ocamlPackages.ocp-build: pin cmdliner to 1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/af34e3be8c7d11b89779ccb5617c0c5f843dda6b><pre>ocamlPackages.cmdliner: default to 1.1

ocamlPackages.alcotest: 1.5.0 → 1.6.0

ocamlPackages.crowbar: 0.2 → 0.2.1

ocamlPackages.dune-release: 1.5.1 → 1.6.2

ocamlPackages.functoria: 3.1.1 → 4.2.0

ocamlPackages.mirage: 3.10.7 → 4.2.0

ocamlPackages.irmin-pack: disable checks

ocamlPackages.mdx: disable checks

ocamlPackages.git-unix: mark as broken</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5cd66a72e8698e49b89d5df66365215470eea295><pre>etcd_3_5: 3.5.4 -> 3.5.5

https://github.com/etcd-io/etcd/releases/tag/v3.5.5</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/2b03570d0cfaad53227318bcafd889087e648bc5...5cd66a72e8698e49b89d5df66365215470eea295