### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -187,6 +187,7 @@ let
 
     "pyml"
     "ppx_python"
+    "pythonlib"
   ];
 
 in

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -184,6 +184,9 @@ let
     "uring"
     "eio_linux"
     "class_group_vdf"
+
+    "pyml"
+    "ppx_python"
   ];
 
 in

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670837426,
-        "narHash": "sha256-VGm7k7R+zxZa5oZXGT/79SUlihzFxeWVcPmIn0k1y+8=",
+        "lastModified": 1671005503,
+        "narHash": "sha256-L5pMUoEAxmqwyAivNKvTcNhxL3xY58Zjh3XYtVO2LaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c",
+        "rev": "f9b0bd5202a0df10856c9fe4cba0074aa0968047",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c",
+        "rev": "f9b0bd5202a0df10856c9fe4cba0074aa0968047",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=f9b0bd5202a0df10856c9fe4cba0074aa0968047";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1486,14 +1486,6 @@ with oself;
     propagatedBuildInputs = [ openssl-oc.dev ];
   });
 
-  stdcompat = osuper.stdcompat.overrideAttrs (o: {
-    nativeBuildInputs = [ ocaml findlib autoconf automake ];
-    src = builtins.fetchurl {
-      url = https://github.com/thierry-martinez/stdcompat/releases/download/v19/stdcompat-19.tar.gz;
-      sha256 = "0m8a6mbv3n5aaf69fdnq5gpdr6yq7z08afjv7s9dw877i5vhd90c";
-    };
-  });
-
   subscriptions-transport-ws = callPackage ./subscriptions-transport-ws { };
 
   syndic = buildDunePackage rec {
@@ -1758,20 +1750,12 @@ with oself;
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ stdio ];
   });
 
-  pyml = buildDunePackage {
-    pname = "pyml";
-    version = "20220905";
-    src = builtins.fetchurl {
-      url = https://github.com/thierry-martinez/pyml/releases/download/20220905/pyml.20220905.tar.gz;
-      sha256 = "1r81iy2fdsi1cmh7s31aac9ih3mn5d2vxwgdg9wxkidrc33a8i5x";
-    };
-
+  pyml = osuper.pyml.overrideAttrs (_: {
     propagatedBuildInputs = [
       python3
       stdcompat
     ];
-
-  };
+  });
 
   pythonlib = osuper.pythonlib.overrideAttrs (o: {
     src = builtins.fetchurl {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1750,13 +1750,6 @@ with oself;
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ stdio ];
   });
 
-  pyml = osuper.pyml.overrideAttrs (_: {
-    propagatedBuildInputs = [
-      python3
-      stdcompat
-    ];
-  });
-
   pythonlib = osuper.pythonlib.overrideAttrs (o: {
     src = builtins.fetchurl {
       url = https://github.com/janestreet/pythonlib/archive/refs/tags/v0.15.1.tar.gz;

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -35,11 +35,9 @@ let
 
       ocamlPackages_5_0 = ocaml-ng.ocamlPackages_5_0.overrideScope' (oself: osuper: {
         ocaml = osuper.ocaml.overrideAttrs (_: {
-          version = "5.0.0";
-
-          src = builtins.fetchTarball {
-            url = https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0.tar.xz;
-            sha256 = "1p0p8wldrnbr61wfy3x4122017g4k5gjvfwlg3mvlqn8r2fxn2m5";
+          src = builtins.fetchurl {
+            url = https://github.com/ocaml/ocaml/archive/refs/tags/5.0.0-beta2.tar.gz;
+            sha256 = "1spramdvdizqxzz19aw67gwrx43w36s1vkmsi7246mdygql2sd7m";
           };
         });
       });

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -35,9 +35,11 @@ let
 
       ocamlPackages_5_0 = ocaml-ng.ocamlPackages_5_0.overrideScope' (oself: osuper: {
         ocaml = osuper.ocaml.overrideAttrs (_: {
-          src = builtins.fetchurl {
-            url = https://github.com/ocaml/ocaml/archive/refs/tags/5.0.0-beta2.tar.gz;
-            sha256 = "1spramdvdizqxzz19aw67gwrx43w36s1vkmsi7246mdygql2sd7m";
+          version = "5.0.0";
+
+          src = builtins.fetchTarball {
+            url = https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0.tar.xz;
+            sha256 = "1p0p8wldrnbr61wfy3x4122017g4k5gjvfwlg3mvlqn8r2fxn2m5";
           };
         });
       });


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/f0dda807b29b61d1ab4ec44662767d0f9bd221b3><pre>ocamlPackages.merlin: 4.6 → 4.7</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/beaf7262e6a1d8276eccc93b3fd9ea2dd2e11470><pre>ocamlPackages.stdcompat: 18 → 19

https://github.com/thierry-martinez/stdcompat/releases/tag/v19</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/35e2079bd5a3c5a213068c9fae1fa766cf1fb249><pre>ocamlPackages.pyml: 20220615 → 20220905

https://github.com/thierry-martinez/pyml/releases/tag/20220905

Aldo switch to dune, which has been available since 2021-09-24.
And remove unneeded dependencies:
- ncurses was needed for Python in the past
- ocaml and findlib are implied by dune</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b1648e3b6a94264087b714b390eb40f9b6649c65><pre>ocaml-ng.ocamlPackages_5_0: 5.0.0-β2 → 5.0.0-rc1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f9b0bd5202a0df10856c9fe4cba0074aa0968047><pre>Merge pull request #205996 from r-ryantm/auto-update/python310Packages.metakernel

python310Packages.metakernel: 0.29.2 -> 0.29.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f9b0bd5202a0df10856c9fe4cba0074aa0968047><pre>Merge pull request #205996 from r-ryantm/auto-update/python310Packages.metakernel

python310Packages.metakernel: 0.29.2 -> 0.29.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f9b0bd5202a0df10856c9fe4cba0074aa0968047><pre>Merge pull request #205996 from r-ryantm/auto-update/python310Packages.metakernel

python310Packages.metakernel: 0.29.2 -> 0.29.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f9b0bd5202a0df10856c9fe4cba0074aa0968047><pre>Merge pull request #205996 from r-ryantm/auto-update/python310Packages.metakernel

python310Packages.metakernel: 0.29.2 -> 0.29.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f9b0bd5202a0df10856c9fe4cba0074aa0968047><pre>Merge pull request #205996 from r-ryantm/auto-update/python310Packages.metakernel

python310Packages.metakernel: 0.29.2 -> 0.29.4</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c...f9b0bd5202a0df10856c9fe4cba0074aa0968047