### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689755274,
-        "narHash": "sha256-GdzWaZYlirBKut4T5qoCuQWvdIRW+E7P82QHmaKVj90=",
+        "lastModified": 1689846679,
+        "narHash": "sha256-89uOAMBZK4jooekzMZcm4sGxZp9kThMvJI6wVf00RfI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a029fb013ed62c143748a061bc1c1c25aee3e518",
+        "rev": "17dd4c92ee12de80a1fe86ea30be723e4e06cd00",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a029fb013ed62c143748a061bc1c1c25aee3e518",
+        "rev": "17dd4c92ee12de80a1fe86ea30be723e4e06cd00",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=a029fb013ed62c143748a061bc1c1c25aee3e518";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=17dd4c92ee12de80a1fe86ea30be723e4e06cd00";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1039,13 +1039,6 @@ with oself;
 
   jose = callPackage ./jose { };
 
-  js_of_ocaml-compiler = osuper.js_of_ocaml-compiler.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/ocsigen/js_of_ocaml/releases/download/5.4.0/js_of_ocaml-5.4.0.tbz;
-      sha256 = "151vilm2vlmxxq6syqkllmln8i70bqi8lyg22vdyyzw66ghms8gi";
-    };
-  });
-
   jsonrpc = osuper.jsonrpc.overrideAttrs (o: {
     src =
       builtins.fetchurl {
@@ -1411,17 +1404,6 @@ with oself;
 
   ocaml = (osuper.ocaml.override { flambdaSupport = true; }).overrideAttrs (_: {
     enableParallelBuilding = true;
-  });
-
-  ocamlformat-lib = osuper.ocamlformat-lib.overrideAttrs (_: {
-    version = "0.26.0";
-    src = builtins.fetchurl {
-      url = https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.0/ocamlformat-0.26.0.tbz;
-      sha256 = "0zc7bskmkj7y22qmgm0cdjmc6ihfcssvw75aysl11vqcfymr8503";
-    };
-  });
-  ocamlformat = osuper.ocamlformat.overrideAttrs (_: {
-    inherit (ocamlformat-lib) src version;
   });
 
   ocamlformat-rpc-lib = buildDunePackage {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/0580710f2379119b7a935e6319951d25439fddd7"><pre>ocamlPackages.iri: 0.6.0 → 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/984a19f393afe3bf52c9d06083d00a1253210b1e"><pre>ocamlformat: 0.25.1 -> 0.26.0

As always, the previous version is retained. The \"preferred\" version is
bumped.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d60110fd977181eb70c85534b88f757d4755a2f1"><pre>ocamlPackages.js_of_ocaml: 5.3.0 → 5.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bbcc727413715bf428d16bddb52bedd034295240"><pre>Merge pull request #244274 from vbgl/ocaml-iri-0.7.0

ocamlPackages.iri: 0.6.0 → 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/17dd4c92ee12de80a1fe86ea30be723e4e06cd00"><pre>Merge pull request #244421 from mig4ng/kubevpn

kubevpn: init at 1.1.34</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/17dd4c92ee12de80a1fe86ea30be723e4e06cd00"><pre>Merge pull request #244421 from mig4ng/kubevpn

kubevpn: init at 1.1.34</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/17dd4c92ee12de80a1fe86ea30be723e4e06cd00"><pre>Merge pull request #244421 from mig4ng/kubevpn

kubevpn: init at 1.1.34</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/17dd4c92ee12de80a1fe86ea30be723e4e06cd00"><pre>Merge pull request #244421 from mig4ng/kubevpn

kubevpn: init at 1.1.34</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/17dd4c92ee12de80a1fe86ea30be723e4e06cd00"><pre>Merge pull request #244421 from mig4ng/kubevpn

kubevpn: init at 1.1.34</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/a029fb013ed62c143748a061bc1c1c25aee3e518...17dd4c92ee12de80a1fe86ea30be723e4e06cd00