### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680750214,
-        "narHash": "sha256-um8SRYtQu6AbQgMR8I4gKWOZl6n7cO6gZ7bxOmLJ78E=",
+        "lastModified": 1680850636,
+        "narHash": "sha256-raLGUhS/0mfnnfz+pgqq7V6rtiez8BbhFUUPiH2gnYc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "060e8eee747772fe07b4751404ddcf998aeccbf3",
+        "rev": "671d22f41fdf1f246e35f3e705c581cc87a34b71",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "060e8eee747772fe07b4751404ddcf998aeccbf3",
+        "rev": "671d22f41fdf1f246e35f3e705c581cc87a34b71",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=060e8eee747772fe07b4751404ddcf998aeccbf3";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=671d22f41fdf1f246e35f3e705c581cc87a34b71";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/33c744266b7dd29029801b898e1fed7a24aa38ac"><pre>ocamlPackages.elpi: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/578fbbb3db93773def13e11af0f78c5e93c1dc08"><pre>ocamlPackages.atdgen: 2.10.0 → 2.11.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6ed41bd5adfe0a378e784fa7553874994dc40858"><pre>Merge pull request #224951 from vbgl/ocaml-atdgen-2.11.0

ocamlPackages.atdgen: 2.10.0 → 2.11.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/671d22f41fdf1f246e35f3e705c581cc87a34b71"><pre>Merge pull request #224596 from r-ryantm/auto-update/spicedb

spicedb: 1.17.0 -> 1.19.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/671d22f41fdf1f246e35f3e705c581cc87a34b71"><pre>Merge pull request #224596 from r-ryantm/auto-update/spicedb

spicedb: 1.17.0 -> 1.19.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/671d22f41fdf1f246e35f3e705c581cc87a34b71"><pre>Merge pull request #224596 from r-ryantm/auto-update/spicedb

spicedb: 1.17.0 -> 1.19.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/671d22f41fdf1f246e35f3e705c581cc87a34b71"><pre>Merge pull request #224596 from r-ryantm/auto-update/spicedb

spicedb: 1.17.0 -> 1.19.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/060e8eee747772fe07b4751404ddcf998aeccbf3...671d22f41fdf1f246e35f3e705c581cc87a34b71