### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691732255,
-        "narHash": "sha256-r0Y7ZRst4XC25gMWSnAWd31LJ+etZOePgQlA8n9TU2g=",
+        "lastModified": 1691837214,
+        "narHash": "sha256-6ObplYKitkWM0dm1h6MQSU9W4luZBDapuGd8uErJF3Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32c89128899f61681ed6a59ba7954eda3e70e95b",
+        "rev": "98008a3c477a7ea470f89f0e3484b00211fffc30",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32c89128899f61681ed6a59ba7954eda3e70e95b",
+        "rev": "98008a3c477a7ea470f89f0e3484b00211fffc30",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=32c89128899f61681ed6a59ba7954eda3e70e95b";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=98008a3c477a7ea470f89f0e3484b00211fffc30";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/camlp5/default.nix
+++ b/ocaml/camlp5/default.nix
@@ -15,7 +15,7 @@
 stdenv.mkDerivation
 {
   pname = "camlp5";
-  version = "8.00.04";
+  version = "8.02.00";
   src = fetchFromGitHub {
     owner = "camlp5";
     repo = "camlp5";

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -402,29 +402,6 @@ with oself;
     buildPhase = "${topkg.buildPhase} --with-cmdliner true";
   });
 
-  cpdf = osuper.cpdf.overrideAttrs (o: {
-    src = fetchFromGitHub {
-      owner = "johnwhitington";
-      repo = "cpdf-source";
-      rev = "d98556e89b2eb1508fdd85b3814b0dd5cd7889fd";
-      hash = "sha256-nXF2wdevFoMOYxHHabC42zd1TIGBQJ/0nUt3jqcMA6M=";
-    };
-    postPatch = ''
-      substituteInPlace Makefile --replace \
-        "PACKS = camlpdf" "PACKS = camlpdf camlp-streams"
-    '';
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ camlp-streams ];
-  });
-
-  camlpdf = osuper.camlpdf.overrideAttrs (o: {
-    src = fetchFromGitHub {
-      owner = "johnwhitington";
-      repo = "camlpdf";
-      rev = "010792c1e22b0bb3030023011549995bd19d4e73";
-      hash = "sha256-eYLFqqeIUyiXNT50jQyFvhgG6a5wyZr2W0BuzpSWNjc=";
-    };
-  });
-
   carton = disableTests osuper.carton;
   carton-lwt = disableTests osuper.carton-lwt;
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/abf1192620abdd20f5226b3409cd4129c6545364"><pre>ocamlPackages.camlpdf: 2.5 → 2.6

ocamlPackages.cpdf: 2.5.1 → 2.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7e5ada58a9c737e6ef95e1cf5ac1aaf6e11a1dd8"><pre>ledit: use OCaml 4.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/032f6c6f936589f3020ffc303dea4c566bfd281f"><pre>ocamlPackages.camlp5: 7.14 → 8.00.05</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fb5e53615b4734ca6eaeeb54b84b8000cdae0389"><pre>hol_light: use default version of OCaml</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/98008a3c477a7ea470f89f0e3484b00211fffc30"><pre>Merge #248663: linux: disable KUNIT only at 5.5 and later</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/98008a3c477a7ea470f89f0e3484b00211fffc30"><pre>Merge #248663: linux: disable KUNIT only at 5.5 and later</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/98008a3c477a7ea470f89f0e3484b00211fffc30"><pre>Merge #248663: linux: disable KUNIT only at 5.5 and later</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/32c89128899f61681ed6a59ba7954eda3e70e95b...98008a3c477a7ea470f89f0e3484b00211fffc30