### PR TITLE
ocaml/redis: make fetched sources match package version

### DIFF
--- a/ocaml/redis/default.nix
+++ b/ocaml/redis/default.nix
@@ -1,12 +1,12 @@
 { lib, fetchFromGitHub, buildDunePackage, uuidm, re, stdlib-shims }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "redis";
-  version = "0.4";
+  version = "0.6";
   src = fetchFromGitHub {
     owner = "0xffea";
     repo = "ocaml-redis";
-    rev = "v0.6";
+    rev = "v${version}";
     sha256 = "sha256-+q0fhWW/T/Q7Aof5cMDyVai/DyeMld/C9YEau6LN+J4=";
   };
 


### PR DESCRIPTION
Right now package claims to be version 0.4 but it's actually version 0.6