### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -152,25 +152,14 @@ let
     "twt"
     "uecc"
     "xml-light"
-    "labltk"
     "lambdapi"
   ];
 
   darwinIgnores = [
-    "ffmpeg"
-    "ffmpeg-av"
-    "ffmpeg-avdevice"
-    "ffmpeg-avfilter"
-    "ffmpeg-avutil"
-    "ffmpeg-avcodec"
-    "ffmpeg-swscale"
-    "ffmpeg-swresample"
     "dssi"
 
     # broken on macOS?
     "llvm"
-    "ocaml_libvirt"
-    "labltk"
 
     "alsa"
     "mm"

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673179929,
-        "narHash": "sha256-mkDqQat24NMqf4z5rK6M4Y+68qVauCSDYouqD3hl66c=",
+        "lastModified": 1674101896,
+        "narHash": "sha256-xWLaexT6IHhOJru54wrOMeBbkKeJzOZ4Pqrxctf82q0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
+        "rev": "a841e262264e48722dccc8469f066068146e406b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c109fe7e80390ebe9b55913646ecb6f621c1ddd2",
+        "rev": "a841e262264e48722dccc8469f066068146e406b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=c109fe7e80390ebe9b55913646ecb6f621c1ddd2";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=a841e262264e48722dccc8469f066068146e406b";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -164,15 +164,6 @@ with oself;
     propagatedBuildInputs = [ ppxlib cmdliner ];
   });
 
-  bjack = osuper.bjack.overrideAttrs (o: {
-    propagatedBuildInputs =
-      o.propagatedBuildInputs
-      ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-        Accelerate
-        CoreAudio
-      ]);
-  });
-
   bls12-381 = disableTests osuper.bls12-381;
 
   bls12-381-legacy = osuper.bls12-381-legacy.overrideAttrs (o: {
@@ -643,15 +634,6 @@ with oself;
     postPatch = ''
       substituteInPlace ./src/dune --replace "bigarray" ""
     '';
-  });
-
-  gstreamer = osuper.gstreamer.overrideAttrs (o: {
-    propagatedBuildInputs =
-      o.propagatedBuildInputs
-      ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-        AppKit
-        Foundation
-      ]);
   });
 
   hacl-star = osuper.hacl-star.overrideAttrs (_: {
@@ -1467,14 +1449,6 @@ with oself;
     propagatedBuildInputs = [ xmlm uri ptime ];
   };
 
-  tar = osuper.tar.overrideAttrs (o: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/ocaml-tar/releases/download/v2.2.1/tar-2.2.1.tbz;
-      sha256 = "0anm3zj4bbcw7qjr2ad9r3vc3mb5vy5jay5r79w56l3vp03j1kj3";
-    };
-    version = "2.2.0";
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ decompress ];
-  });
   tar-mirage = buildDunePackage {
     pname = "tar-mirage";
     inherit (tar) version src;

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -159,16 +159,6 @@ with oself;
 
   binaryen = callPackage ./binaryen { };
 
-  biniou = osuper.biniou.overrideAttrs (o: {
-    patches = [
-      (fetchpatch {
-        url = https://raw.githubusercontent.com/ocaml-bench/sandmark/2c5102156afd81cb4c0c91ab77375d5fc5d332bf/dependencies/packages/biniou/biniou.1.2.1/files/biniou-use-camlp-streams.patch;
-        sha256 = "sha256-xwB+zpV1xZQyQgyF+NS+B/doxTZyE7vitXb+iN3sBbg=";
-      })
-    ];
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ camlp-streams ];
-  });
-
   bisect_ppx = osuper.bisect_ppx.overrideAttrs (_: {
     buildInputs = [ ];
     propagatedBuildInputs = [ ppxlib cmdliner ];
@@ -1498,15 +1488,6 @@ with oself;
       tar
     ];
   };
-
-  toml = osuper.toml.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/ocaml-toml/to.ml/archive/7.1.0.tar.gz;
-      sha256 = "1vsjlwsq3q7wf0mcvxszxdl212zwqynr9kjpsxnx894yxlb9qkhx";
-    };
-
-    patches = [ ];
-  });
 
   topkg = osuper.topkg.overrideAttrs (_: {
     src = builtins.fetchurl {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -643,13 +643,6 @@ with oself;
     '';
   });
 
-  happy-eyeballs = osuper.happy-eyeballs.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/roburio/happy-eyeballs/releases/download/v0.3.0/happy-eyeballs-0.3.0.tbz;
-      sha256 = "17mnid1gvq1ml1zmqzn0m6jmrqw4kqdrjqrdsrphl5kxxyhs03m6";
-    };
-  });
-
   h2 = callPackage ./h2 { };
   h2-lwt = callPackage ./h2/lwt.nix { };
   h2-lwt-unix = callPackage ./h2/lwt-unix.nix { };


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/dea24b6610be436e65df7fc54ac9ad56c63d3209"><pre>ocamlPackages.ocaml_libvirt: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0a29695c1f488e7d1932baa572625bf668e975aa"><pre>ocamlPackages.labltk: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5c304acd4332e5e582572e1ef12947a563a91877"><pre>ocamlPackages.gstreamer: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a5b1e495fdd63232c1469a4f982c3e86f6ce39f"><pre>ocamlPackages.ffmpeg-avutil: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d66b3c77e50f5bd8daad425090d9fc639e8719d1"><pre>ocamlPackages.bjack: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/be7dbbe58910b4f41db4fdb1aa7503d7da02845a"><pre>ocamlPackages.ffmpeg-avcodec: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/eddbd3d8e28368b6765937904a12b1682b092f15"><pre>ocamlPackages.ffmpeg-avfilter: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/50f77e3b9d0c2dde4ca4a8ac6f614e58b0effbf7"><pre>ocamlPackages.ffmpeg-swscale: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/278da9f0932f1352e410a34835369e92e757bfe3"><pre>ocamlPackages.ffmpeg-av: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/699b87b8a420207446cb76034874d0a90fbbd5c2"><pre>ocamlPackages.ffmpeg-avdevice: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/50100d192e31e444261bb2f3ff4f54cfdbbcb788"><pre>ocamlPackages.ffmpeg-swresample: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/719809517df4cf2acceabaad6952c89c3d2ce3b9"><pre>ocamlPackages.toml: 7.0.0 → 7.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9ad7623ebe76c952ee283ec83690bb22ca7cb625"><pre>ocamlPackages.biniou: 1.2.1 → 1.2.2 (#208852)

