### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -136,9 +136,6 @@ let
     "uring"
     "eio_linux"
     "magic-trace"
-
-    "hacl-star"
-    "hacl-star-raw"
   ];
 
   lowerThanOCaml5Ignores = [

--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683286087,
-        "narHash": "sha256-xseOd7W7xwF5GOF2RW8qhjmVGrKoBz+caBlreaNzoeI=",
+        "lastModified": 1683403239,
+        "narHash": "sha256-qWkXlRYy9+ZNi3CehxIRh+DcMaJZhpIm2Bilsd2WRos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e313808bd2e0a0669430787fb22e43b2f4bf8bf",
+        "rev": "e700696f494dad736aa768cd88528e8510d15c9b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e313808bd2e0a0669430787fb22e43b2f4bf8bf",
+        "rev": "e700696f494dad736aa768cd88528e8510d15c9b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=3e313808bd2e0a0669430787fb22e43b2f4bf8bf";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=e700696f494dad736aa768cd88528e8510d15c9b";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/pg_query/default.nix
+++ b/ocaml/pg_query/default.nix
@@ -18,7 +18,5 @@ buildDunePackage {
     AR := \$(AR) rs"
   '';
 
-  useDune2 = true;
-
   propagatedBuildInputs = [ ppx_inline_test ppx_deriving ctypes ctypes-foreign ];
 }

--- a/ocaml/ppx_jsx_embed/default.nix
+++ b/ocaml/ppx_jsx_embed/default.nix
@@ -10,6 +10,5 @@ buildDunePackage {
     hash = "sha256-7dPvSmpT+hU6+GlZoa/SpHVi7zRHwX/SZR7Jsk2aJ3A=";
   };
   doCheck = true;
-  useDune2 = true;
   propagatedBuildInputs = [ reason ppxlib ];
 }

--- a/ocaml/reason/default.nix
+++ b/ocaml/reason/default.nix
@@ -37,7 +37,6 @@ buildDunePackage rec {
 
   nativeBuildInputs = [ cppo menhir ];
 
-  useDune2 = true;
   patches = [
     ./patches/0001-rename-labels.patch
   ];

--- a/ocaml/subscriptions-transport-ws/default.nix
+++ b/ocaml/subscriptions-transport-ws/default.nix
@@ -3,7 +3,6 @@
 buildDunePackage {
   pname = "subscriptions-transport-ws";
   version = "0.0.1-dev";
-  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "anmonteiro";


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/093fcd1629c4c0c9bfc0d6c7a538a679e9d481ef"><pre>ocamlPackages.hacl-star-raw: use _mm_malloc on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/caf436a52b25164b71e0d48b671127ac2e2a5b75"><pre>ocamlPackages.buildDunePackage: deprecate useDune2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e700696f494dad736aa768cd88528e8510d15c9b"><pre>Merge #230386: Revert \"nixos/qemu-vm: fix diskless VMs\"</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e700696f494dad736aa768cd88528e8510d15c9b"><pre>Merge #230386: Revert \"nixos/qemu-vm: fix diskless VMs\"</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e700696f494dad736aa768cd88528e8510d15c9b"><pre>Merge #230386: Revert \"nixos/qemu-vm: fix diskless VMs\"</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e700696f494dad736aa768cd88528e8510d15c9b"><pre>Merge #230386: Revert \"nixos/qemu-vm: fix diskless VMs\"</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/3e313808bd2e0a0669430787fb22e43b2f4bf8bf...e700696f494dad736aa768cd88528e8510d15c9b