### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681770396,
-        "narHash": "sha256-tq+GZOkRA3uF3I/jIzuBGfnTRQFT4QnnRCWJ8DKSaMg=",
+        "lastModified": 1681885569,
+        "narHash": "sha256-2nu5Eey6uipVAkOeHQ+qf41LCIZ5AZ87sdWzXesQMvw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4df48038a44e9f3a3da8e9b42ca182726b743de4",
+        "rev": "2fa5e844de089b7c2dd9257436147d17fd361e69",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4df48038a44e9f3a3da8e9b42ca182726b743de4",
+        "rev": "2fa5e844de089b7c2dd9257436147d17fd361e69",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=4df48038a44e9f3a3da8e9b42ca182726b743de4";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=2fa5e844de089b7c2dd9257436147d17fd361e69";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/26214bb8887b44132615a5c4b634125301f3935d"><pre>ocamlPackages.class_group_vdf: Bump MACOSX_DEPLOYMENT_TARGET to fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3365aa18ebd795656bab7d9c5700a5341b5a42d3"><pre>ocamlPackages.cohttp*: 5.0.0 -> 5.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/de9b7f2e5d236907afeff351c9e4e3d9b916bf76"><pre>ocamlPackages.dates_calc: init at 0.0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dfbcd782b3ad78ab1fd38b6a6194834014080834"><pre>ocamlPackages.ppx_monad: init at 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/50ce88d4ae0920ae4e0ac219774051c211a866a7"><pre>ocamlPackages.mdx: 2.2.1 → 2.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d64bfc5c44b046417103123fb1c9300b7ab4f6f0"><pre>Merge pull request #226668 from Niols/dates_calc

ocamlPackages.dates_calc: init at 0.0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4e62ec62910c22e68a5f5e86d088c7a15d31a5b4"><pre>Merge pull request #226670 from Niols/ppx_monad

ocamlPackages.ppx_monad: init at 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5bbb301be2b91eee486949389abe254bc6643bbb"><pre>ocamlPackages.bdd: init at unstable-2022-07-14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/336e0b71e819dfed6b3e7c3113b64287243b24b3"><pre>Merge pull request #226798 from vbgl/ocaml-mdx-2.3.0

ocamlPackages.mdx: 2.2.1 → 2.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/92b59980554d78efbd4d380786f6c2be75e2b429"><pre>Merge pull request #226800 from wegank/bdd-init

ocamlPackages.bdd: init at unstable-2022-07-14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/971abff5d5bed01e4e5f574282390c52f7b94aff"><pre>ocamlPackages.async_ssl: remove broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c987ccb045a5d9f6171e02e2e41182f09023612a"><pre>ocamlPackages.janeStreet: pin Dune to version 1 for OCaml < 4.08</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/114ea420db12a3a6fa19b6aadce52b25819c3481"><pre>ocamlPackages.slug: init at 1.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9b419c67cfeb210d333fc0c34ae6e8c7a987d443"><pre>ocaml-ng.ocamlPackages_4_02.bdd: fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f6528b39330032e7b390e60ed5adf0de5f5a6554"><pre>Merge pull request #226669 from Niols/slug

ocamlPackages.slug: init at 1.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9684ea491023a27797dfbb6fe4ce3f1167fb4c2d"><pre>ocamlPackages.arp: disable tests on Darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2f0a70084d3ded422d514e5dd8c9f13f9bd3a033"><pre>Merge pull request #226657 from Niols/cohttp-5.1.0

ocamlPackages.cohttp*: 5.0.0 -> 5.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ca07838f2e95a4a516801f9eb03e40cec90f0ab5"><pre>Merge pull request #226835 from vbgl/ocaml-janestreet-legacy-clean

ocamlPackages.janeStreet: small cleaning of legacy package sets</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7abd3e8f67e26b1aa859cf3a14d1065cae2f97fb"><pre>Merge pull request #225260 from Et7f3/fix_class_group_vdf

ocamlPackages.class_group_vdf: Bump MACOSX_DEPLOYMENT_TARGET to fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fa5e844de089b7c2dd9257436147d17fd361e69"><pre>Merge pull request #223749 from Alexis211/add-wgautomesh

wgautomesh: init at 0.1.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/4df48038a44e9f3a3da8e9b42ca182726b743de4...2fa5e844de089b7c2dd9257436147d17fd361e69