### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -9,7 +9,6 @@ let
     "dypgen"
     "earlybird"
     "gtktop"
-    "lablgtk_2_14"
     "camlimages_4_2_4"
     "lablgtk-extras"
     "magick"

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665577221,
-        "narHash": "sha256-UrN2UFSeWrZHYDhRNOzyG4Vo74iShbR/jG6B/OwV410=",
+        "lastModified": 1665641667,
+        "narHash": "sha256-uUkrud79H5L0x7OPcrELuPh54NONWGCchX7I0y+/iE8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7fc8453a6872573b1f0c75118a09367d1461b3ac",
+        "rev": "7a94322ed7898db6d9b308b76a6bb4a0c6f99c38",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7fc8453a6872573b1f0c75118a09367d1461b3ac",
+        "rev": "7a94322ed7898db6d9b308b76a6bb4a0c6f99c38",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=7fc8453a6872573b1f0c75118a09367d1461b3ac";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=7a94322ed7898db6d9b308b76a6bb4a0c6f99c38";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -920,13 +920,6 @@ with oself;
     enableParallelBuilding = true;
   });
 
-  ocamlbuild = osuper.ocamlbuild.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.14.2.tar.gz;
-      sha256 = "1ccihx2jnk3nsprx2w2kckqqq0bd0skq9i9sm01cg53p0fvdmlk2";
-    };
-  });
-
   ocaml_extlib-1-7-8 = osuper.ocaml_extlib-1-7-8.overrideAttrs (_: {
     src = builtins.fetchurl {
       url = https://github.com/ygrek/ocaml-extlib/archive/9e9270de9d6c33e08a18096f7fb75b4205e6c1ed.tar.gz;


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/bb38470b969039859fdcfc084485b58fdb7898ad><pre>ocamlPackages.ff: 0.4.0 → 0.6.2

ocamlPackages.ff-pbt: 0.6.1 → 0.6.2
ocamlPackages.ff-sig: 0.6.1 → 0.6.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/d451ea73dc8b4ed51d2a534f9c7b6e64268c3271><pre>coqPackages.coq-elpi: disable OCaml warnings</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/661ee3a26903ff58fd57f4f4396a748950ba3570><pre>coq_8_16: use OCaml 4.14</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/0671df7f0299648e5a08b718077ef6406a8cc70b><pre>ocamlPackages.uuidm: disable for OCaml < 4.08</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ed50e17618a0b28196401a3f9d7f707df93b88b8><pre>ocamlPackages.lablgtk_2_14: remove at 2.14.0 (broken)</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/d618530963a0e1d112c2584e2fc1ae9743cf7b08><pre>ocamlPackages.ocamlbuild: 0.14.1 → 0.14.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7a94322ed7898db6d9b308b76a6bb4a0c6f99c38><pre>Merge #182618: GNOME 42 → 43</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7a94322ed7898db6d9b308b76a6bb4a0c6f99c38><pre>Merge #182618: GNOME 42 → 43</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7a94322ed7898db6d9b308b76a6bb4a0c6f99c38><pre>Merge #182618: GNOME 42 → 43</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7a94322ed7898db6d9b308b76a6bb4a0c6f99c38><pre>Merge #182618: GNOME 42 → 43</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7a94322ed7898db6d9b308b76a6bb4a0c6f99c38><pre>Merge #182618: GNOME 42 → 43</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/7fc8453a6872573b1f0c75118a09367d1461b3ac...7a94322ed7898db6d9b308b76a6bb4a0c6f99c38