Co-authored-by: Et7f3 <cadeaudeelie@gmail.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ca1bcab936e93a7c43eef4ba73d8d9e12913623b"><pre>opa: migrate to OCaml 4.05</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0127d48a3e4f8a990be8541ee70bc683897ef7fd"><pre>monotoneViz: migrate to OCaml 4.05</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7148e613d5a3e36f0a5bd0a7d564cac33724de74"><pre>ocamlPackages.tar: 2.0.1 → 2.2.2 (#209021)

Co-authored-by: Ulrik Strid <ulrik.strid@outlook.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/94ba1055239297f21cdbb275027604d88722cd10"><pre>hivex: build OCaml bindings

These are used by libguestfs\'s optional appliance builder program.  I
haven\'t been able to get that working yet, but this is a prerequisite.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/493fe01d9f00257654ee346f6b039cda8d960a35"><pre>ocamlPackages.mldoc: 1.4.9 -> 1.5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/91f334c3dcfb9bf88c09dcf012b350a9cc598271"><pre>ocamlPackages.ocsigen_server: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4b7da5f3bee55c266f90483978c039ea441c7a48"><pre>ocamlPackages.google-drive-ocamlfuse: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6b4546dfc222d9449999378b729549942b6c7dac"><pre>ocamlPackages.gapi-ocaml: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e21396d81c9f596e47559ff9ed76098325e2d19b"><pre>ocamlPackages.async_smtp: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6bda65e481d43385d67b5b0687695c50897e9a71"><pre>ocamlPackages.email_message: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/481df0c2649e7334ddf60fad75c492c23f24c47c"><pre>ocamlPackages.async_rpc_websocket: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d75e38bb6ebde568ff9a58dae518f032a41f0fbc"><pre>ocamlPackages.cohttp_async_websocket: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7bab58ecd1322f294dea62c07b84ddbc24a9b379"><pre>ocamlPackages.async_websocket: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/586aea4c8ab1b850d2ecb28ee25720adc8096dee"><pre>ocamlPackages.cryptokit: 1.17 → 1.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/90a21f4771906aa2bd5729a3a23b151fb9e8c422"><pre>ocamlPackages.letsencrypt: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4d86aa6b507ec80795ba9d7e8baa8f71300d0374"><pre>ocamlPackages.git: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aa339b2365f8df1858bf8c65bb11d68ea0572c36"><pre>ocamlPackages.mimic: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/589e4a2bb246f08b083beecb383172f2529b7f42"><pre>ocamlPackages.graphql: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0c17d9acac514ffe647b5be40b3c9bdb43fedb93"><pre>ocamlPackages.dune-release: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/373aa5e812a0b1a4dc61b1207a12e8cf33b48a0c"><pre>ocamlPackages.curly: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5f73c562d0ac5092fa31e073f7dc2a26bb48587c"><pre>ocamlPackages.resto: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/389bbb0c8478a7c30713e822d468004a108cb7cd"><pre>ocamlPackages.webmachine: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4ad9083feeba5d0453e859fce23756c63df7ea5a"><pre>ocamlPackages.telegraml: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d3491557ef2b3c06263430bb1828fb0780d5eb83"><pre>ocamlPackages.cohttp: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ebe4402d0a42452da47486254463995c0ed232a9"><pre>ocamlPackages.conduit: use dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e2f0148a2052cb6d948d7f5326cde18391f48f5f"><pre>ocamlPackages.dns: 6.3.0 → 6.4.1

ocamlPackages.happy-eyeballs: 0.3.0 → 0.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e7d375310f00c81a660b0405ba1625d982854e33"><pre>Merge pull request #209132 from Et7f3/ocamlPackages_fix_build_on_darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7a0b7b8051cb3027ab8c3568ece719e78b78573a"><pre>Merge pull request #210319 from marsam/update-mldoc

ocamlPackages.mldoc: 1.4.9 -> 1.5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c52c4d4aa13ff4d33f88af2edb3aa527ca470903"><pre>ocamlPackages.fzf: Patch hardcoded path to fzf binary</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c83517aba760fd968e4916c8d155eee47e4a5088"><pre>Merge pull request #210144 from wegank/ocaml-bump-obsolete</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/67548d607d6ae5cc1b716e5da12de63dc0d85f30"><pre>ocaml-ng.ocamlPackages_4_0[2-5].ocaml: unbreak on aarch64-linux</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/81aef2338a3834f4d0071978dbc114497ec56a7e"><pre>ocamlPackages.tls: 0.15.3 → 0.15.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/76645347bd7dadd7164de2e57084373e3dfe6304"><pre>Merge pull request #210117 from wegank/ocaml-aarch64-linux

ocaml-ng.ocamlPackages_4_0[2-5].ocaml: unbreak on aarch64-linux</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/c109fe7e80390ebe9b55913646ecb6f621c1ddd2...a841e262264e48722dccc8469f066068146e406b