### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674101896,
-        "narHash": "sha256-xWLaexT6IHhOJru54wrOMeBbkKeJzOZ4Pqrxctf82q0=",
+        "lastModified": 1674247172,
+        "narHash": "sha256-6gbmukIy81hh95YS7xIFfHjhOCcwIuw37mEopJSsIzs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a841e262264e48722dccc8469f066068146e406b",
+        "rev": "f043916573c888930442d101ff4adc2e4cae3665",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a841e262264e48722dccc8469f066068146e406b",
+        "rev": "f043916573c888930442d101ff4adc2e4cae3665",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=a841e262264e48722dccc8469f066068146e406b";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=f043916573c888930442d101ff4adc2e4cae3665";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/64a4e05f0d2932619fa8b4642d89ea97512771e8"><pre>ocaml: add unsafe string support</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/16ef918b424e3456d809d50109e8605a9969db5f"><pre>ekrhyper: migrate to OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0b9f9e8621e2bc5b98bb396e7a1740f9aaf22bf4"><pre>mldonkey: migrate to OCaml 4.13</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f043916573c888930442d101ff4adc2e4cae3665"><pre>Merge pull request #211791 from athre0z/zydis-split-zycore

zydis: split zycore into separate derivation</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/a841e262264e48722dccc8469f066068146e406b...f043916573c888930442d101ff4adc2e4cae3665