### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681559998,
-        "narHash": "sha256-bGa3v5qKM+dPyEP4Keyt/LR/S+HhRVbfI5LRAm5T5co=",
+        "lastModified": 1681713375,
+        "narHash": "sha256-UPDEwrzOQLTNzNDMkcf3J7+7vV3zlQCCrO33kwlFsdY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "280b1cdc1ea37bb477be1dada5d753f0246759a8",
+        "rev": "9a60b3eef1a0ccb4e3459eba1814bae91d07134e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "280b1cdc1ea37bb477be1dada5d753f0246759a8",
+        "rev": "9a60b3eef1a0ccb4e3459eba1814bae91d07134e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=280b1cdc1ea37bb477be1dada5d753f0246759a8";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=9a60b3eef1a0ccb4e3459eba1814bae91d07134e";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a3b117a70aeae149eca3a69b7767b8163ef63f0b"><pre>ocamlPackages.bisect_ppx: 2.8.1 → 2.8.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bb7aafa62c303354c711e230cc7bbc75569426e2"><pre>Merge pull request #226193 from vbgl/ocaml-bisect_ppx-2.8.2

ocamlPackages.bisect_ppx: 2.8.1 → 2.8.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8c0901412f7030f999ba32f5bfa6e70fc53934c"><pre>ocamlPackages.ppx_tools_versioned: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/244c5561fb36ee1b10285aec4fbf14917646df06"><pre>ocamlPackages.hack_parallel: use Dune 3

And disable for OCaml < 4.08 (broken)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0939a9604db7f77186505833ddf327649a944ba8"><pre>ocamlPackages.ocaml-migrate-parsetree: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a60b3eef1a0ccb4e3459eba1814bae91d07134e"><pre>Merge pull request #226580 from natsukium/sketchybar/update

sketchybar: 2.14.1 -> 2.14.4 and fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a60b3eef1a0ccb4e3459eba1814bae91d07134e"><pre>Merge pull request #226580 from natsukium/sketchybar/update

sketchybar: 2.14.1 -> 2.14.4 and fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a60b3eef1a0ccb4e3459eba1814bae91d07134e"><pre>Merge pull request #226580 from natsukium/sketchybar/update

sketchybar: 2.14.1 -> 2.14.4 and fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a60b3eef1a0ccb4e3459eba1814bae91d07134e"><pre>Merge pull request #226580 from natsukium/sketchybar/update

sketchybar: 2.14.1 -> 2.14.4 and fix build</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/280b1cdc1ea37bb477be1dada5d753f0246759a8...9a60b3eef1a0ccb4e3459eba1814bae91d07134e