### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668989135,
-        "narHash": "sha256-ePwGDHmrbvii9mVLdxfi0D62PXLlOtXRWdp88ZjH88M=",
+        "lastModified": 1669067947,
+        "narHash": "sha256-DbTlGzUSj2j+3tMJ7UwV5ExGSg1WeZ+XZq6eAGpyd40=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7da50a95bbfcd3569745d4e5373c4e302cd56aa4",
+        "rev": "802115d0227228b66b691f3b85b30b868976e8eb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7da50a95bbfcd3569745d4e5373c4e302cd56aa4",
+        "rev": "802115d0227228b66b691f3b85b30b868976e8eb",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=7da50a95bbfcd3569745d4e5373c4e302cd56aa4";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=802115d0227228b66b691f3b85b30b868976e8eb";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/6ee0a023cdd54dd5aa5fbd4b0e659f57c88e25c7><pre>ocamlPackages.labltk: add version 8.06.13 for OCaml 5.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/3f1058adb1ac9df62f97a1e8fe59c31d3bfa4787><pre>ocamlPackages.linenoise: 1.3.1 → 1.4.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/802115d0227228b66b691f3b85b30b868976e8eb><pre>dar: unbreak on Darwin

Error with LLVM stdenv on aarch64-darwin:

libtool: compile:  clang++ -DHAVE_CONFIG_H -I. -I../.. -DLIBDAR_MODE=64 -DDAR_LOCALEDIR=\/nix/store/waclhq32gacp2010gyjx17f9h6xpsf8d-dar-2.7.7/share/locale\ -I/nix/store/1m4gsx4p4fl5xpg0h8splmwz7j2y3cbp-gpgme-1.18.0-dev/include -I/nix/store/fpc4g6ql1mx4na5rkjhik5f2wixymzhy-libassuan-2.5.5-dev/include -I/nix/store/qhznxypyfh3w5xdbxxd2n47d9c8jr2bx-libgpg-error-1.45-dev/include -g -O2 -c parallel_block_compressor.cpp  -D__DYNAMIC__  -fno-common -DPIC -o .libs/parallel_block_compressor.o
In file included from parallel_tronconneuse.cpp:28:
In file included from ./parallel_tronconneuse.hpp:39:
In file included from /nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/string:506:
In file included from /nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/string_view:175:
In file included from /nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/__string:57:
In file included from /nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/algorithm:643:
/nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/memory:3455:7: error: exception specification of overriding function is more lax than base version
class __shared_ptr_emplace
      ^
/nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/memory:4291:26: note: in instantiation of template class \'std::__1::__shared_ptr_emplace<libthreadar::barrier, std::__1::allocator<libthreadar::barrier>>\' requested here
    ::new(__hold2.get()) _CntrlBlk(__a2, _VSTD::forward<_Args>(__args)...);
                         ^
parallel_tronconneuse.cpp:102:15: note: in instantiation of function template specialization \'std::__1::make_shared<libthreadar::barrier, unsigned long>\' requested here
            waiter = make_shared<barrier>(num_workers + 2); // +1 for crypto_reade thread, +1 this thread
                     ^
/nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/memory:3364:13: note: overridden virtual function is here
    virtual ~__shared_weak_count();
            ^
1 error generated.
make[3]: *** [Makefile:1383: parallel_tronconneuse.lo] Error 1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/802115d0227228b66b691f3b85b30b868976e8eb><pre>dar: unbreak on Darwin

Error with LLVM stdenv on aarch64-darwin:

libtool: compile:  clang++ -DHAVE_CONFIG_H -I. -I../.. -DLIBDAR_MODE=64 -DDAR_LOCALEDIR=\/nix/store/waclhq32gacp2010gyjx17f9h6xpsf8d-dar-2.7.7/share/locale\ -I/nix/store/1m4gsx4p4fl5xpg0h8splmwz7j2y3cbp-gpgme-1.18.0-dev/include -I/nix/store/fpc4g6ql1mx4na5rkjhik5f2wixymzhy-libassuan-2.5.5-dev/include -I/nix/store/qhznxypyfh3w5xdbxxd2n47d9c8jr2bx-libgpg-error-1.45-dev/include -g -O2 -c parallel_block_compressor.cpp  -D__DYNAMIC__  -fno-common -DPIC -o .libs/parallel_block_compressor.o
In file included from parallel_tronconneuse.cpp:28:
In file included from ./parallel_tronconneuse.hpp:39:
In file included from /nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/string:506:
In file included from /nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/string_view:175:
In file included from /nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/__string:57:
In file included from /nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/algorithm:643:
/nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/memory:3455:7: error: exception specification of overriding function is more lax than base version
class __shared_ptr_emplace
      ^
/nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/memory:4291:26: note: in instantiation of template class \'std::__1::__shared_ptr_emplace<libthreadar::barrier, std::__1::allocator<libthreadar::barrier>>\' requested here
    ::new(__hold2.get()) _CntrlBlk(__a2, _VSTD::forward<_Args>(__args)...);
                         ^
parallel_tronconneuse.cpp:102:15: note: in instantiation of function template specialization \'std::__1::make_shared<libthreadar::barrier, unsigned long>\' requested here
            waiter = make_shared<barrier>(num_workers + 2); // +1 for crypto_reade thread, +1 this thread
                     ^
/nix/store/3lsnbsiwzy2gzga1m2bszb7r9d6wraz2-libcxx-11.1.0-dev/include/c++/v1/memory:3364:13: note: overridden virtual function is here
    virtual ~__shared_weak_count();
            ^
1 error generated.
make[3]: *** [Makefile:1383: parallel_tronconneuse.lo] Error 1</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/7da50a95bbfcd3569745d4e5373c4e302cd56aa4...802115d0227228b66b691f3b85b30b868976e8eb