### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694669921,
-        "narHash": "sha256-6ESpJ6FsftHV96JO/zn6je07tyV2dlLR7SdLsmkegTY=",
+        "lastModified": 1694783612,
+        "narHash": "sha256-9XhxTN/PcWap9EIKFXp7t9KpAj2o2sUwet8ly44tH0Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2ea252d23ebc9a5336bf6a61e0644921f64e67c",
+        "rev": "3b1f3712a415f6bf8352f3bb457973daa8bce91d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2ea252d23ebc9a5336bf6a61e0644921f64e67c",
+        "rev": "3b1f3712a415f6bf8352f3bb457973daa8bce91d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=f2ea252d23ebc9a5336bf6a61e0644921f64e67c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=3b1f3712a415f6bf8352f3bb457973daa8bce91d";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1801,26 +1801,6 @@ with oself;
     meta = owl-base.meta;
   });
 
-  ocaml-protoc = osuper.ocaml-protoc.overrideAttrs (_: {
-    postPatch = ''
-      substituteInPlace \
-        src/compilerlib/pb_codegen_util.ml \
-        src/compilerlib/pb_codegen_backend.ml \
-        src/compilerlib/pb_codegen_encode_binary.ml \
-        --replace "String.capitalize " "String.capitalize_ascii "
-
-      substituteInPlace \
-        src/compilerlib/pb_codegen_util.ml \
-        src/compilerlib/pb_codegen_backend.ml \
-        src/compilerlib/pb_codegen_encode_binary.ml \
-        --replace "String.lowercase" "String.lowercase_ascii "
-
-      substituteInPlace \
-        src/compilerlib/pb_codegen_util.ml \
-        --replace "Char.uppercase " "Char.uppercase_ascii "
-    '';
-  });
-
   ocaml_pcre = osuper.ocaml_pcre.override { pcre = pcre-oc; };
 
   # These require crowbar which is still not compatible with newer cmdliner.


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/3807ab24077dd827482cc76c2a0d598e12578119"><pre>ocamlPackages.ocaml-protoc: 2.0.2 → 2.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/67f7fb56e2f50a705a7456fb297dcf3ccce57169"><pre>Merge pull request #255066 from vbgl/ocaml-ocaml-protoc-2.4

ocamlPackages.ocaml-protoc: 2.0.2 → 2.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3b1f3712a415f6bf8352f3bb457973daa8bce91d"><pre>Merge pull request #255128 from PuercoPop/ruby-document-extraConfigPaths

ruby: document extraConfigPaths option from bundlerEnv</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3b1f3712a415f6bf8352f3bb457973daa8bce91d"><pre>Merge pull request #255128 from PuercoPop/ruby-document-extraConfigPaths

ruby: document extraConfigPaths option from bundlerEnv</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3b1f3712a415f6bf8352f3bb457973daa8bce91d"><pre>Merge pull request #255128 from PuercoPop/ruby-document-extraConfigPaths

ruby: document extraConfigPaths option from bundlerEnv</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/f2ea252d23ebc9a5336bf6a61e0644921f64e67c...3b1f3712a415f6bf8352f3bb457973daa8bce91d