### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692231980,
-        "narHash": "sha256-tvkB3PIrkRaaP0nVFsCKYrr2Ij3VLLHI7k5mjlDSnB4=",
+        "lastModified": 1692708274,
+        "narHash": "sha256-qxSG0qncf8PouWtO97n5Gz61bxUr59S2kvzZ0LNh/H8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5414083f0ba82e98e49976311e1fddf7d7a2074d",
+        "rev": "e2a44ef6d9150975151fbf98dab728c8d726bee6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5414083f0ba82e98e49976311e1fddf7d7a2074d",
+        "rev": "e2a44ef6d9150975151fbf98dab728c8d726bee6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5414083f0ba82e98e49976311e1fddf7d7a2074d";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=e2a44ef6d9150975151fbf98dab728c8d726bee6";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -893,26 +893,7 @@ with oself;
     '';
   });
 
-  hack_parallel = (osuper.hack_parallel.override { sqlite = sqlite-oc; }).overrideAttrs (_: {
-    postPatch = ''
-      substituteInPlace \
-        src/utils/collections/myMap.ml \
-        src/third-party/hack_core/hack_result.ml \
-        src/third-party/hack_core/hack_result.mli \
-        src/third-party/hack_core/hack_core_list.ml \
-        src/utils/exit_status.ml \
-        src/utils/measure.ml \
-        src/utils/daemon.ml \
-        src/utils/daemon.mli \
-        src/utils/timeout.ml \
-        src/utils/hack_path.ml \
-        src/procs/worker.ml \
-        src/interface/hack_parallel_intf.mli \
-        --replace "Pervasives." "Stdlib."
-      substituteInPlace src/third-party/hack_core/hack_caml.ml --replace "include Pervasives" ""
-      substituteInPlace src/utils/sys_utils.ml --replace "String.create" "Bytes.create"
-    '';
-  });
+  hack_parallel = osuper.hack_parallel.override { sqlite = sqlite-oc; };
 
   h2 = callPackage ./h2 { };
   h2-lwt = callPackage ./h2/lwt.nix { };
@@ -2366,14 +2347,6 @@ with oself;
   unstrctrd = disableTests osuper.unstrctrd;
 
   uring = osuper.uring.overrideAttrs (_: {
-    src = fetchFromGitHub {
-      owner = "ocaml-multicore";
-      repo = "ocaml-uring";
-      rev = "566b225c1b028fa845d071b9950f03e96c34e82f";
-      hash = "sha256-3FAMsk26BrC1YVSFoq7B762ZJiDbpaMO9kAYxas6BLw=";
-    };
-
-    doCheck = ! (lib.versionOlder "5.1" ocaml.version);
     postPatch = ''
       patchShebangs vendor/liburing/configure
       substituteInPlace lib/uring/dune --replace \

--- a/ocaml/ocaml5.nix
+++ b/ocaml/ocaml5.nix
@@ -74,30 +74,6 @@ with oself;
 
   ppx_rapper_eio = callPackage ./ppx_rapper/eio.nix { };
 
-
-  qcheck-multicoretests-util = buildDunePackage {
-    pname = "qcheck-multicoretests-util";
-    version = "0.2";
-
-    src = fetchFromGitHub {
-      owner = "ocaml-multicore";
-      repo = "multicoretests";
-      rev = "0.2";
-      hash = "sha256-U1ZqfWMwpAvbPq5yp2U9YTFklT4MypzTSfNvcKJfaYE=";
-    };
-    propagatedBuildInputs = [ qcheck-core ];
-  };
-  qcheck-lin = buildDunePackage {
-    pname = "qcheck-lin";
-    inherit (qcheck-multicoretests-util) src version;
-    propagatedBuildInputs = [ qcheck-core qcheck-multicoretests-util ];
-  };
-  qcheck-stm = buildDunePackage {
-    pname = "qcheck-stm";
-    inherit (qcheck-multicoretests-util) src version;
-    propagatedBuildInputs = [ qcheck-core qcheck-multicoretests-util ];
-  };
-
   runtime_events_tools = buildDunePackage {
     pname = "runtime_events_tools";
     version = "0.4.0";


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/73846153396e6019fafcff1a07380abe3998fed0"><pre>ocamlPackages.dscheck: 0.1.0 → 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8fc24972c51a2ab5fb55fcdebc6c5fa8d06c8888"><pre>ocamlPackages.domain-local-await: 0.2.1 → 1.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8d96cbfdcad1bd42c02611e93900cf5763cc6728"><pre>ocaml-protoc-plugin: init at 4.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/428862de06da5bb7a402b945560dd1d021f4291f"><pre>ocamlPackages.odoc-parser: disable old versions for OCaml ≥ 5.0

and clean a bit</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/778e5e88025101ab1f9835555d927de3960abe44"><pre>ocamlPackages.ocamlformat: disable old versions for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e81ef545b19868a10bca8a32c98e9728c2e8e2c"><pre>ocamlPackages.ppx_inline_test: 0.15.0 → 0.15.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/500544191075a4ecd5aba2fb5b9241b55d170d2e"><pre>Merge pull request #249795 from vbgl/ocaml-ppx_inline_test-0.15.1

ocamlPackages.ppx_inline_test: 0.15.0 → 0.15.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e4eab5e3be9cf557484d6872205d0a8225bbedb4"><pre>Merge pull request #249687 from vbgl/ocaml-dscheck-0.2.0

ocamlPackages.dscheck: 0.1.0 → 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c48e3d8ccc70b2e28032933dcbb4d4804d13e971"><pre>ocamlPackages.ppx_bench: 0.15.0 → 0.15.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c1322a76a2de0cfa5218c32bdc3d03690ec2834a"><pre>ocamlPackages.sel init at 0.4.0 (#247479)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8ca5a5a7687c76d13ae3a4b2769778ed09acf574"><pre>ocamlPackages.uring: 0.6 → 0.7 (#250313)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aa47da4c2c37d2889c85885c401c805bf4fb9844"><pre>ocamlPackages.qcheck-multicoretests-util: init at 0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/991356c8074eedea2ee40879188b9a8a622b3b4b"><pre>ocamlPackages.qcheck-lin: init at 0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6698fd456eed52fdf91e5fd48b6d6cef478ff3ff"><pre>ocamlPackages.qcheck-stm: init at 0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d92c5c1d9d2090aaab025c1ffdef66cb8434461a"><pre>Merge pull request #250493 from vbgl/ocaml-qcheck-stm-0.2

ocamlPackages.qcheck-{lin,stm}: init at 0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/82c1cc46cdf16196472f7caca69989070894a7d6"><pre>Merge pull request #249948 from vbgl/ocaml-ppx_bench-0.15.1

ocamlPackages.ppx_bench: 0.15.0 → 0.15.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e55d51881ea16623b1efb799f5c002ee3c78e379"><pre>ocamlPackages.hack_parallel: fix for OCaml 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fd9ad30866da0fd7c8b015fbf264b17ff1b6fd9f"><pre>Merge pull request #250614 from vbgl/ocaml-hack_parallel-ocaml-5

ocamlPackages.hack_parallel: fix for OCaml 5.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5414083f0ba82e98e49976311e1fddf7d7a2074d...e2a44ef6d9150975151fbf98dab728c8d726bee6