### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670657915,
-        "narHash": "sha256-8otbCnGfuap6QgMws5hntqupj6sxJxsGX6LqkoF1z5Q=",
+        "lastModified": 1670918062,
+        "narHash": "sha256-iOhkyBYUU9Jfkk0lvI4ahpjyrTsLXj9uyJWwmjKg+gg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78c259e2dc87b6039af1436e1d3fd6a76c9fbff8",
+        "rev": "84575b0bd882be979516f4fecfe4d7c8de8f6a92",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78c259e2dc87b6039af1436e1d3fd6a76c9fbff8",
+        "rev": "84575b0bd882be979516f4fecfe4d7c8de8f6a92",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=78c259e2dc87b6039af1436e1d3fd6a76c9fbff8";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=84575b0bd882be979516f4fecfe4d7c8de8f6a92";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/6f05af913cd9a1a5ddd6abcf64948a9733482f46><pre>ocamlPackages.otfm: 0.3.0 → 0.4.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/79eaf1dbb9bfed9876088b3826f50645f6b0b39c><pre>ocaml-ng.ocamlPackages_4_00_1.ocaml: use xorg.* packages directly instead of xlibsWrapper indirection

Validated as no material change in `out` output with `diffoscope`.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7f63ad9029e1ae8d9662c8370909205decc73a9e><pre>ocamlPackages.piqi: support for sedlex ≥ 3.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/9acb1fcfb6dacefec7caf49523ac13c41ab6ef30><pre>ocamlPackages.sedlex: 2.6 → 3.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/bee0009e1e704fdeaf56ee9f1999e2e56b29c831><pre>Merge pull request #205480 from trofi/ocaml-4_00_1-without-xlibsWrapper

ocaml-ng.ocamlPackages_4_00_1.ocaml: use xorg.* packages directly ins…</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ffca9ffaaafb38c8979068cee98b2644bd3f14cb><pre>ocamlPackages.uecc: 0.3 → 0.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f0dda807b29b61d1ab4ec44662767d0f9bd221b3><pre>ocamlPackages.merlin: 4.6 → 4.7</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/84575b0bd882be979516f4fecfe4d7c8de8f6a92><pre>Merge pull request #205853 from r-ryantm/auto-update/python310Packages.appthreat-vulnerability-db

python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/84575b0bd882be979516f4fecfe4d7c8de8f6a92><pre>Merge pull request #205853 from r-ryantm/auto-update/python310Packages.appthreat-vulnerability-db

python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/84575b0bd882be979516f4fecfe4d7c8de8f6a92><pre>Merge pull request #205853 from r-ryantm/auto-update/python310Packages.appthreat-vulnerability-db

python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/84575b0bd882be979516f4fecfe4d7c8de8f6a92><pre>Merge pull request #205853 from r-ryantm/auto-update/python310Packages.appthreat-vulnerability-db

python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/84575b0bd882be979516f4fecfe4d7c8de8f6a92><pre>Merge pull request #205853 from r-ryantm/auto-update/python310Packages.appthreat-vulnerability-db

python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/84575b0bd882be979516f4fecfe4d7c8de8f6a92><pre>Merge pull request #205853 from r-ryantm/auto-update/python310Packages.appthreat-vulnerability-db

python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/84575b0bd882be979516f4fecfe4d7c8de8f6a92><pre>Merge pull request #205853 from r-ryantm/auto-update/python310Packages.appthreat-vulnerability-db

python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/84575b0bd882be979516f4fecfe4d7c8de8f6a92><pre>Merge pull request #205853 from r-ryantm/auto-update/python310Packages.appthreat-vulnerability-db

python310Packages.appthreat-vulnerability-db: 4.1.11 -> 4.1.12</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/78c259e2dc87b6039af1436e1d3fd6a76c9fbff8...84575b0bd882be979516f4fecfe4d7c8de8f6a92