### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689065019,
-        "narHash": "sha256-oCQM37FahwN5uEr5PQZZGDuGBe9TnIOIFcz4bGXvGdE=",
+        "lastModified": 1689150988,
+        "narHash": "sha256-Ue5BvtYYszqzX4ONWjgj6pnazCbOzdRBfLIx8l1Wa1w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f7eabf5564b06eafc39d4a5c9fa442c06b3bd55",
+        "rev": "bec27fabee7ff51a4788840479b1730ed1b64427",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f7eabf5564b06eafc39d4a5c9fa442c06b3bd55",
+        "rev": "bec27fabee7ff51a4788840479b1730ed1b64427",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=8f7eabf5564b06eafc39d4a5c9fa442c06b3bd55";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=bec27fabee7ff51a4788840479b1730ed1b64427";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/daf4863891eadae16e0774d92ad503c5db29ffc3"><pre>ocamlPackages.duppy: 0.9.2 -> 0.9.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cce4012caa7184a3de3154fc05fd565fb965805c"><pre>Merge pull request #242786 from r-ryantm/auto-update/ocamlPackages.duppy

ocamlPackages.duppy: 0.9.2 -> 0.9.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2a1faef7db78d25a8a2994f0f15b026b69bea681"><pre>ocamlPackages.cpdf: 2.5 → 2.5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/79390459000f25d71b89a4be307e1880f3f1832b"><pre>Merge pull request #242937 from vbgl/ocaml-cpdf-2.5.1

ocamlPackages.cpdf: 2.5 → 2.5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bec27fabee7ff51a4788840479b1730ed1b64427"><pre>treewide: use lib.optional instead of \'then []\'</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bec27fabee7ff51a4788840479b1730ed1b64427"><pre>treewide: use lib.optional instead of \'then []\'</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/8f7eabf5564b06eafc39d4a5c9fa442c06b3bd55...bec27fabee7ff51a4788840479b1730ed1b64427