### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669067947,
-        "narHash": "sha256-DbTlGzUSj2j+3tMJ7UwV5ExGSg1WeZ+XZq6eAGpyd40=",
+        "lastModified": 1669154743,
+        "narHash": "sha256-oqWVq/eYsjvIakytYlw3NBt0lcTQyXb7xDiJMDWIIf4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "802115d0227228b66b691f3b85b30b868976e8eb",
+        "rev": "977d4985a05cc68c9f3a208415aa2ef028b52772",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "802115d0227228b66b691f3b85b30b868976e8eb",
+        "rev": "977d4985a05cc68c9f3a208415aa2ef028b52772",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=802115d0227228b66b691f3b85b30b868976e8eb";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=977d4985a05cc68c9f3a208415aa2ef028b52772";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/287131c409bcb8fb53c401ed028815c3e20b6b39><pre>ocamlPackages.phylogenetics: run full test suite

As of upstream commit
https://github.com/biocaml/phylogenetics/commit/a107e96fa64fecb75a9e855293b2822196540b31
, the full tests using `bppsuite`, although barely longer than the short
tests, were not being run.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/977d4985a05cc68c9f3a208415aa2ef028b52772><pre>Merge pull request #202374 from fabaff/pip-audit-bump

pip-audit: 2.4.5 -> 2.4.6</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/802115d0227228b66b691f3b85b30b868976e8eb...977d4985a05cc68c9f3a208415aa2ef028b52772