### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691732255,
-        "narHash": "sha256-r0Y7ZRst4XC25gMWSnAWd31LJ+etZOePgQlA8n9TU2g=",
+        "lastModified": 1692078446,
+        "narHash": "sha256-Wq7dbQ4a+nP/Cx1eAoPKpgsuV4/5jKkD7eDFHI477R0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32c89128899f61681ed6a59ba7954eda3e70e95b",
+        "rev": "b51db7ec1be773cc478a3f7060e04721f2a5c881",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32c89128899f61681ed6a59ba7954eda3e70e95b",
+        "rev": "b51db7ec1be773cc478a3f7060e04721f2a5c881",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=32c89128899f61681ed6a59ba7954eda3e70e95b";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=b51db7ec1be773cc478a3f7060e04721f2a5c881";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/0436d3fbc5d3888bd972a74c68dd19e71f7b8bb4"><pre>ocamlPackages.ssl: 0.5.13 -> 0.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/abf1192620abdd20f5226b3409cd4129c6545364"><pre>ocamlPackages.camlpdf: 2.5 → 2.6

ocamlPackages.cpdf: 2.5.1 → 2.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7e5ada58a9c737e6ef95e1cf5ac1aaf6e11a1dd8"><pre>ledit: use OCaml 4.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/032f6c6f936589f3020ffc303dea4c566bfd281f"><pre>ocamlPackages.camlp5: 7.14 → 8.00.05</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fb5e53615b4734ca6eaeeb54b84b8000cdae0389"><pre>hol_light: use default version of OCaml</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ffd4ef38261f35f3ca76ccfda1f3a5d5ae0be1b"><pre>ocamlPackages.odoc: 2.2.0 -> 2.2.1

Diff: https://github.com/ocaml/odoc/compare/2.2.0...2.2.1

Changelog: https://github.com/ocaml/odoc/blob/2.2.1/CHANGES.md</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/28ea69efc32a521b82e83947b555b489e4694f9a"><pre>ocamlPackages.ssl: 0.6.0 -> 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e01981cad3d2510b363221da5aea018d8aff7a80"><pre>Merge pull request #241404 from r-ryantm/auto-update/ocamlPackages.ssl

ocamlPackages.ssl: 0.5.13 -> 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6eb97ebbf9faf6faa52890b6dd11fee2ad3c032f"><pre>ocamlPackages.linol: 2023-04-25 -> 2023-08-04</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/737212ecc8254b746b29302cd377e72eb78db070"><pre>ocamlPackages.thread-table: 0.1.0 → 1.0.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/32c89128899f61681ed6a59ba7954eda3e70e95b...b51db7ec1be773cc478a3f7060e04721f2a5c881