### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695597504,
-        "narHash": "sha256-CKhj6wOKqndfHsDg8CKVBbpJWG8zHRZRLi7MnOatf0U=",
+        "lastModified": 1695644571,
+        "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a862f0a660d5bd850457a0ad7772e1672109ccd",
+        "rev": "6500b4580c2a1f3d0f980d32d285739d8e156d92",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a862f0a660d5bd850457a0ad7772e1672109ccd",
+        "rev": "6500b4580c2a1f3d0f980d32d285739d8e156d92",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=7a862f0a660d5bd850457a0ad7772e1672109ccd";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=6500b4580c2a1f3d0f980d32d285739d8e156d92";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/48e2e83db5ae5bb915d5956ba198ea0fb02f3b61"><pre>ocamlPackages.ptime: fix evaluation

Evaluation must fail and not silently return the bogus null value.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/591ae3ccd609d742992a09c63d61579349ed7ca3"><pre>Merge pull request #257192 from vbgl/ocaml-ptime-fix

ocamlPackages.ptime: fix evaluation</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6500b4580c2a1f3d0f980d32d285739d8e156d92"><pre>Revert \"nixos/boot/rasbperrypi: add support for boot.initrd.secret with uboot (#240358)\" (#257251)

This reverts commit 94e939985b7730fd74b1c2e03292661734b490f0.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6500b4580c2a1f3d0f980d32d285739d8e156d92"><pre>Revert \"nixos/boot/rasbperrypi: add support for boot.initrd.secret with uboot (#240358)\" (#257251)

This reverts commit 94e939985b7730fd74b1c2e03292661734b490f0.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6500b4580c2a1f3d0f980d32d285739d8e156d92"><pre>Revert \"nixos/boot/rasbperrypi: add support for boot.initrd.secret with uboot (#240358)\" (#257251)

This reverts commit 94e939985b7730fd74b1c2e03292661734b490f0.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/7a862f0a660d5bd850457a0ad7772e1672109ccd...6500b4580c2a1f3d0f980d32d285739d8e156d92