### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679307304,
-        "narHash": "sha256-wyhof6C1TnXxISFhcB/8U1tYNeYbPeka6hJr8K8ADGI=",
+        "lastModified": 1679402416,
+        "narHash": "sha256-OXx8Faah7TTZTA+P0v5YRNSaOEMveAet3RdhtHY0y7s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "28376bd3853ccc16451a407ac0882edf207adf40",
+        "rev": "fedc9837343482896a0d9f76fc4f1b54cc4b3643",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "28376bd3853ccc16451a407ac0882edf207adf40",
+        "rev": "fedc9837343482896a0d9f76fc4f1b54cc4b3643",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=28376bd3853ccc16451a407ac0882edf207adf40";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=fedc9837343482896a0d9f76fc4f1b54cc4b3643";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/f05c5da8e0a5ebdfeaeaf9838a5a47d41d543f91"><pre>ocamlPackages.ppx_cstubs: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/79fa97caa3e61f4793744b7148d5bdac01f0aa4e"><pre>ocamlPackages.containers: 3.10 → 3.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/edf81049b1e89ed31f17722429e77fcba87f31c3"><pre>ocaml-ng.ocamlPackages_4_01_0.csv: remove at 1.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/832ce14a2103077ce137b2b6808636a656d7777c"><pre>ocamlPackages.csv: fix for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8c9e49ab50689e4e1b9f11867809e16ece4d00ca"><pre>Merge pull request #222143 from vbgl/ocaml-csv-cleanup

ocamlPackages.csv: fix for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8501a1645abcc4ad91c9eadd53061124f5bebb3b"><pre>Merge pull request #221971 from vbgl/ocaml-containers-3.11

ocamlPackages.containers: 3.10 → 3.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e12230e71628a460bf82a8477242280868efe799"><pre>why3: 1.5.1 → 1.6.0; ocamlPackages.lambdapi: 2.2.1 → 2.3.1 (#220986)

why3: 1.5.1 → 1.6.0
ocamlPackages.lambdapi: 2.2.1 → 2.3.1

Co-authored-by: Weijia Wang <9713184+wegank@users.noreply.github.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fedc9837343482896a0d9f76fc4f1b54cc4b3643"><pre>linuxManualConfig: add pahole to moduleBuildDependencies

This seems to be needed for out-of-tree module builds since d57568fcad7.
We do not yet understand why, but this will unblock the channels while
we figure it out.

Fixes: d57568fcad7 (\"linuxManualConfig: install GDB scripts\")</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fedc9837343482896a0d9f76fc4f1b54cc4b3643"><pre>linuxManualConfig: add pahole to moduleBuildDependencies

This seems to be needed for out-of-tree module builds since d57568fcad7.
We do not yet understand why, but this will unblock the channels while
we figure it out.

Fixes: d57568fcad7 (\"linuxManualConfig: install GDB scripts\")</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fedc9837343482896a0d9f76fc4f1b54cc4b3643"><pre>linuxManualConfig: add pahole to moduleBuildDependencies

This seems to be needed for out-of-tree module builds since d57568fcad7.
We do not yet understand why, but this will unblock the channels while
we figure it out.

Fixes: d57568fcad7 (\"linuxManualConfig: install GDB scripts\")</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fedc9837343482896a0d9f76fc4f1b54cc4b3643"><pre>linuxManualConfig: add pahole to moduleBuildDependencies

This seems to be needed for out-of-tree module builds since d57568fcad7.
We do not yet understand why, but this will unblock the channels while
we figure it out.

Fixes: d57568fcad7 (\"linuxManualConfig: install GDB scripts\")</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fedc9837343482896a0d9f76fc4f1b54cc4b3643"><pre>linuxManualConfig: add pahole to moduleBuildDependencies

This seems to be needed for out-of-tree module builds since d57568fcad7.
We do not yet understand why, but this will unblock the channels while
we figure it out.

Fixes: d57568fcad7 (\"linuxManualConfig: install GDB scripts\")</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fedc9837343482896a0d9f76fc4f1b54cc4b3643"><pre>linuxManualConfig: add pahole to moduleBuildDependencies

This seems to be needed for out-of-tree module builds since d57568fcad7.
We do not yet understand why, but this will unblock the channels while
we figure it out.

Fixes: d57568fcad7 (\"linuxManualConfig: install GDB scripts\")</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fedc9837343482896a0d9f76fc4f1b54cc4b3643"><pre>linuxManualConfig: add pahole to moduleBuildDependencies

This seems to be needed for out-of-tree module builds since d57568fcad7.
We do not yet understand why, but this will unblock the channels while
we figure it out.

Fixes: d57568fcad7 (\"linuxManualConfig: install GDB scripts\")</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fedc9837343482896a0d9f76fc4f1b54cc4b3643"><pre>linuxManualConfig: add pahole to moduleBuildDependencies

This seems to be needed for out-of-tree module builds since d57568fcad7.
We do not yet understand why, but this will unblock the channels while
we figure it out.

Fixes: d57568fcad7 (\"linuxManualConfig: install GDB scripts\")</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/28376bd3853ccc16451a407ac0882edf207adf40...fedc9837343482896a0d9f76fc4f1b54cc4b3643