### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680334200,
-        "narHash": "sha256-kDEdiPCw41us+8p6ae2vz2Xd8cmPxXzc9uTftAWuUzc=",
+        "lastModified": 1680450296,
+        "narHash": "sha256-4SJqREZkmyQufQcudS+j0WqsHeRDE6jyFw6l6QcrMrE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "45c671173b3392e946dee7f9aa6c40c6f348bec3",
+        "rev": "cd9eead62d1cb6dd692cd87c209e0bc48f733669",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "45c671173b3392e946dee7f9aa6c40c6f348bec3",
+        "rev": "cd9eead62d1cb6dd692cd87c209e0bc48f733669",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=45c671173b3392e946dee7f9aa6c40c6f348bec3";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=cd9eead62d1cb6dd692cd87c209e0bc48f733669";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/98ee323ad3048c94081bc9119dd55a39558c5671"><pre>ocamlPackages.json-data-encoding: 0.11 → 0.12.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/572dcae7cc96450e72a244065ee3e1f18a2d52a7"><pre>Merge pull request #224168 from vbgl/ocaml-json-data-encoding-0.12.1

ocamlPackages.json-data-encoding: 0.11 → 0.12.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cd9eead62d1cb6dd692cd87c209e0bc48f733669"><pre>Merge pull request #223929 from Enzime/fix/1password-wayland

Fix \`NIXOS_OZONE_WL\` not working with 1Password</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cd9eead62d1cb6dd692cd87c209e0bc48f733669"><pre>Merge pull request #223929 from Enzime/fix/1password-wayland

Fix \`NIXOS_OZONE_WL\` not working with 1Password</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/45c671173b3392e946dee7f9aa6c40c6f348bec3...cd9eead62d1cb6dd692cd87c209e0bc48f733669