### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681254024,
-        "narHash": "sha256-CAvazxjSm83u/RywS8sSsN59DOGr+7mqHsyR4RbN/iI=",
+        "lastModified": 1681330038,
+        "narHash": "sha256-JZeiBkcb6KPe0IeTQXspzd6GyZ69AgpDzuSvGh146h0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bca7aaf8ea4c99c16c257a0e4f2e8384f28fb2cf",
+        "rev": "b3f466c32a2fbd34566d72fa71df8beca049e9a1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bca7aaf8ea4c99c16c257a0e4f2e8384f28fb2cf",
+        "rev": "b3f466c32a2fbd34566d72fa71df8beca049e9a1",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=bca7aaf8ea4c99c16c257a0e4f2e8384f28fb2cf";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=b3f466c32a2fbd34566d72fa71df8beca049e9a1";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -52,13 +52,6 @@ in
 with oself;
 
 {
-  alcotest = osuper.alcotest.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/alcotest/releases/download/1.7.0/alcotest-1.7.0.tbz;
-      sha256 = "1pq2g5k427sx3mzn75hrxxwj9xxjv9mk1mq7bscqhpml6kdsqaw1";
-    };
-  });
-
   ansiterminal = osuper.ansiterminal.overrideAttrs (_: {
     postPatch = ''
       substituteInPlace src/dune --replace " bytes" ""
@@ -960,7 +953,7 @@ with oself;
   luv = osuper.luv.overrideAttrs (_: {
     src = builtins.fetchurl {
       url = https://github.com/aantron/luv/releases/download/0.5.12/luv-0.5.12.tar.gz;
-      sha256 = "1brsgdzhqpkfsa9qw3zv70y4z96fqbpcws9c6h2bn5p0qv1dvk3p";
+      sha256 = "10ra3dkj3x3icplhzxg1gh1smk12fmnxmqg7yx9wmlbrjl985xzr";
     };
   });
   luv_unix = buildDunePackage {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/9c94eecac188f786c70708444fc814f061d9d76e"><pre>ocamlPackages.sexp: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3421799d7c3ad538bfdcd426a893fcc02022de3d"><pre>ocamlPackages.vcaml: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9db7b70800c071bffbf39de384d5af0b523cc621"><pre>ocamlPackages.jsonaf: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/248265cdc34c9d3aa6c009e3bfc012c9b2aea412"><pre>ocamlPackages.faraday: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e919a21c3e3c4c4ea7c1cb704b23801ef24730b"><pre>ocamlPackages.domain-name: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dd8841872aa672b34d79a7a20959585171e6a316"><pre>ocamlPackages.encore: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/716adb19e27745c04e5e44a90d44860aa240913d"><pre>ocamlPackages.unstrctrd: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/40153f233e9fc8e70e9fb9f18f85ccd3a82bf103"><pre>ocamlPackages.angstrom: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/704a0dd9544a96d85cfca0ceb40df8228852f7cd"><pre>ocamlPackages.ke: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7bbbb27a83ec26d1cf1c05ad2497a130f5df1e04"><pre>ocamlPackages.duff: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b9821fbd4d5dcedb0412e9bf1ca35d4bdc32bb14"><pre>ocamlPackages.bigstringaf: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f94acff2393fc940b1cf9cfcd60ccfe89e97e6ad"><pre>ocamlPackages.yuscii: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c1db7e08ebf6be654d26c945140371f03b28656e"><pre>ocamlPackages.ppx_blob: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6ab83d22558860198aaa79fb544b92b58ff913d0"><pre>ocamlPackages.ppx_deriving_cmdliner: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bed82a9b5029883473d2c6e6b97f23b1c907790b"><pre>ocamlPackages.junit: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ca7d2614d71265121bb7cedd7f41ed53f240c944"><pre>ocamlPackages.gmap: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7464ae25e79290fa9798bef17cf4e23d7fca0dd9"><pre>ocamlPackages.dispatch: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/23100ea3c8cbae76dd672d4c5ed67e668ac2061d"><pre>ocamlPackages.ff: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cb9fc605bb17bf16c2dff33abf35f5806f47f098"><pre>ocamlPackages.terminal: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8a288f2c760948466d357a7fe1b02c685d5663cb"><pre>ocamlPackages.pecu: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/234b193821368fd1a6e8c1d6b19fc7eee843740f"><pre>ocamlPackages.alcotest: 1.6.0 → 1.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c70dabd94612630c6857b2200e8e1176d458b672"><pre>Merge pull request #225681 from vbgl/ocaml-alcotest-1.7.0

ocamlPackages.alcotest: 1.6.0 → 1.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0dc61806f6bb84977e488cbafa6f57f29fcd75e3"><pre>ocamlPackages.headache: init at 1.06</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9973e55944acaa60cdaed97b02d459cfdcfadf0e"><pre>Merge pull request #225714 from Niols/headache-1.06

ocamlPackages.headache: init at 1.06</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/bca7aaf8ea4c99c16c257a0e4f2e8384f28fb2cf...b3f466c32a2fbd34566d72fa71df8beca049e9a1