### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670837426,
-        "narHash": "sha256-VGm7k7R+zxZa5oZXGT/79SUlihzFxeWVcPmIn0k1y+8=",
+        "lastModified": 1671222642,
+        "narHash": "sha256-wh7Z4Mru2yhrDvshXlSVHwVVSW7621eo7tjVvt/EaAg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c",
+        "rev": "da1333cdd296f891ef68327c36ffe5c0f44ab555",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c",
+        "rev": "da1333cdd296f891ef68327c36ffe5c0f44ab555",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=da1333cdd296f891ef68327c36ffe5c0f44ab555";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/f0dda807b29b61d1ab4ec44662767d0f9bd221b3><pre>ocamlPackages.merlin: 4.6 → 4.7</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/beaf7262e6a1d8276eccc93b3fd9ea2dd2e11470><pre>ocamlPackages.stdcompat: 18 → 19

https://github.com/thierry-martinez/stdcompat/releases/tag/v19</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/35e2079bd5a3c5a213068c9fae1fa766cf1fb249><pre>ocamlPackages.pyml: 20220615 → 20220905

https://github.com/thierry-martinez/pyml/releases/tag/20220905

Aldo switch to dune, which has been available since 2021-09-24.
And remove unneeded dependencies:
- ncurses was needed for Python in the past
- ocaml and findlib are implied by dune</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b1648e3b6a94264087b714b390eb40f9b6649c65><pre>ocaml-ng.ocamlPackages_5_0: 5.0.0-β2 → 5.0.0-rc1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/8a9769cb060320d9947987c2e862b3143c4c1caa><pre>ocamlPackages.batteries: 3.5.1 → 3.6.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/9f0e0580258cf265c455ac6a83add0e0f377729c><pre>Merge pull request #206027 from vbgl/ocaml-batteries-3.6.0

ocamlPackages.batteries: 3.5.1 → 3.6.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/062b7f42fdbb383f7d228d9b5444a720fba1d3ec><pre>ocamlPackages.lustre-v6: 6.103.3 -> 6.107.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b28b8118f2b528f236133ffef79d0ad693f320a2><pre>ocamlPackages.sha: 1.15.1 → 1.15.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/da1333cdd296f891ef68327c36ffe5c0f44ab555><pre>pms: init at unstable-2022-11-12 (#205941)

Co-authored-by: Nikolay Korotkiy <sikmir@disroot.org>
Co-authored-by: Sandro <sandro.jaeckel@gmail.com></pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c...da1333cdd296f891ef68327c36ffe5c0f44ab555