### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -23,9 +23,7 @@ let
     "config-file"
     "erm_xmpp"
     "gmetadom"
-    "herelib"
     "ocsigen_deriving"
-    "pipebang"
     "stog"
     "ulex"
     "lablgl"
@@ -48,7 +46,6 @@ let
 
     # linking issues?
     "spacetime_lib"
-    "prof_spacetime"
     "mariadb"
     "caqti-driver-mariadb"
 

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666615827,
-        "narHash": "sha256-oAf8l7eMEFjXMVsrQgHnRUeQbSrY/Amjm8xnUioNbJ8=",
+        "lastModified": 1666688649,
+        "narHash": "sha256-i1Tq2VgXbEZKgjM2p2OqZdxcnK4FZjRZ9Oy4Ewx8gjA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f93f9f43c6b3347b2091a8a41421d31e84cb9275",
+        "rev": "03a00f66fc4e893dccba1579df6d0c83852e1c2c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f93f9f43c6b3347b2091a8a41421d31e84cb9275",
+        "rev": "03a00f66fc4e893dccba1579df6d0c83852e1c2c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=f93f9f43c6b3347b2091a8a41421d31e84cb9275";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=03a00f66fc4e893dccba1579df6d0c83852e1c2c";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/eafdbcc9b4c9f0312a276f2c2c5f097d2f6e7846><pre>ocamlPackages.tezos-bls12-381-polynomial: 0.1.2 -> 0.1.3</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/0766c6574776957774ffa4fc7eda0f36dad5b91b><pre>Update ocaml packages.git and paf le chien (#197422)

* ocamlPackages.paf: 0.1.0 -> 0.2.0

* ocamlPackages.git: 3.9.1 -> 3.10.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b42a0ec29ad2bf5aff18d9d4cdd2c6ba12711734><pre>ocamlPackages.pipebang: remove at 113.00.00</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/fbd942993f1e5d1215749f51a7ef42fd7948583b><pre>ocamlPackages.herelib: remove at 112.35.00</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/8b11f0a5138c23c0be6e6a04caaf647fca644856><pre>ocamlPackages.buildOcaml: remove</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/03a00f66fc4e893dccba1579df6d0c83852e1c2c><pre>Merge pull request #197603 from markuskowa/fix-pyscf

python3Packages.pyscf: fix build with libxc-6.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/03a00f66fc4e893dccba1579df6d0c83852e1c2c><pre>Merge pull request #197603 from markuskowa/fix-pyscf

python3Packages.pyscf: fix build with libxc-6.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/03a00f66fc4e893dccba1579df6d0c83852e1c2c><pre>Merge pull request #197603 from markuskowa/fix-pyscf

python3Packages.pyscf: fix build with libxc-6.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/03a00f66fc4e893dccba1579df6d0c83852e1c2c><pre>Merge pull request #197603 from markuskowa/fix-pyscf

python3Packages.pyscf: fix build with libxc-6.0.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/f93f9f43c6b3347b2091a8a41421d31e84cb9275...03a00f66fc4e893dccba1579df6d0c83852e1c2c