### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685349480,
-        "narHash": "sha256-hBBxs/Bv3JwNIGWHryR0ab9uQ+V1Y359LtqRbDNrLCA=",
+        "lastModified": 1685379691,
+        "narHash": "sha256-wBtVZ5Ry7CBVfdXthwMfIYMPII0/MLs1OEf9cqAp8Pk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a4a8624d74c99b44c19427cf4fdfd6e5b319efd8",
+        "rev": "0ad8dd62975cb44ed2f5d8a122f756529798bec5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a4a8624d74c99b44c19427cf4fdfd6e5b319efd8",
+        "rev": "0ad8dd62975cb44ed2f5d8a122f756529798bec5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=a4a8624d74c99b44c19427cf4fdfd6e5b319efd8";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=0ad8dd62975cb44ed2f5d8a122f756529798bec5";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1348,10 +1348,6 @@ with oself;
   ocamlformat-rpc-lib = callPackage ./ocamlformat/rpc-lib.nix { };
 
   ocamlfuse = osuper.ocamlfuse.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/astrada/ocamlfuse/archive/v2.7.1_cvs8.tar.gz;
-      sha256 = "13sr6mwa6k17naikzg0lvsaj3d2yrj4pfay5qh5243wgs63l4x0q";
-    };
     meta = {
       platforms = lib.platforms.all;
     };
@@ -1551,13 +1547,6 @@ with oself;
     postPatch = ''
       substituteInPlace src/otfm.ml --replace "Pervasives." "Stdlib."
     '';
-  });
-
-  oseq = osuper.oseq.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/c-cube/oseq/releases/download/v0.5/oseq-0.5.tbz;
-      sha256 = "1si3ql8fdbxz2q3ycnajrdq2sd6k0clmxjx95cgpl3n58azif75f";
-    };
   });
 
   eigen = osuper.eigen.overrideAttrs (_: {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/1c4d9e9a752232eb35579ab9d213ab217897cb6f"><pre>ocamlPackages.ocamlfuse: 2.7.1_cvs7 -> 2.7.1_cvs8

Diff: https://github.com/astrada/ocamlfuse/compare/v2.7.1_cvs7...v2.7.1_cvs8

Changelog: https://github.com/astrada/ocamlfuse/releases/tag/v2.7.1_cvs8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b9a58b4ade8418d7d2675648c007981d4560edab"><pre>ocamlPackages.gapi-ocaml: 0.4.3 -> 0.4.4

Diff: https://github.com/astrada/gapi-ocaml/compare/v0.4.3...v0.4.4

Changelog: https://github.com/astrada/gapi-ocaml/releases/tag/v0.4.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/afd309e2a6c313902e98691eda6a0980e68cf105"><pre>ocamlPackages.oseq: 0.4 -> 0.5

Diff: https://github.com/c-cube/oseq/compare/v0.4...v0.5

Changelog: https://github.com/c-cube/oseq/releases/tag/v0.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/041094ad2ff90eab7d3d044c3eaad463666d2caa"><pre>ocamlPackages.ppx_yojson_conv_lib: 0.15.0 -> 0.16.0

Diff: https://github.com/janestreet/ppx_yojson_conv_lib/compare/v0.15.0...v0.16.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0ad8dd62975cb44ed2f5d8a122f756529798bec5"><pre>BeatSaberModManager: suffix PATH with xdg-utils rather than prefix

See https://github.com/NixOS/nixpkgs/pull/181171</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0ad8dd62975cb44ed2f5d8a122f756529798bec5"><pre>BeatSaberModManager: suffix PATH with xdg-utils rather than prefix

See https://github.com/NixOS/nixpkgs/pull/181171</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0ad8dd62975cb44ed2f5d8a122f756529798bec5"><pre>BeatSaberModManager: suffix PATH with xdg-utils rather than prefix

See https://github.com/NixOS/nixpkgs/pull/181171</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0ad8dd62975cb44ed2f5d8a122f756529798bec5"><pre>BeatSaberModManager: suffix PATH with xdg-utils rather than prefix

See https://github.com/NixOS/nixpkgs/pull/181171</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/a4a8624d74c99b44c19427cf4fdfd6e5b319efd8...0ad8dd62975cb44ed2f5d8a122f756529798bec5