### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670332253,
-        "narHash": "sha256-O5SmhlIUt1s+vK4NXeGYqwcBIMwbBPAEZ3GHE3XT28c=",
+        "lastModified": 1670483520,
+        "narHash": "sha256-kwbvwK316pGEARY2ahF0/Pgv6THlQsNS20FAjPeRgQc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c9ffcf70786f0966982ce0fc76ec05df2e1dec2",
+        "rev": "92b4f173803f65531e066321934e7d1ee7eb5090",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c9ffcf70786f0966982ce0fc76ec05df2e1dec2",
+        "rev": "92b4f173803f65531e066321934e7d1ee7eb5090",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=1c9ffcf70786f0966982ce0fc76ec05df2e1dec2";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=92b4f173803f65531e066321934e7d1ee7eb5090";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/ea05022a19c2691da43c36d3b912a8c66fd274a2><pre>ocamlPackages.js_of_ocaml: 4.0.0 → 4.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/9cc7f80dea4cde202c1ee514532b53953b1f3510><pre>ocamlPackages.camlzip: 1.10 → 1.11</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/d5338a356afb26eff72cc764fbd4faf80ae9e64d><pre>ocamlPackages.sexp_pretty: 0.15.0 → 0.15.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/4d63564ae582b2a04da348a1b6518aa4406abd69><pre>ocamlPackages.csvfields: 0.15.0 → 0.15.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/c24b7eab34936d7d67ffea8fde5ee1096ae4ddda><pre>ocamlPackages.core_unix: 0.15.0 → 0.15.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/92b4f173803f65531e066321934e7d1ee7eb5090><pre>tennix: avoid URL literal

It\'s not allowed anymore:
https://hydra.nixos.org/build/201125718
This amends PR #204859</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/1c9ffcf70786f0966982ce0fc76ec05df2e1dec2...92b4f173803f65531e066321934e7d1ee7eb5090