### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -54,9 +54,6 @@ let
     "irmin-graphql"
     "irmin-mirage-graphql"
 
-    # broken since 4.12
-    "ocaml_extlib-1-7-7"
-
     # doesn't work with my fork of http/af
     "paf"
     "paf-le"

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668568764,
-        "narHash": "sha256-8lzcK4mAt0W+DbWVm2RnE33uRT+O/lgvysrKKDuHdSo=",
+        "lastModified": 1668658157,
+        "narHash": "sha256-0WfUAIj2L868oCYLr6WepNUZud47MlIzys/eJ4TO8NI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10181346e6db3f327700e944cc73e0ea4ae44099",
+        "rev": "396ba2dd17956d991bd0eb97f91e7f0a234401ff",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10181346e6db3f327700e944cc73e0ea4ae44099",
+        "rev": "396ba2dd17956d991bd0eb97f91e7f0a234401ff",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=10181346e6db3f327700e944cc73e0ea4ae44099";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=396ba2dd17956d991bd0eb97f91e7f0a234401ff";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -23,6 +23,7 @@
 , cairo
 , gtk2
 , zlib-oc
+, wget
 }:
 
 oself: osuper:

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -377,7 +377,7 @@ with oself;
       sha256 = "0yiisyl5a6la9mlhplfyjxl21ccwv6axjbb1v76xm69324z2xf9g";
     };
 
-    propagatedBuildInputs = [ ocaml_extlib ];
+    propagatedBuildInputs = [ extlib ];
 
     postPatch = ''
       substituteInPlace ./cudf.ml --replace "Pervasives." "Stdlib."
@@ -454,10 +454,6 @@ with oself;
   dune_2 = dune_3;
 
   dune_3 = osuper.dune_3.overrideAttrs (o: {
-    src = builtins.fetchurl {
-      url = https://github.com/ocaml/dune/releases/download/3.6.0/dune-3.6.0.tbz;
-      sha256 = "0y7j5gfwzxpfnwplmlgfa7ghgcgixhva1yvayc6fc10nab4wd808";
-    };
     nativeBuildInputs = o.nativeBuildInputs ++ [ makeWrapper ];
 
     postPatch = ''
@@ -692,6 +688,16 @@ with oself;
   irmin-tezos = disableTests osuper.irmin-tezos;
   # https://github.com/mirage/metrics/issues/57
   irmin-test = null;
+
+  iso639 = buildDunePackage {
+    pname = "iso639";
+    version = "0.0.5";
+    src = builtins.fetchurl {
+      url = https://github.com/paurkedal/ocaml-iso639/releases/download/v0.0.5/iso639-v0.0.5.tbz;
+      sha256 = "11bk38m5wsh3g4pr1px3865w8p42n0cq401pnrgpgyl25zdfamk0";
+    };
+    nativeBuildInputs = [ wget ];
+  };
 
   iter = osuper.iter.overrideAttrs (o: {
     src = builtins.fetchurl {
@@ -1014,13 +1020,6 @@ with oself;
 
   ocaml = (osuper.ocaml.override { flambdaSupport = true; }).overrideAttrs (_: {
     enableParallelBuilding = true;
-  });
-
-  ocaml_extlib-1-7-8 = osuper.ocaml_extlib-1-7-8.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/ygrek/ocaml-extlib/archive/9e9270de9d6c33e08a18096f7fb75b4205e6c1ed.tar.gz;
-      sha256 = "006zc8jc1zx20iis06z3gppmikc6pfarx5ikdhihggk7k1wam6c1";
-    };
   });
 
   jsonrpc = osuper.jsonrpc.overrideAttrs (o: {

--- a/ocaml/esy/default.nix
+++ b/ocaml/esy/default.nix
@@ -96,7 +96,7 @@ let
       cmdliner
       cudf
       mccs
-      ocaml_extlib
+      extlib
     ];
     src = fetchFromGitHub {
       owner = "andreypopp";


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/8ab639a6b718c8bee820f6c4216706158a5560b3><pre>ocamlPackages.qcheck: 0.19.1 → 0.20</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/a834cc840fddf422d8b8ba6c2b06726cdacf2eec><pre>ocamlPackages.ocaml_extlib: 1.7.8 -> 1.7.9

Use new dune based build system. This no longer has a way to
enable the non-minimal build. As it turns out, though, no
package required that (and it was impossible to get a non-minimal
extlib build from OPAM before anyways).

The old expression needs to be retained for extlib 1.7.7 and just
moved over.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/a110f08f12eb10a25e1e0c7545c13e1246d0da25><pre>ocamlPackages.extlib: rename from ocaml_extlib

This matches the name used in dune and on OPAM.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff><pre>rootlesskit: 1.0.1 -> 1.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff><pre>rootlesskit: 1.0.1 -> 1.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff><pre>rootlesskit: 1.0.1 -> 1.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff><pre>rootlesskit: 1.0.1 -> 1.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff><pre>rootlesskit: 1.0.1 -> 1.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff><pre>rootlesskit: 1.0.1 -> 1.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff><pre>rootlesskit: 1.0.1 -> 1.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff><pre>rootlesskit: 1.0.1 -> 1.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff><pre>rootlesskit: 1.0.1 -> 1.1.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/10181346e6db3f327700e944cc73e0ea4ae44099...396ba2dd17956d991bd0eb97f91e7f0a234401ff