### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687898314,
-        "narHash": "sha256-B4BHon3uMXQw8ZdbwxRK1BmxVOGBV4viipKpGaIlGwk=",
+        "lastModified": 1688180391,
+        "narHash": "sha256-oTUSZepWQ7AYQKvNPkf8QyxkfoVpEhGioVji0hd3p8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e18dc963075ed115afb3e312b64643bf8fd4b474",
+        "rev": "1353de5923daba8462cfc3624d8c2d70cbafafcd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e18dc963075ed115afb3e312b64643bf8fd4b474",
+        "rev": "1353de5923daba8462cfc3624d8c2d70cbafafcd",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e18dc963075ed115afb3e312b64643bf8fd4b474";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=1353de5923daba8462cfc3624d8c2d70cbafafcd";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/26775c365901eb099baa798ea0a1e38b6d9d51c9"><pre>ocamlformat: 0.24.1 -> 0.25.1

The ocamlformat package have been split into two in version 0.25.1:
one for the library and one for the executable.

This adds both packages at the same time.
They have the same sources and very similar dependencies, for which the
definition is shared.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3833306fc4c166e54062c99796b6bc309a0defef"><pre>ocamlformat: add maintainer Julow</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5183c8d21d95fa6c9e9c7ba97bd68066e8585209"><pre>ocamlPackages.carton-lwt: disable tests</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e4ba29c31d6a15fc51e6d64a957edb00e9ca655d"><pre>ocamlPackages.awa: 0.2.0 → 0.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d2676c949823e3792e9390c06256cdbd8ebe2854"><pre>Merge pull request #239315 from vbgl/ocaml-awa-0.3.0

ocamlPackages.awa: 0.2.0 → 0.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8f342bfa950f610e7497800e707111d69646f801"><pre>ocamlPackages.menhirLib: 20220210 -> 20230608

Diff: https://gitlab.inria.fr/fpottier/menhir/-/compare/20220210...20230608</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db0b79082867de35bacceff8e8b129d0634c7048"><pre>Merge pull request #227229 from Julow/ocamlformat_0_25_1

Ocamlformat 0 25 1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2f8b76be563dbce1e05efdc6b147649618e255e2"><pre>ocamlPackages.sedlex: 3.1 -> 3.2

https://github.com/ocaml-community/sedlex/releases/tag/v3.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1353de5923daba8462cfc3624d8c2d70cbafafcd"><pre>Merge pull request #240812 from r-ryantm/auto-update/vimix-icon-theme

vimix-icon-theme: 2023-01-18 -> 2023-06-26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1353de5923daba8462cfc3624d8c2d70cbafafcd"><pre>Merge pull request #240812 from r-ryantm/auto-update/vimix-icon-theme

vimix-icon-theme: 2023-01-18 -> 2023-06-26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1353de5923daba8462cfc3624d8c2d70cbafafcd"><pre>Merge pull request #240812 from r-ryantm/auto-update/vimix-icon-theme

vimix-icon-theme: 2023-01-18 -> 2023-06-26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1353de5923daba8462cfc3624d8c2d70cbafafcd"><pre>Merge pull request #240812 from r-ryantm/auto-update/vimix-icon-theme

vimix-icon-theme: 2023-01-18 -> 2023-06-26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1353de5923daba8462cfc3624d8c2d70cbafafcd"><pre>Merge pull request #240812 from r-ryantm/auto-update/vimix-icon-theme

vimix-icon-theme: 2023-01-18 -> 2023-06-26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1353de5923daba8462cfc3624d8c2d70cbafafcd"><pre>Merge pull request #240812 from r-ryantm/auto-update/vimix-icon-theme

vimix-icon-theme: 2023-01-18 -> 2023-06-26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1353de5923daba8462cfc3624d8c2d70cbafafcd"><pre>Merge pull request #240812 from r-ryantm/auto-update/vimix-icon-theme

vimix-icon-theme: 2023-01-18 -> 2023-06-26</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e18dc963075ed115afb3e312b64643bf8fd4b474...1353de5923daba8462cfc3624d8c2d70cbafafcd