### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -137,6 +137,7 @@ let
 
     "uring"
     "eio_linux"
+    "magic-trace"
   ];
 
   lowerThanOCaml5Ignores = [

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679542234,
-        "narHash": "sha256-NrUIxT2MtOcRDLq+bAFqAUno4w9Ds7UDaKQj+3yJPQk=",
+        "lastModified": 1679716343,
+        "narHash": "sha256-Y+gX9K//+Fujjz0VZKM/Aew/mmjQ6zA+6Vz9yK4F+CU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "99265ac4a8c83e4109f9cfc7c911707b86437b67",
+        "rev": "b5ccc5d0de289ef9b16f705aed137d65e1a60c0f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "99265ac4a8c83e4109f9cfc7c911707b86437b67",
+        "rev": "b5ccc5d0de289ef9b16f705aed137d65e1a60c0f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=99265ac4a8c83e4109f9cfc7c911707b86437b67";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=b5ccc5d0de289ef9b16f705aed137d65e1a60c0f";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/eio-ssl/default.nix
+++ b/ocaml/eio-ssl/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, buildDunePackage, ssl, eio_main }:
+{ fetchFromGitHub, buildDunePackage, ssl, eio }:
 
 buildDunePackage {
   pname = "eio-ssl";
@@ -7,5 +7,5 @@ buildDunePackage {
     url = https://github.com/anmonteiro/eio-ssl/releases/download/0.1.1/eio-ssl-0.1.1.tbz;
     sha256 = "1v24k03ml0hyycxx87z0nyf9qqa447la9kycm7hvhrs68zsn2d6b";
   };
-  propagatedBuildInputs = [ ssl eio_main ];
+  propagatedBuildInputs = [ ssl eio ];
 }


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/c9d19defb1cc575c083bcfa92a8d5242a016243e"><pre>ocamlPackages.mirage-net: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f2aa79b5e11d3c87d090089f87e7071bdbebfa16"><pre>ocamlPackages.mirage-runtime: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/33cffcde611ae2c6b62456f016ca0916e42d5401"><pre>ocamlPackages.tuntap: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b174387ba919dddd50e347f18012343dcb6ba4fa"><pre>ocamlPackages.macaddr: 5.3.0 → 5.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8807247a1dbf76909da510e9f7703995ae6d5f03"><pre>ocamlPackages.macaddr: 5.3.0 → 5.4.0

ocamlPackages.macaddr: 5.3.0 → 5.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a29c4b0bf543f64a87688732c66c24f49412ed8c"><pre>ocamlPackages.bls12-381: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cc766b2e44f90e1fb6338d82832e6de80a04ae50"><pre>ocamlPackages.hex: 1.4.0 → 1.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fc8420f3793e9b43f0906a35d7aea87e33f23653"><pre>ocamlPackages.shared-memory-ring: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/580bb886228f454ffaec89025cba75d284445649"><pre>ocamlPackages.mirage-logs: 1.2.0 → 1.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fa448b51e0034926d70ea13dd7fcb9c25b3a1aab"><pre>ocamlPackages.mirage-profile: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/69dda0be8e59d4412f1ebf2c470da0b82037dd57"><pre>ocamlPackages.mirage-logs: 1.2.0 → 1.3.0

ocamlPackages.mirage-logs: 1.2.0 → 1.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e0591b2e56b0010869307b7b836ae7d14e03fa97"><pre>ocamlPackages.cohttp_static_handler: init at 0.15.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/089467fefb3d6c0a568a379af110de4447c6dc2f"><pre>ocamlPackages.owee: 0.4 -> 0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d9610bb9330f12b615d697a5ff063314859fa3b"><pre>ocamlPackages.magic-trace: init at 1.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d1833117a89aca751b0a12220c933c33e9e74a03"><pre>ocamlPackages.spacetime_lib: patch for compat with owee 0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b9831fe22c13cf46b9ea35b7f9e16f6fe170dab1"><pre>Merge pull request #222652 from Alizter/ps/branch/ocamlpackages_cohttp_static_handler__init_at_0_15_0

ocamlPackages.magic-trace: init at 1.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ec0134632ceca175a3a9c1e2783512234abc5bba"><pre>ocamlPackages.tezos-base58: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/02d564498703e5a6edb48f99674cdaaaee509949"><pre>ocamlPackages.digestif: 1.1.2 → 1.1.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/830dbba75df7d071d0c827b95e50e69c5a016143"><pre>ocamlPackages.digestif: 1.1.3 → 1.1.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dda0967dce2f071b8f92232d431d84f1039cb870"><pre>Merge pull request #222897 from vbgl/ocaml-digestif-1.1.3

ocamlPackages.digestif: 1.1.2 → 1.1.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5ccc5d0de289ef9b16f705aed137d65e1a60c0f"><pre>terraform-providers.tencentcloud: 1.79.17 → 1.79.18</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/99265ac4a8c83e4109f9cfc7c911707b86437b67...b5ccc5d0de289ef9b16f705aed137d65e1a60c0f