### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692231980,
-        "narHash": "sha256-tvkB3PIrkRaaP0nVFsCKYrr2Ij3VLLHI7k5mjlDSnB4=",
+        "lastModified": 1692408586,
+        "narHash": "sha256-OeL3DabI+U3z/lEmKNnWsfawq3AxNYLeVSyhay9M0nQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5414083f0ba82e98e49976311e1fddf7d7a2074d",
+        "rev": "25cdc712eae9721530c38a8e81d44fd4346490dd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5414083f0ba82e98e49976311e1fddf7d7a2074d",
+        "rev": "25cdc712eae9721530c38a8e81d44fd4346490dd",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5414083f0ba82e98e49976311e1fddf7d7a2074d";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=25cdc712eae9721530c38a8e81d44fd4346490dd";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/73846153396e6019fafcff1a07380abe3998fed0"><pre>ocamlPackages.dscheck: 0.1.0 → 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8fc24972c51a2ab5fb55fcdebc6c5fa8d06c8888"><pre>ocamlPackages.domain-local-await: 0.2.1 → 1.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8d96cbfdcad1bd42c02611e93900cf5763cc6728"><pre>ocaml-protoc-plugin: init at 4.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/428862de06da5bb7a402b945560dd1d021f4291f"><pre>ocamlPackages.odoc-parser: disable old versions for OCaml ≥ 5.0

and clean a bit</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/778e5e88025101ab1f9835555d927de3960abe44"><pre>ocamlPackages.ocamlformat: disable old versions for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e81ef545b19868a10bca8a32c98e9728c2e8e2c"><pre>ocamlPackages.ppx_inline_test: 0.15.0 → 0.15.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/500544191075a4ecd5aba2fb5b9241b55d170d2e"><pre>Merge pull request #249795 from vbgl/ocaml-ppx_inline_test-0.15.1

ocamlPackages.ppx_inline_test: 0.15.0 → 0.15.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e4eab5e3be9cf557484d6872205d0a8225bbedb4"><pre>Merge pull request #249687 from vbgl/ocaml-dscheck-0.2.0

ocamlPackages.dscheck: 0.1.0 → 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c1322a76a2de0cfa5218c32bdc3d03690ec2834a"><pre>ocamlPackages.sel init at 0.4.0 (#247479)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/25cdc712eae9721530c38a8e81d44fd4346490dd"><pre>Merge pull request #250038 from ereslibre/bump-wasm-tools

wasm-tools: 1.0.38 -> 1.0.39</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/25cdc712eae9721530c38a8e81d44fd4346490dd"><pre>Merge pull request #250038 from ereslibre/bump-wasm-tools

wasm-tools: 1.0.38 -> 1.0.39</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/25cdc712eae9721530c38a8e81d44fd4346490dd"><pre>Merge pull request #250038 from ereslibre/bump-wasm-tools

wasm-tools: 1.0.38 -> 1.0.39</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/25cdc712eae9721530c38a8e81d44fd4346490dd"><pre>Merge pull request #250038 from ereslibre/bump-wasm-tools

wasm-tools: 1.0.38 -> 1.0.39</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/25cdc712eae9721530c38a8e81d44fd4346490dd"><pre>Merge pull request #250038 from ereslibre/bump-wasm-tools

wasm-tools: 1.0.38 -> 1.0.39</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/25cdc712eae9721530c38a8e81d44fd4346490dd"><pre>Merge pull request #250038 from ereslibre/bump-wasm-tools

wasm-tools: 1.0.38 -> 1.0.39</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/25cdc712eae9721530c38a8e81d44fd4346490dd"><pre>Merge pull request #250038 from ereslibre/bump-wasm-tools

wasm-tools: 1.0.38 -> 1.0.39</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5414083f0ba82e98e49976311e1fddf7d7a2074d...25cdc712eae9721530c38a8e81d44fd4346490dd