### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684919781,
-        "narHash": "sha256-YoPHy7ZDw5I154nFnRd20OfZA26NW53BO9S9jg4IRxs=",
+        "lastModified": 1684974435,
+        "narHash": "sha256-Wfu69hMoJPM7DQHkApzmDdWh9o4PXXoh/xvLocUDh5s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56fb53c5a8406c176d470b2ffaef9920cad8305e",
+        "rev": "306cfb4b034436de11a28db49ea47a0d92a81498",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56fb53c5a8406c176d470b2ffaef9920cad8305e",
+        "rev": "306cfb4b034436de11a28db49ea47a0d92a81498",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=56fb53c5a8406c176d470b2ffaef9920cad8305e";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=306cfb4b034436de11a28db49ea47a0d92a81498";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/5b70dbe789b632ba14adfb42859c3c5c579b7340"><pre>ocamlPackages.csexp: 1.5.1 -> 1.5.2

https://github.com/ocaml-dune/csexp/releases/tag/1.5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b947c0575ab3c07b64ed052df5332d4ab3ac2741"><pre>ocamlPackages.csexp: remove result from dependencies

\`result\` was removed from dependencies in csexp 1.5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3a4ba9e8ea7eb26e68adae559aadb13f76d7ad77"><pre>ocamlPackages.csexp: add changelog to meta</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8d02422093330569723b92dbad086f803b2f081a"><pre>ocamlPackages.csexp: add liquidsoap as reverse dependency to passthru.tests</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7f26cae2b913bbb8b27d92bcd57ac8d37d891d8e"><pre>Merge pull request #223084 from marsam/update-csexp

ocamlPackages.csexp: 1.5.1 -> 1.5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/306cfb4b034436de11a28db49ea47a0d92a81498"><pre>Merge pull request #233888 from NixOS/revert-233885-pyatv-bump

Revert \"python311Packages.pyatv: 0.11.0 -> 0.12.0\"</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/56fb53c5a8406c176d470b2ffaef9920cad8305e...306cfb4b034436de11a28db49ea47a0d92a81498