### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684776312,
-        "narHash": "sha256-zEIfN9c8eVzVGQ/wtX8DSoPAkTvykfCn1TgR/o6FOuM=",
+        "lastModified": 1684919781,
+        "narHash": "sha256-YoPHy7ZDw5I154nFnRd20OfZA26NW53BO9S9jg4IRxs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "229321224ae97d6a723cc084674f57016c46dacd",
+        "rev": "56fb53c5a8406c176d470b2ffaef9920cad8305e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "229321224ae97d6a723cc084674f57016c46dacd",
+        "rev": "56fb53c5a8406c176d470b2ffaef9920cad8305e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=229321224ae97d6a723cc084674f57016c46dacd";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=56fb53c5a8406c176d470b2ffaef9920cad8305e";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/9d9fe9971d4a71712c1a154b1dc14ff315fb9bf2"><pre>ocamlPackages.polynomial: disable for OCaml < 4.08</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6c31436baae0df3ca41077a4a6cc2052173608e1"><pre>ocamlPackages.dot-merlin-reader: add missing input</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c26ad319b39232a0cd4a2680a7d7e62e43af1a80"><pre>ocamlPackages.lsp: add missing input</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/703640f648024a3f291525dfbd9fa4f208d0ee71"><pre>Merge pull request #233743 from vbgl/ocaml-cleaning-20230523

ocamlPackages: small fixes</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/56fb53c5a8406c176d470b2ffaef9920cad8305e"><pre>Merge pull request #233525 from r-ryantm/auto-update/commonsDaemon

commonsDaemon: 1.3.3 -> 1.3.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/56fb53c5a8406c176d470b2ffaef9920cad8305e"><pre>Merge pull request #233525 from r-ryantm/auto-update/commonsDaemon

commonsDaemon: 1.3.3 -> 1.3.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/56fb53c5a8406c176d470b2ffaef9920cad8305e"><pre>Merge pull request #233525 from r-ryantm/auto-update/commonsDaemon

commonsDaemon: 1.3.3 -> 1.3.4</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/229321224ae97d6a723cc084674f57016c46dacd...56fb53c5a8406c176d470b2ffaef9920cad8305e