### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667729201,
-        "narHash": "sha256-Jzjf1kR7iE918jnPaqY/8ze5tYElRyUBD0Q21yJgiLg=",
+        "lastModified": 1667816927,
+        "narHash": "sha256-BjRdmoHVakdmnaY6BBGge+rpBEMhIjgXjXP4d2UvuO4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a362cc95bd578019ab03558d7e39fadee9abfbbb",
+        "rev": "ad83bff0088bcefd621fcf16b0db5d34f0cebf1c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a362cc95bd578019ab03558d7e39fadee9abfbbb",
+        "rev": "ad83bff0088bcefd621fcf16b0db5d34f0cebf1c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=a362cc95bd578019ab03558d7e39fadee9abfbbb";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=ad83bff0088bcefd621fcf16b0db5d34f0cebf1c";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1880,12 +1880,6 @@ with oself;
     '';
   });
 
-  base = osuper.base.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/janestreet/base/archive/refs/tags/v0.15.1.tar.gz;
-      sha256 = "050syrp6v00gn50d6xvwv6a36zsk4zmahymgllxpw9paf4qk0pkm";
-    };
-  });
 
   core = osuper.core.overrideAttrs (o: {
     src = builtins.fetchurl {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/bbc00643c7344ed39880edcc8c9d1baacf45dda8><pre>ocaml-ng.ocamlPackages_4_09.ocaml: mark as broken on aarch64-darwin</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/51e1e1ea473c78b10d873672aeb580d24c5d6b80><pre>ocamlPackages.base: 0.15.0 → 0.15.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/76796543e4f9c9318a22126042b804cd86a34d93><pre>ocamlPackages.eqaf: 0.8 → 0.9</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/59518c6eb826e6e65d9aa6e514e2b79b4d943a98><pre>Merge pull request #199185 from wegank/ocaml-4.09-broken</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ad83bff0088bcefd621fcf16b0db5d34f0cebf1c><pre>nixos/binfmt: restart systemd-binfmt when registrations change</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ad83bff0088bcefd621fcf16b0db5d34f0cebf1c><pre>nixos/binfmt: restart systemd-binfmt when registrations change</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ad83bff0088bcefd621fcf16b0db5d34f0cebf1c><pre>nixos/binfmt: restart systemd-binfmt when registrations change</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/a362cc95bd578019ab03558d7e39fadee9abfbbb...ad83bff0088bcefd621fcf16b0db5d34f0cebf1c