### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692708274,
-        "narHash": "sha256-qxSG0qncf8PouWtO97n5Gz61bxUr59S2kvzZ0LNh/H8=",
+        "lastModified": 1693103197,
+        "narHash": "sha256-vJU5u52DOe3DhuXH0+ZezpE0cRFjnixrH5g9QGtO15E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2a44ef6d9150975151fbf98dab728c8d726bee6",
+        "rev": "fcfa6f73f8adccdcaa8ed1a908e834a3afa06505",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2a44ef6d9150975151fbf98dab728c8d726bee6",
+        "rev": "fcfa6f73f8adccdcaa8ed1a908e834a3afa06505",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e2a44ef6d9150975151fbf98dab728c8d726bee6";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=fcfa6f73f8adccdcaa8ed1a908e834a3afa06505";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/6b5f1432ad9171ae72f589155b7023e4b0ca52bb"><pre>ocamlPackages.ppx_cstruct: minor cleaning</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0f4fcbe60d9642d9c90ecc4bfa7fb6652235e7c9"><pre>ocamlPackages.ppxlib: do not (always) depend on OMP</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/df2dcf61225128b08140e75ead7a17f314941485"><pre>ocamlPackages.ppxlib: 0.28.0 → 0.30.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ae5f80614a12799c603465f9da5f45b2b9b357d2"><pre>Merge pull request #250678 from vbgl/ocaml-ppxlib-0.30.0

ocamlPackages.ppxlib: 0.28.0 → 0.30.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/62a2b30b0951e6739d661e8870aea553a82f904b"><pre>ocamlPackages.ppx_deriving: do not (always) depend on OMP</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9edb077ace8bf9c281a0dfc85351ed2d5c3d2a31"><pre>Merge pull request #250907 from vbgl/ocaml-ppx_deriving-noomp

ocamlPackages.ppx_deriving: do not (always) depend on OMP</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e2a44ef6d9150975151fbf98dab728c8d726bee6...fcfa6f73f8adccdcaa8ed1a908e834a3afa06505