### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672897942,
-        "narHash": "sha256-5RijBVaikhHgBMaoZ3kG6W1QjPKcnHmJGJgY0TfzUIE=",
+        "lastModified": 1673039641,
+        "narHash": "sha256-Bc9FVhyLxp2mX2SXr0N4Fj4St7o4yaYEXpd12etSNBY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c575c59f986548cc3ecaf870f4d4d4791a175f4",
+        "rev": "d9f73e41fd3c8e85b266bdb91cb7535600010798",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c575c59f986548cc3ecaf870f4d4d4791a175f4",
+        "rev": "d9f73e41fd3c8e85b266bdb91cb7535600010798",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=6c575c59f986548cc3ecaf870f4d4d4791a175f4";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=d9f73e41fd3c8e85b266bdb91cb7535600010798";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/0d394e08c826d7c7238c49d4a4d70462626d78b3"><pre>ocamlPackages.containers: 3.9 → 3.10</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4c9c1b6c84b1c623cb912b00d44eec9e3c63a352"><pre>ocamlPackages.ppxlib: use release tarballs instead of git repositories

This allows to fetch ppxlib\'s version using findlib. One example of
package which depends on this is metapp (https://github.com/thierry-martinez/metapp),
which fetches ppxlib\'s version at build time and fails to build if it\'s
not found.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d9f73e41fd3c8e85b266bdb91cb7535600010798"><pre>Merge pull request #209346 from fabaff/life360-bump

python310Packages.life360: 5.4.1 -> 5.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d9f73e41fd3c8e85b266bdb91cb7535600010798"><pre>Merge pull request #209346 from fabaff/life360-bump

python310Packages.life360: 5.4.1 -> 5.5.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/6c575c59f986548cc3ecaf870f4d4d4791a175f4...d9f73e41fd3c8e85b266bdb91cb7535600010798