### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680450296,
-        "narHash": "sha256-4SJqREZkmyQufQcudS+j0WqsHeRDE6jyFw6l6QcrMrE=",
+        "lastModified": 1680480876,
+        "narHash": "sha256-Xmb4hOhwyYnD8RXCb3ZtjBN2talE14O0geeUxzdE1+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd9eead62d1cb6dd692cd87c209e0bc48f733669",
+        "rev": "f521f4613355f8628fe378dad4c41d3fd8886966",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd9eead62d1cb6dd692cd87c209e0bc48f733669",
+        "rev": "f521f4613355f8628fe378dad4c41d3fd8886966",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=cd9eead62d1cb6dd692cd87c209e0bc48f733669";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=f521f4613355f8628fe378dad4c41d3fd8886966";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/7a9da552fbc512d04d4707bd075a3766f6f2dd26"><pre>ocamlPackages.posix: 2.0.0 → 2.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f0f598bee4feb80826db8285b727bd015c15ac76"><pre>Merge pull request #224023 from vbgl/ocaml-posix-2.0.2

ocamlPackages.posix: 2.0.0 → 2.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f521f4613355f8628fe378dad4c41d3fd8886966"><pre>linuxManualConfig: get rid of drvAttrs

This is an attempt to make linuxManualConfig look a lot more like a
normal package.  Previously, about half the attributes passed to
mkDerivation come from calling a \"drvAttrs\" function, which just
served to alias some variables through function parameters.  There
wasn\'t really a system for which attributes came from drvAttrs, and
which did not.

I\'ve also made a few other minor changes, like re-ordering attributes
to be more idiomatic, and using variables that were moved out of
drvAttrs in the definitions of attributes that weren\'t in drvAttrs
before.  I\'ve limited my changes here to what I can confidently do
without causing any rebuilds.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f521f4613355f8628fe378dad4c41d3fd8886966"><pre>linuxManualConfig: get rid of drvAttrs

This is an attempt to make linuxManualConfig look a lot more like a
normal package.  Previously, about half the attributes passed to
mkDerivation come from calling a \"drvAttrs\" function, which just
served to alias some variables through function parameters.  There
wasn\'t really a system for which attributes came from drvAttrs, and
which did not.

I\'ve also made a few other minor changes, like re-ordering attributes
to be more idiomatic, and using variables that were moved out of
drvAttrs in the definitions of attributes that weren\'t in drvAttrs
before.  I\'ve limited my changes here to what I can confidently do
without causing any rebuilds.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f521f4613355f8628fe378dad4c41d3fd8886966"><pre>linuxManualConfig: get rid of drvAttrs

This is an attempt to make linuxManualConfig look a lot more like a
normal package.  Previously, about half the attributes passed to
mkDerivation come from calling a \"drvAttrs\" function, which just
served to alias some variables through function parameters.  There
wasn\'t really a system for which attributes came from drvAttrs, and
which did not.

I\'ve also made a few other minor changes, like re-ordering attributes
to be more idiomatic, and using variables that were moved out of
drvAttrs in the definitions of attributes that weren\'t in drvAttrs
before.  I\'ve limited my changes here to what I can confidently do
without causing any rebuilds.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f521f4613355f8628fe378dad4c41d3fd8886966"><pre>linuxManualConfig: get rid of drvAttrs

This is an attempt to make linuxManualConfig look a lot more like a
normal package.  Previously, about half the attributes passed to
mkDerivation come from calling a \"drvAttrs\" function, which just
served to alias some variables through function parameters.  There
wasn\'t really a system for which attributes came from drvAttrs, and
which did not.

I\'ve also made a few other minor changes, like re-ordering attributes
to be more idiomatic, and using variables that were moved out of
drvAttrs in the definitions of attributes that weren\'t in drvAttrs
before.  I\'ve limited my changes here to what I can confidently do
without causing any rebuilds.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/cd9eead62d1cb6dd692cd87c209e0bc48f733669...f521f4613355f8628fe378dad4c41d3fd8886966