### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687898314,
-        "narHash": "sha256-B4BHon3uMXQw8ZdbwxRK1BmxVOGBV4viipKpGaIlGwk=",
+        "lastModified": 1688034761,
+        "narHash": "sha256-5JvF67rWxHSoM8Wdkd33LSiHXBmXmiVFv53R7yRmfGw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e18dc963075ed115afb3e312b64643bf8fd4b474",
+        "rev": "d02209e8cfbdc925ec204a5c75d5551374516002",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e18dc963075ed115afb3e312b64643bf8fd4b474",
+        "rev": "d02209e8cfbdc925ec204a5c75d5551374516002",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e18dc963075ed115afb3e312b64643bf8fd4b474";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=d02209e8cfbdc925ec204a5c75d5551374516002";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -682,14 +682,7 @@ with oself;
   dune_2 = dune_3;
 
   dune_3 = osuper.dune_3.overrideAttrs (o: {
-    src = fetchFromGitHub {
-      owner = "ocaml";
-      repo = "dune";
-      rev = "df8db5c20edd492b1bb7a7fdfd55f610f73ab58a";
-      hash = "sha256-+nfbtdBJLtDwpR62mBYlTzKZbpowarrUCfzbV5oGltY=";
-    };
     nativeBuildInputs = o.nativeBuildInputs ++ [ makeWrapper ];
-
     postFixup =
       if stdenv.isDarwin then ''
         wrapProgram $out/bin/dune \
@@ -1457,7 +1450,11 @@ with oself;
   });
 
   ocurl = osuper.ocurl.overrideAttrs (_: {
+<<<<<<< HEAD
     propagatedBuildInputs = [ curl ];
+=======
+    propagatedBuildInputs = [ curl lwt ];
+>>>>>>> 3d33a3e (wip)
   });
 
   oidc = callPackage ./oidc { };

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1450,11 +1450,7 @@ with oself;
   });
 
   ocurl = osuper.ocurl.overrideAttrs (_: {
-<<<<<<< HEAD
     propagatedBuildInputs = [ curl ];
-=======
-    propagatedBuildInputs = [ curl lwt ];
->>>>>>> 3d33a3e (wip)
   });
 
   oidc = callPackage ./oidc { };

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1459,6 +1459,7 @@ with oself;
   ocurl = osuper.ocurl.overrideAttrs (_: {
     propagatedBuildInputs = [ curl ];
   });
+
   oidc = callPackage ./oidc { };
   oidc-client = callPackage ./oidc/client.nix { };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/26775c365901eb099baa798ea0a1e38b6d9d51c9"><pre>ocamlformat: 0.24.1 -> 0.25.1

The ocamlformat package have been split into two in version 0.25.1:
one for the library and one for the executable.

This adds both packages at the same time.
They have the same sources and very similar dependencies, for which the
definition is shared.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3833306fc4c166e54062c99796b6bc309a0defef"><pre>ocamlformat: add maintainer Julow</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5183c8d21d95fa6c9e9c7ba97bd68066e8585209"><pre>ocamlPackages.carton-lwt: disable tests</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e4ba29c31d6a15fc51e6d64a957edb00e9ca655d"><pre>ocamlPackages.awa: 0.2.0 → 0.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d2676c949823e3792e9390c06256cdbd8ebe2854"><pre>Merge pull request #239315 from vbgl/ocaml-awa-0.3.0

ocamlPackages.awa: 0.2.0 → 0.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8f342bfa950f610e7497800e707111d69646f801"><pre>ocamlPackages.menhirLib: 20220210 -> 20230608

Diff: https://gitlab.inria.fr/fpottier/menhir/-/compare/20220210...20230608</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db0b79082867de35bacceff8e8b129d0634c7048"><pre>Merge pull request #227229 from Julow/ocamlformat_0_25_1

Ocamlformat 0 25 1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d02209e8cfbdc925ec204a5c75d5551374516002"><pre>Merge pull request #238934 from raboof/codeql-fix-java-path

codeql: fix passing in nix JDK</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d02209e8cfbdc925ec204a5c75d5551374516002"><pre>Merge pull request #238934 from raboof/codeql-fix-java-path

codeql: fix passing in nix JDK</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d02209e8cfbdc925ec204a5c75d5551374516002"><pre>Merge pull request #238934 from raboof/codeql-fix-java-path

codeql: fix passing in nix JDK</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d02209e8cfbdc925ec204a5c75d5551374516002"><pre>Merge pull request #238934 from raboof/codeql-fix-java-path

codeql: fix passing in nix JDK</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d02209e8cfbdc925ec204a5c75d5551374516002"><pre>Merge pull request #238934 from raboof/codeql-fix-java-path

codeql: fix passing in nix JDK</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d02209e8cfbdc925ec204a5c75d5551374516002"><pre>Merge pull request #238934 from raboof/codeql-fix-java-path

codeql: fix passing in nix JDK</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d02209e8cfbdc925ec204a5c75d5551374516002"><pre>Merge pull request #238934 from raboof/codeql-fix-java-path

codeql: fix passing in nix JDK</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d02209e8cfbdc925ec204a5c75d5551374516002"><pre>Merge pull request #238934 from raboof/codeql-fix-java-path

codeql: fix passing in nix JDK</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d02209e8cfbdc925ec204a5c75d5551374516002"><pre>Merge pull request #238934 from raboof/codeql-fix-java-path

codeql: fix passing in nix JDK</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e18dc963075ed115afb3e312b64643bf8fd4b474...d02209e8cfbdc925ec204a5c75d5551374516002