### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687220634,
-        "narHash": "sha256-WUfpTwQ4UK1nQwv4+v+oFTRFGgX0kK2FSa/tm8EVhho=",
+        "lastModified": 1687277670,
+        "narHash": "sha256-pN5XLJGNz5b/kOjfk2At3aU2+QJa0a2o/cDM6GX686I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f7918807eee2f180741ce2da8e0406434ebbf70b",
+        "rev": "e4d9386f02195182adb9766ede4798e1c8ba8dd9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f7918807eee2f180741ce2da8e0406434ebbf70b",
+        "rev": "e4d9386f02195182adb9766ede4798e1c8ba8dd9",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=f7918807eee2f180741ce2da8e0406434ebbf70b";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=e4d9386f02195182adb9766ede4798e1c8ba8dd9";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -253,8 +253,6 @@ with oself;
     propagatedBuildInputs = [ ppxlib cmdliner ];
   });
 
-  bls12-381 = disableTests osuper.bls12-381;
-
   bos = osuper.bos.overrideAttrs (_: {
     src = fetchFromGitHub {
       owner = "dbuenzli";


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/14c735ccf7cbd829c48b77eb02f226fb3972b53d"><pre>ocamlPackages.camomile_0_8_2: drop</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9c9b348b75a8559245812446328f55bea4eb0b77"><pre>Merge pull request #238511 from wegank/camomile-drop-1

ocamlPackages.camomile_0_8_2: drop</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f737b4d32c82f13db2eac9093958cb4214660563"><pre>ocamlPackages.seqes: init at 0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cf4ce51861fe1e7bb74b74d6dfd45a57e6d63dcf"><pre>ocamlPackages.tezos-bls12-381-polynomial: drop at 1.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0a705f573b7e2fa7a7d6bb0761b249d7b7711e11"><pre>ocamlPackages.bls12-381: 5.0.0 -> 6.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2278b4b61b2d5e986294d3bd370f0fc57a83d583"><pre>ocamlPackages.bls12-381-hash: drop at 1.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e4d9386f02195182adb9766ede4798e1c8ba8dd9"><pre>Merge pull request #238737 from panchoh/bump-emacs-29.0.92

emacs29: 29.0.91 -> 29.0.92</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e4d9386f02195182adb9766ede4798e1c8ba8dd9"><pre>Merge pull request #238737 from panchoh/bump-emacs-29.0.92

emacs29: 29.0.91 -> 29.0.92</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e4d9386f02195182adb9766ede4798e1c8ba8dd9"><pre>Merge pull request #238737 from panchoh/bump-emacs-29.0.92

emacs29: 29.0.91 -> 29.0.92</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/f7918807eee2f180741ce2da8e0406434ebbf70b...e4d9386f02195182adb9766ede4798e1c8ba8dd9