### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677932085,
-        "narHash": "sha256-+AB4dYllWig8iO6vAiGGYl0NEgmMgGHpy9gzWJ3322g=",
+        "lastModified": 1678101937,
+        "narHash": "sha256-Trmgbc6DTXaofJHbegtN1YCJUIjBOg5ByRHYtxLf1qU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
+        "rev": "b6cc2f2979a19ec2983cef156d5d44b2fe0e545f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
+        "rev": "b6cc2f2979a19ec2983cef156d5d44b2fe0e545f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=3c5319ad3aa51551182ac82ea17ab1c6b0f0df89";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=b6cc2f2979a19ec2983cef156d5d44b2fe0e545f";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1694,17 +1694,6 @@ with oself;
     };
   });
 
-  sedlex = osuper.sedlex.overrideAttrs (_: {
-    src = fetchFromGitHub {
-      owner = "ocaml-community";
-      repo = "sedlex";
-      rev = "v3.1";
-      hash = "sha256-qG8Wxd/ATwoogeKJDyt5gkGhP5Wvc0j0mMqcoVDkeq4=";
-    };
-    checkInputs = [ ppx_expect ];
-    doCheck = lib.versionAtLeast osuper.ocaml.version "4.14";
-  });
-
   sendfile = callPackage ./sendfile { };
 
   session = callPackage ./session { };
@@ -1737,7 +1726,6 @@ with oself;
       substituteInPlace src/lib/of_mutable.ml --replace "Pervasives" "Stdlib"
     '';
   });
-
 
   sourcemaps = buildDunePackage {
     pname = "sourcemaps";


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/e68c7797ab08abfd0edc5bdab5e710d428792b42"><pre>dune_3: 3.6.2 -> 3.7.0

https://github.com/ocaml/dune/releases/tag/3.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/18819f92284f3e165c51922d3bd72c24703bfc2f"><pre>ocamlPackages.fiber: move source to repository</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fc016267627c9e10c078861908bce51278aac052"><pre>dune_3: add ocaml-lsp as reverse dependency to passthru.tests</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/50e35e9b6c8fbd2e84bf569bfb3c7dd9ab6a6329"><pre>obliv-c: migrate to OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cc4169d737e092ef877cf8b8d9b940df849a7312"><pre>glsurf: migrate to OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/684306b246d05168e42425a3610df7e2c4d51fcd"><pre>ocamlPackages.sedlex: 3.0 -> 3.1

https://github.com/ocaml-community/sedlex/releases/tag/v3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/55bb9cd6c01b6120bc55c14520efb7a3c95ed7ad"><pre>Merge pull request #219604 from wegank/glsurf-ocaml

glsurf: migrate to OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aecb04e7ab49b94b9601cebf957bd7b7820d822d"><pre>Merge pull request #219598 from wegank/obliv-c-ocaml

obliv-c: migrate to OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b6cc2f2979a19ec2983cef156d5d44b2fe0e545f"><pre>element-desktop: electron_22 -> electron_23 (#219823)

Apparently this got changed in 1.11.24[1], but wasn\'t mentioned in the
release notes.

Thank you yu-re-ka for pointing that out!

[1] https://github.com/vector-im/element-desktop/commit/1462e879450c8bd386b8a4cfc910b58f9ff23c85</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b6cc2f2979a19ec2983cef156d5d44b2fe0e545f"><pre>element-desktop: electron_22 -> electron_23 (#219823)

Apparently this got changed in 1.11.24[1], but wasn\'t mentioned in the
release notes.

Thank you yu-re-ka for pointing that out!

[1] https://github.com/vector-im/element-desktop/commit/1462e879450c8bd386b8a4cfc910b58f9ff23c85</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b6cc2f2979a19ec2983cef156d5d44b2fe0e545f"><pre>element-desktop: electron_22 -> electron_23 (#219823)

Apparently this got changed in 1.11.24[1], but wasn\'t mentioned in the
release notes.

Thank you yu-re-ka for pointing that out!

[1] https://github.com/vector-im/element-desktop/commit/1462e879450c8bd386b8a4cfc910b58f9ff23c85</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/3c5319ad3aa51551182ac82ea17ab1c6b0f0df89...b6cc2f2979a19ec2983cef156d5d44b2fe0e545f