### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686501370,
-        "narHash": "sha256-G0WuM9fqTPRc2URKP9Lgi5nhZMqsfHGrdEbrLvAPJcg=",
+        "lastModified": 1686587353,
+        "narHash": "sha256-LW8lIsKj+Y9jM25p15kdokqBHK+R7YpA/FmV2x379D8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "75a5ebf473cd60148ba9aec0d219f72e5cf52519",
+        "rev": "3463e24e1d1df4d9f47c6e74e62864f915010db2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "75a5ebf473cd60148ba9aec0d219f72e5cf52519",
+        "rev": "3463e24e1d1df4d9f47c6e74e62864f915010db2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=75a5ebf473cd60148ba9aec0d219f72e5cf52519";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=3463e24e1d1df4d9f47c6e74e62864f915010db2";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -810,12 +810,6 @@ with oself;
 
   flow_parser = callPackage ./flow_parser { };
 
-  functoria-runtime = osuper.functoria-runtime.overrideAttrs (_: {
-    postPatch = ''
-      substituteInPlace ./lib_runtime/functoria/dune --replace "bytes" ""
-    '';
-  });
-
   gen_js_api = disableTests osuper.gen_js_api;
 
   gettext-stub = disableTests osuper.gettext-stub;
@@ -923,12 +917,6 @@ with oself;
       sha256 = "11bk38m5wsh3g4pr1px3865w8p42n0cq401pnrgpgyl25zdfamk0";
     };
   };
-
-  qtest = osuper.qtest.overrideAttrs (_: {
-    postPatch = ''
-      substituteInPlace src/dune --replace "bytes" ""
-    '';
-  });
 
   index = osuper.index.overrideAttrs (_: {
     src = builtins.fetchurl {
@@ -1490,12 +1478,6 @@ with oself;
       rev = "499e8260df6487ebdacb9fcccb2f9dec36df8063";
       sha256 = "sha256-h1+D0HiCdEOBez+9EyqkF63TRW7pWkoUJYkugBTywI4=";
     };
-  });
-
-  omd = osuper.omd.overrideAttrs (o: {
-    postPatch = ''
-      substituteInPlace src/dune --replace "bytes" ""
-    '';
   });
 
   opam-core = osuper.opam-core.overrideAttrs (_: {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/09c1d496d9cbf3dfdc97aa8fcef395ebcbc3d1fa"><pre>ocamlPackages.qtest: fix for OCaml 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c98657f164494345d8466797528ad6f94b6a3bc9"><pre>ocamlPackages.omd: fix for OCaml 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4e3d46a3ea37d09c3d6dda557a0623c18ed58afe"><pre>ocamlPackages.functoria: 4.3.4 → 4.3.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8cb1f7a2df211360ff492b13ffdf896a8c25d00"><pre>ocamlPackages.minisat: 0.4 -> 0.5

Diff: https://github.com/c-cube/ocaml-minisat/compare/v0.4...v0.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3463e24e1d1df4d9f47c6e74e62864f915010db2"><pre>Merge pull request #223104 from xworld21/texlive-fixed-hashes-nix

texlive: generate \"fixed-hashes.nix\" from Nixpkgs attribute</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3463e24e1d1df4d9f47c6e74e62864f915010db2"><pre>Merge pull request #223104 from xworld21/texlive-fixed-hashes-nix

texlive: generate \"fixed-hashes.nix\" from Nixpkgs attribute</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3463e24e1d1df4d9f47c6e74e62864f915010db2"><pre>Merge pull request #223104 from xworld21/texlive-fixed-hashes-nix

texlive: generate \"fixed-hashes.nix\" from Nixpkgs attribute</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3463e24e1d1df4d9f47c6e74e62864f915010db2"><pre>Merge pull request #223104 from xworld21/texlive-fixed-hashes-nix

texlive: generate \"fixed-hashes.nix\" from Nixpkgs attribute</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/75a5ebf473cd60148ba9aec0d219f72e5cf52519...3463e24e1d1df4d9f47c6e74e62864f915010db2