### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670657915,
-        "narHash": "sha256-8otbCnGfuap6QgMws5hntqupj6sxJxsGX6LqkoF1z5Q=",
+        "lastModified": 1670837426,
+        "narHash": "sha256-VGm7k7R+zxZa5oZXGT/79SUlihzFxeWVcPmIn0k1y+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78c259e2dc87b6039af1436e1d3fd6a76c9fbff8",
+        "rev": "f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78c259e2dc87b6039af1436e1d3fd6a76c9fbff8",
+        "rev": "f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=78c259e2dc87b6039af1436e1d3fd6a76c9fbff8";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1422,14 +1422,6 @@ with oself;
     };
   });
 
-  sedlex = osuper.sedlex.overrideAttrs (o: {
-    preBuild = ''
-      substituteInPlace src/lib/dune --replace "(libraries " "(libraries camlp-streams "
-    '';
-
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ camlp-streams ];
-  });
-
   sendfile = callPackage ./sendfile { };
 
   session = callPackage ./session { };


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/6f05af913cd9a1a5ddd6abcf64948a9733482f46><pre>ocamlPackages.otfm: 0.3.0 → 0.4.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/79eaf1dbb9bfed9876088b3826f50645f6b0b39c><pre>ocaml-ng.ocamlPackages_4_00_1.ocaml: use xorg.* packages directly instead of xlibsWrapper indirection

Validated as no material change in `out` output with `diffoscope`.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7f63ad9029e1ae8d9662c8370909205decc73a9e><pre>ocamlPackages.piqi: support for sedlex ≥ 3.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/9acb1fcfb6dacefec7caf49523ac13c41ab6ef30><pre>ocamlPackages.sedlex: 2.6 → 3.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/bee0009e1e704fdeaf56ee9f1999e2e56b29c831><pre>Merge pull request #205480 from trofi/ocaml-4_00_1-without-xlibsWrapper

ocaml-ng.ocamlPackages_4_00_1.ocaml: use xorg.* packages directly ins…</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ffca9ffaaafb38c8979068cee98b2644bd3f14cb><pre>ocamlPackages.uecc: 0.3 → 0.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c><pre>Merge pull request #203926 from urandom2/code-generator

kubernetes-code-generator: init at 0.25.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c><pre>Merge pull request #203926 from urandom2/code-generator

kubernetes-code-generator: init at 0.25.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c><pre>Merge pull request #203926 from urandom2/code-generator

kubernetes-code-generator: init at 0.25.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c><pre>Merge pull request #203926 from urandom2/code-generator

kubernetes-code-generator: init at 0.25.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c><pre>Merge pull request #203926 from urandom2/code-generator

kubernetes-code-generator: init at 0.25.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c><pre>Merge pull request #203926 from urandom2/code-generator

kubernetes-code-generator: init at 0.25.4</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/78c259e2dc87b6039af1436e1d3fd6a76c9fbff8...f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c