### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692708274,
-        "narHash": "sha256-qxSG0qncf8PouWtO97n5Gz61bxUr59S2kvzZ0LNh/H8=",
+        "lastModified": 1693282374,
+        "narHash": "sha256-QZUxjv/MsWjradxgHlQFkP1ynR4BAuedY/Hs+gMyss8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2a44ef6d9150975151fbf98dab728c8d726bee6",
+        "rev": "3d958404528cd939451ca2ed30473c3d7ae4d746",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2a44ef6d9150975151fbf98dab728c8d726bee6",
+        "rev": "3d958404528cd939451ca2ed30473c3d7ae4d746",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e2a44ef6d9150975151fbf98dab728c8d726bee6";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=3d958404528cd939451ca2ed30473c3d7ae4d746";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1905,25 +1905,14 @@ with oself;
     nativeBuildInputs = [ cppo ];
   };
 
-  ppxlib =
-    let
-      src =
-        builtins.fetchurl {
-          url = https://github.com/ocaml-ppx/ppxlib/releases/download/0.30.0/ppxlib-0.30.0.tbz;
-          sha256 = "04118jn57bdnh8chxjj1m5vz2cn96wwnbmq41s0lk6yjx6yn6jnx";
-
-        };
-    in
-    osuper.ppxlib.overrideAttrs (_: {
-      inherit src;
-
-      propagatedBuildInputs = [
-        ocaml-compiler-libs
-        ppx_derivers
-        sexplib0
-        stdlib-shims
-      ];
-    });
+  ppxlib = osuper.ppxlib.overrideAttrs (_: {
+    propagatedBuildInputs = [
+      ocaml-compiler-libs
+      ppx_derivers
+      sexplib0
+      stdlib-shims
+    ];
+  });
 
   re = osuper.re.overrideAttrs (_: {
     src = builtins.fetchurl {
@@ -2414,12 +2403,6 @@ with oself;
   });
 
   zed = osuper.zed.overrideAttrs (o: {
-    src = fetchFromGitHub {
-      owner = "ocaml-community";
-      repo = "zed";
-      rev = "3.2.3";
-      hash = "sha256-lbhqjZxeUqHdd+yahRO+B6L2mc+h+4T2+qKVgWC2HY8=";
-    };
     propagatedBuildInputs = [ react uchar uutf uucp uuseg ];
     postPatch = ''
       substituteInPlace src/dune --replace "result" ""


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/6b5f1432ad9171ae72f589155b7023e4b0ca52bb"><pre>ocamlPackages.ppx_cstruct: minor cleaning</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0f4fcbe60d9642d9c90ecc4bfa7fb6652235e7c9"><pre>ocamlPackages.ppxlib: do not (always) depend on OMP</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/df2dcf61225128b08140e75ead7a17f314941485"><pre>ocamlPackages.ppxlib: 0.28.0 → 0.30.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ae5f80614a12799c603465f9da5f45b2b9b357d2"><pre>Merge pull request #250678 from vbgl/ocaml-ppxlib-0.30.0

ocamlPackages.ppxlib: 0.28.0 → 0.30.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/62a2b30b0951e6739d661e8870aea553a82f904b"><pre>ocamlPackages.ppx_deriving: do not (always) depend on OMP</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9edb077ace8bf9c281a0dfc85351ed2d5c3d2a31"><pre>Merge pull request #250907 from vbgl/ocaml-ppx_deriving-noomp

ocamlPackages.ppx_deriving: do not (always) depend on OMP</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/839e22ee64c5becba02dce7359bb136a5fcbab99"><pre>ocamlPackages.ethernet: 3.0.0 → 3.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/702419396a9e3c96bbee40632664fc9e3216aa65"><pre>ocamlPackages.zed: 3.2.0 -> 3.2.3

Diff: https://github.com/ocaml-community/zed/compare/3.2.0...3.2.3

Changelog: https://github.com/ocaml-community/zed/blob/3.2.3/CHANGES.md</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3005e695d4eb4b072bfc4b631fe1277a7d71a997"><pre>ocamlPackages.bwd: 2.1.0 -> 2.2.0

Diff: https://github.com/RedPRL/ocaml-bwd/compare/2.1.0...2.2.0

Changelog: https://github.com/RedPRL/ocaml-bwd/blob/2.2.0/CHANGELOG.markdown</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/842f85514f2e289c1709f99880ad4ed939662208"><pre>Merge pull request #251022 from vbgl/ocaml-ethernet-3.2.0

ocamlPackages.ethernet: 3.0.0 → 3.2.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e2a44ef6d9150975151fbf98dab728c8d726bee6...3d958404528cd939451ca2ed30473c3d7ae4d746