### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674527004,
-        "narHash": "sha256-njBB4Pg0VGK2WmwqEBM5tyvaEft7sRGs/QCKJ1hA2Ac=",
+        "lastModified": 1674556162,
+        "narHash": "sha256-X5b93+HMdyDqo+loT6Z7bIhaHUhSqVTw/T0lNrlZbvw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e10dc5b12183b764ae211b4c76c3b3de65660874",
+        "rev": "353e2d957c7421cae4e3ab42739a0997ea7e310f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e10dc5b12183b764ae211b4c76c3b3de65660874",
+        "rev": "353e2d957c7421cae4e3ab42739a0997ea7e310f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e10dc5b12183b764ae211b4c76c3b3de65660874";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=353e2d957c7421cae4e3ab42739a0997ea7e310f";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/e0532dd87c099ddfe20c53c8a2bc860ab6f90355"><pre>ocamlPackages.carton: Tests require getconf

https://github.com/mirage/ocaml-git/blob/471406dde6c3056ea49547de379fef12871da48b/bin/fiber/fiber.ml#L132</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d079571aa24a774999ef1fa227687251e274cb96"><pre>ocamlPackages.paf, ocamlPackages.paf-cohttp: add local networking for test

in test we can read this:
[exception] Unix.Unix_error(Unix.EPERM, \"bind\", \"\")
            Raised by primitive operation at Tcpv4v6_socket.listen.(fun) in file \"src/stack-unix/tcpv4v6_socket.ml\", line 149, characters 6-50</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/67da8ff5c509c0fa5315ba67ba90a5539ff92d3a"><pre>Merge pull request #212342 from Et7f3/patch-2

ocamlPackages.paf: add local networking for test</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dff69fffd007cef0fe67d9ebcc98c779c930b7f4"><pre>Merge pull request #197048 from Et7f3/fix-ocamlPackages.carton-test

ocamlPackages.carton: Tests require getconf</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/353e2d957c7421cae4e3ab42739a0997ea7e310f"><pre>Merge pull request #212408 from raboof/imapsync-fix-license

imapsync: fix license</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/353e2d957c7421cae4e3ab42739a0997ea7e310f"><pre>Merge pull request #212408 from raboof/imapsync-fix-license

imapsync: fix license</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/353e2d957c7421cae4e3ab42739a0997ea7e310f"><pre>Merge pull request #212408 from raboof/imapsync-fix-license

imapsync: fix license</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/353e2d957c7421cae4e3ab42739a0997ea7e310f"><pre>Merge pull request #212408 from raboof/imapsync-fix-license

imapsync: fix license</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e10dc5b12183b764ae211b4c76c3b3de65660874...353e2d957c7421cae4e3ab42739a0997ea7e310f