### PR TITLE
Reflect changes to `overlays` in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In your `flake.nix`:
       pkgs = import nixpkgs {
         inherit system;
         overlays = [
-          ocaml-overlay.overlays.${system}
+          ocaml-overlay.overlays.default
         ];
       };
     in


### PR DESCRIPTION
The README was a little outdated concerning the exact attribute in the provided overlays.  This should fix it.