### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682932822,
-        "narHash": "sha256-Nsb4GEbza0v2DrUNMpJkpqz+iUbGqW/oMT13W0xHHq8=",
+        "lastModified": 1682960002,
+        "narHash": "sha256-5Zjh4pT3lAjFGN1gVrjqj1LLJHKCAlGdLD8raU7oEMc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8663481786dc8edb406b9a75191b53fbc770dc03",
+        "rev": "8670e496ffd093b60e74e7fa53526aa5920d09eb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8663481786dc8edb406b9a75191b53fbc770dc03",
+        "rev": "8670e496ffd093b60e74e7fa53526aa5920d09eb",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=8663481786dc8edb406b9a75191b53fbc770dc03";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=8670e496ffd093b60e74e7fa53526aa5920d09eb";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1561,7 +1561,6 @@ with oself;
     postPatch = ''
       substituteInPlace src/dune --replace " bigarray" ""
     '';
-    propagatedBuildInputs = [ libpq ];
   });
 
   pp = disableTests osuper.pp;


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/e689a64f24490753c79cf9e2139117607a21938d"><pre>ocamlPackages.postgresql: \`postgresql\` is a buildInput</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/68378870ab44d78e688232c6ecc78febd928cb1f"><pre>Merge pull request #229239 from anmonteiro/patch-6

ocamlPackages.postgresql: \`postgresql\` is a buildInput</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8670e496ffd093b60e74e7fa53526aa5920d09eb"><pre>Merge pull request #227714 from ony/feature/generateLuarocksConfig-toLua

lua.lib: use toLua in generateLuarocksConfig</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/8663481786dc8edb406b9a75191b53fbc770dc03...8670e496ffd093b60e74e7fa53526aa5920d09eb