### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676431766,
-        "narHash": "sha256-LcuG0sutA1ZNncFBDCnp7y2XZjASUQTiajph480L0vo=",
+        "lastModified": 1676569297,
+        "narHash": "sha256-2n4C4H3/U+3YbDrQB6xIw7AaLdFISCCFwOkcETAigqU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6e8ebef1966ec47edc3f1e92f3ccf6f82d0c7c4",
+        "rev": "ac1f5b72a9e95873d1de0233fddcb56f99884b37",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6e8ebef1966ec47edc3f1e92f3ccf6f82d0c7c4",
+        "rev": "ac1f5b72a9e95873d1de0233fddcb56f99884b37",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=b6e8ebef1966ec47edc3f1e92f3ccf6f82d0c7c4";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=ac1f5b72a9e95873d1de0233fddcb56f99884b37";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/55f76accb31ffc52ec58241961c92fe62dc1ccd3"><pre>ocamlPackages.owl: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/12fdba08f0596c74f883470e842aa69dc91d0756"><pre>ocamlPackages.torch: 0.15 → 0.17</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c1f110eef4c301ebe00cd6b0d8df5ea06f361a75"><pre>ocamlPackages.npy: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ac1f5b72a9e95873d1de0233fddcb56f99884b37"><pre>Merge pull request #216662 from wegank/nushell-darwin

nushell: use newer libproc.h</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ac1f5b72a9e95873d1de0233fddcb56f99884b37"><pre>Merge pull request #216662 from wegank/nushell-darwin

nushell: use newer libproc.h</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ac1f5b72a9e95873d1de0233fddcb56f99884b37"><pre>Merge pull request #216662 from wegank/nushell-darwin

nushell: use newer libproc.h</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ac1f5b72a9e95873d1de0233fddcb56f99884b37"><pre>Merge pull request #216662 from wegank/nushell-darwin

nushell: use newer libproc.h</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/b6e8ebef1966ec47edc3f1e92f3ccf6f82d0c7c4...ac1f5b72a9e95873d1de0233fddcb56f99884b37