### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -76,6 +76,7 @@ let
     "git-paf"
     "irmin-mirage-git"
     "git-mirage"
+    "irmin-git"
 
     # broken with ppxlib 0.23
     "elpi"
@@ -184,7 +185,6 @@ let
     "imagelib"
     "incr_dom"
     "inifiles"
-    "irmin-git"
     "lablgtk3-gtkspell3"
     "lablgtk3-sourceview3"
     "lablgtk3"

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -41,6 +41,7 @@ let
     "z3"
     "nonstd"
     "ocaml-r"
+    "nocrypto"
 
     "melange-compiler-libs"
     "melange"

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -62,10 +62,8 @@ let
     "caqti-driver-mariadb"
 
     # graphql incompatible
-    "irmin-containers"
     "irmin-graphql"
     "irmin-mirage-graphql"
-    "irmin-unix"
 
     # broken since 4.12
     "ocaml_extlib-1-7-7"
@@ -169,9 +167,6 @@ let
     "bls12-381-unix"
     "camlp5_strict"
     "camlp5"
-    "carton-git"
-    "carton-lwt"
-    "carton"
     "cfstream"
     "cpdf"
     "csvfields"

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -74,6 +74,7 @@ let
     "paf-cohttp"
     "git-paf"
     "irmin-mirage-git"
+    "git-mirage"
 
     # broken with ppxlib 0.23
     "elpi"

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665447519,
-        "narHash": "sha256-WaCcXad4HErnUsnIIceLegTgBn+alPfLGqobLb9M2pM=",
+        "lastModified": 1665577221,
+        "narHash": "sha256-UrN2UFSeWrZHYDhRNOzyG4Vo74iShbR/jG6B/OwV410=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2327ed0f403c2cf4db990d94030ffd4027600f86",
+        "rev": "7fc8453a6872573b1f0c75118a09367d1461b3ac",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2327ed0f403c2cf4db990d94030ffd4027600f86",
+        "rev": "7fc8453a6872573b1f0c75118a09367d1461b3ac",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=2327ed0f403c2cf4db990d94030ffd4027600f86";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=7fc8453a6872573b1f0c75118a09367d1461b3ac";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -350,6 +350,8 @@ with oself;
     doCheck = lib.versionAtLeast ocaml.version "5.0";
   });
 
+  data-encoding = disableTests osuper.data-encoding;
+
   dataloader = callPackage ./dataloader { };
   dataloader-lwt = callPackage ./dataloader/lwt.nix { };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -369,8 +369,6 @@ with oself;
     propagatedBuildInputs = [ decoders yojson ];
   };
 
-  decompress = disableTests osuper.decompress;
-
   dolog = buildDunePackage {
     pname = "dolog";
     version = "6.0.0";
@@ -521,27 +519,6 @@ with oself;
   gen_js_api = disableTests osuper.gen_js_api;
 
   gettext-stub = disableTests osuper.gettext-stub;
-
-  git = osuper.git.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/ocaml-git/archive/0de355b.tar.gz;
-      sha256 = "1x5waa8kandjlf798bd635f1bvnhpkq7hcc3awhg053g9phqfcmv";
-    };
-  });
-  git-unix = osuper.git-unix.overrideAttrs (_: {
-    buildInputs = [ ];
-    propagatedBuildInputs = [
-      awa
-      awa-mirage
-      cmdliner
-      mirage-clock
-      mirage-clock-unix
-      tcpip
-      git
-      happy-eyeballs-lwt
-      mirage-unix
-    ];
-  });
 
   gluten = callPackage ./gluten { };
   gluten-lwt = callPackage ./gluten/lwt.nix { };

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -604,6 +604,7 @@ with oself;
   irmin-pack = disableTests osuper.irmin-pack;
   irmin-git = disableTests osuper.irmin-git;
   irmin-http = disableTests osuper.irmin-http;
+  irmin-tezos = disableTests osuper.irmin-tezos;
   # https://github.com/mirage/metrics/issues/57
   irmin-test = null;
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -894,18 +894,6 @@ with oself;
 
   multipart-form-data = callPackage ./multipart-form-data { };
 
-  nocrypto = buildDunePackage {
-    pname = "nocrypto";
-    version = "0.5.4+dune";
-    src = builtins.fetchurl {
-      url = https://github.com/mirleft/ocaml-nocrypto/archive/b31c381.tar.gz;
-      sha256 = "1ajyiz48zr5wpc48maxfjn4sj9knrmbcdzq0vn407fc3y0wdxf52";
-    };
-    buildInputs = [ dune-configurator ];
-    propagatedBuildInputs = [ cstruct ppx_deriving ppx_sexp_conv sexplib zarith cstruct-lwt cpuid ];
-
-  };
-
   mmap = osuper.mmap.overrideAttrs (o: {
     src = builtins.fetchurl {
       url = https://github.com/mirage/mmap/archive/41596aa.tar.gz;


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/aee04b1bed64cd205f4d24072750b878fe7d8e71><pre>ocamlPackages.git: 3.5.0 -> 3.9.1 (#188389)

* ocamlPackages.cstruct: 6.0.1 -> 6.1.1

* ocamlPackages.git: 3.5.0 -> 3.9.1

* ocamlPackages.carton: 0.4.3 -> 0.4.4

* ocamlPackages.bigstringaf: 0.7.0 -> 0.9.0

* ocamlPackages.decompress: 1.4.2 -> 1.5.1

* ocamlPackages.repr: 0.5.0 -> 0.6.0

* ocamlPackages.irmin: 2.9.1 -> 3.4.1

* ligo: 0.36.0 -> 0.47.0

ocamlPackages.ringo: 0.5 → 0.9
ocamlPackages.data-encoding: 0.4.0 → 0.5.3
ocamlPackages.bls12-381: 1.1.0 -> 3.0.0

Co-authored-by: bezmuth <benkel97@protonmail.com></pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac><pre>libusb1: enable udev support for dynamically linked musl platform (#195351)

This was previously disabled because pkgs.udev (=pkgs.systemd) was not building on musl, but that is no longer the case.
This fixes the build of pkgsMusl.usbutils, which requires udev support in libusb1.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/2327ed0f403c2cf4db990d94030ffd4027600f86...7fc8453a6872573b1f0c75118a09367d1461b3ac