### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -75,7 +75,6 @@ let
     "pythonlib"
     "graphql-async"
     "magic-trace"
-    "telegraml"
 
     # Old mirage-kv interface
     "mirage-fs"

--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695043561,
-        "narHash": "sha256-ajrDIUJA5RB6Y2I1G4suDhiDMJuwg1WarNuasshRobE=",
+        "lastModified": 1695197739,
+        "narHash": "sha256-TZ1LGUwpEcI7Jzd0VFhyT8J5TibXa5roHcp4/i5dMr0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "089313d7c7c864b21648d78fb8700062dafab1f2",
+        "rev": "b1adee2f9396e4101e70fe31d04010d3489d9be5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "089313d7c7c864b21648d78fb8700062dafab1f2",
+        "rev": "b1adee2f9396e4101e70fe31d04010d3489d9be5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=089313d7c7c864b21648d78fb8700062dafab1f2";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=b1adee2f9396e4101e70fe31d04010d3489d9be5";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -231,20 +231,6 @@ with oself;
     };
   };
 
-  batteries = buildDunePackage {
-    pname = "batteries";
-    version = "dev";
-    src =
-      fetchFromGitHub {
-        owner = "ocaml-batteries-team";
-        repo = "batteries-included";
-        rev = "v3.7.1";
-        hash = "sha256-0ZCaJA9xowO9QxCWcyJ1zhqG7+GNkMYJt62+VPOFj4Y=";
-      };
-
-    propagatedBuildInputs = [ num camlp-streams ];
-  };
-
   benchmark = osuper.buildDunePackage {
     pname = "benchmark";
     version = "1.6";
@@ -1514,13 +1500,6 @@ with oself;
   ocamlfuse = osuper.ocamlfuse.overrideAttrs (_: {
     meta = {
       platforms = lib.platforms.all;
-    };
-  });
-
-  ocamlgraph = osuper.ocamlgraph.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/backtracking/ocamlgraph/releases/download/2.1.0/ocamlgraph-2.1.0.tbz;
-      sha256 = "0r9d61yva190bdwyz79az6r2d95nfjq43bsm74wz4g95z4v2r5hg";
     };
   });
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/443321aed24916a572c67c7cb0d678c3aff9ec0d"><pre>ocamlPackages.telegraml: prepare for batteries 3.7.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fefd0ab1c1b0c8225e87085572f95804f58eb3ae"><pre>ocamlPackages.batteries: 3.6.0 → 3.7.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c7d62eecb9bfbc3954bbc11c628df83226cb9677"><pre>ocamlPackages.batteries: enable tests on AArch64</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3dd248db21547e8f1daa8cf4807e20d40b1f4358"><pre>ocamlPackages.ocamlgraph: 2.0.0 → 2.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5164552aa4b8d4125673dd1673250088a3f0f0f0"><pre>Merge pull request #255822 from vbgl/ocaml-batteries-3.7.1

ocamlPackages.batteries: 3.6.0 → 3.7.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/24d7dda90afcbdc2ae10ab840dfdcb49b5985532"><pre>ocamlPackages.dolmen_type: init at 0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/46b9ee34e4634ce8093fd3bfd1828140ed8c7bc0"><pre>ocamlPackages.dolmen_loop: init at 0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fe16955be79c29a643773fe115c09c88d2924cfe"><pre>ocamlPackages.dolmen: 0.6 → 0.9</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b1adee2f9396e4101e70fe31d04010d3489d9be5"><pre>Merge pull request #256183 from fabaff/garminconnect-bump

python311Packages.garminconnect: 0.2.4 -> 0.2.6, python311Packages.garth: 0.4.25 -> 0.4.26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b1adee2f9396e4101e70fe31d04010d3489d9be5"><pre>Merge pull request #256183 from fabaff/garminconnect-bump

python311Packages.garminconnect: 0.2.4 -> 0.2.6, python311Packages.garth: 0.4.25 -> 0.4.26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b1adee2f9396e4101e70fe31d04010d3489d9be5"><pre>Merge pull request #256183 from fabaff/garminconnect-bump

python311Packages.garminconnect: 0.2.4 -> 0.2.6, python311Packages.garth: 0.4.25 -> 0.4.26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b1adee2f9396e4101e70fe31d04010d3489d9be5"><pre>Merge pull request #256183 from fabaff/garminconnect-bump

python311Packages.garminconnect: 0.2.4 -> 0.2.6, python311Packages.garth: 0.4.25 -> 0.4.26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b1adee2f9396e4101e70fe31d04010d3489d9be5"><pre>Merge pull request #256183 from fabaff/garminconnect-bump

python311Packages.garminconnect: 0.2.4 -> 0.2.6, python311Packages.garth: 0.4.25 -> 0.4.26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b1adee2f9396e4101e70fe31d04010d3489d9be5"><pre>Merge pull request #256183 from fabaff/garminconnect-bump

python311Packages.garminconnect: 0.2.4 -> 0.2.6, python311Packages.garth: 0.4.25 -> 0.4.26</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b1adee2f9396e4101e70fe31d04010d3489d9be5"><pre>Merge pull request #256183 from fabaff/garminconnect-bump

python311Packages.garminconnect: 0.2.4 -> 0.2.6, python311Packages.garth: 0.4.25 -> 0.4.26</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/089313d7c7c864b21648d78fb8700062dafab1f2...b1adee2f9396e4101e70fe31d04010d3489d9be5