### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678780369,
-        "narHash": "sha256-D8wM0K1EkWLwbUu9fohC57+n89zC9qQ3hdC9Bys5GYw=",
+        "lastModified": 1678898139,
+        "narHash": "sha256-gidgjrUdNIK7xaQbvL19lZO+uij4035NafNotHRTjUU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1474943fd91fbe5567f7582acf568e0f999f4af1",
+        "rev": "a86610144f60e8a54f12a75f2ca0ad62e2a5b7fa",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1474943fd91fbe5567f7582acf568e0f999f4af1",
+        "rev": "a86610144f60e8a54f12a75f2ca0ad62e2a5b7fa",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=1474943fd91fbe5567f7582acf568e0f999f4af1";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=a86610144f60e8a54f12a75f2ca0ad62e2a5b7fa";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -60,16 +60,6 @@ in
 with oself;
 
 {
-  buildDunePackage = args: (osuper.buildDunePackage ({
-    installPhase = ''
-      runHook preInstall
-      dune install --prefix $out --libdir $OCAMLFIND_DESTDIR ${args.pname} --docdir $out/share/doc
-      runHook postInstall
-    '';
-  } // args
-  ));
-
-
   alcotest = osuper.alcotest.overrideAttrs (_: {
     src = builtins.fetchurl {
       url = https://github.com/mirage/alcotest/releases/download/1.7.0/alcotest-1.7.0.tbz;


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/72e0ac1bb86f3d31be4337fbd5595d5d490a9160"><pre>ocamlPackages.findlib: explain how to bypass the dep conflict detection

Inspired by https://github.com/NixOS/nixpkgs/pull/205646#issuecomment-1412713324</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/72d9c8354ddfca7ce54807873a73129b6cd27ce2"><pre>Merge pull request #214239 from symphorien/ocaml-conflict-verbose

ocamlPackages.findlib: explain how to bypass the dep conflict detection</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1480cd40981da3986ead8ea0554eb13c47515127"><pre>ocamlPackages.merlin: 4.7 → 4.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3c66f2de15281ed7925ac08c6ca6f64729b39bf9"><pre>Merge pull request #220209 from vbgl/ocaml-merlin-4.8.0

ocamlPackages.merlin: 4.7 → 4.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/629c0fbcad21b77065d5c282ef9582e5cd770604"><pre>ocamlPackages.mirage-time: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8122f3ef0db47dee5efe38af152a1b1c5c56ff5a"><pre>ocamlPackages.alcotest-mirage: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/50a35f7c20256b9de289e5e1470b51d6b1552c7b"><pre>ocamlPackages.happy-eyeballs: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2a9ab2a9671d2a14523500b842aba31067b0c04e"><pre>ocamlPackages.mirage-vnetif: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2ac2434fe090f5a636edb564d19471673c2951c7"><pre>ocamlPackages.mirage-unix: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8971fdbc3c0b103d103f347e2feb0836a2c0c4c3"><pre>ocamlPackages.metrics: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7c21cff3579df967f9000287d8aed8b6156a40c8"><pre>ocamlPackages.duration: 0.2.0 → 0.2.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3b3e37f996a1265c6bfb7b4415241e3519c286c0"><pre>[OCaml] tell dune where to install man

\`fixupPhase\` move \`\$out/man\` to \`\$out/share/man\`. So the information of their location in the dune-project file is outdated which breaks dependencies on packages ( \`(package foo)\`).</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1c03223e5c1cf29a349a47ddf76f14806c048852"><pre>Merge pull request #220543 from vbgl/ocaml-duration-0.2.1

ocamlPackages.duration: 0.2.0 → 0.2.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e0a772558cb6d056689b743497a3724938d13b4"><pre>ocamlPackages.routes: 1.0.0 → 2.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4fb8cce280a0deef3dd3a432be5f9487d9630e6c"><pre>ocamlPackages.routes: 1.0.0 → 2.0.0

ocamlPackages.routes: 1.0.0 → 2.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a86610144f60e8a54f12a75f2ca0ad62e2a5b7fa"><pre>Merge #219444: staging-next 2023-03-04</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/1474943fd91fbe5567f7582acf568e0f999f4af1...a86610144f60e8a54f12a75f2ca0ad62e2a5b7fa