### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695859332,
-        "narHash": "sha256-w2a7NW3VtI5FgFPUKslYRGAj5Qb7y4i0I2QO0S/lBMQ=",
+        "lastModified": 1695962284,
+        "narHash": "sha256-vygWW+zz/5NHWpH7nIfNFlKiJChp6kVRXkzAcPK08hY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "248a83fffc10b627da67fa6b25d2c13fc7542628",
+        "rev": "cdd726e1deb44c031ee8975528d6b283ed8cf021",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "248a83fffc10b627da67fa6b25d2c13fc7542628",
+        "rev": "cdd726e1deb44c031ee8975528d6b283ed8cf021",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=248a83fffc10b627da67fa6b25d2c13fc7542628";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=cdd726e1deb44c031ee8975528d6b283ed8cf021";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/86f5431801a68dfda1d8b7f4481a8c19b75498e3"><pre>ocamlPackages.apron: 0.9.13 → 0.9.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e7a162f48ae79bbfb5aa5a1165bd989bec55cc6d"><pre>ocamlPackages.apron: enable PPLite support</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/499149ef950c54c669e4a1d6cdf6f4cc121f543e"><pre>ocamlPackages.b0: Init at 0.0.5

The recent package is a dependency for odig.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/187d777aada735b5793f78b9b62726ce0752d739"><pre>ocamlPackages.buildTopkgPackage: Added

This function helps building an OCaml package that builds with topkg.
There are currently many such packages in nixpkgs and this function
would greatly simplify adding more.

This is heavily inspired by \`ocamlPackages.buildDunePackage\`.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b94953dbd41c3e6e371a9ba2fe97e7c7750b92a8"><pre>odig: Init at 0.0.9

Odig is a tool for building the documentation of OCaml libraries. It is
described with the recent \`buildTopkgPackage\` function.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3dfaa2a965f3ab82ab1f19c543c2917621c0014c"><pre>ocamlPackages.apron: don’t strip libraries on darwin

See https://github.com/antoinemine/apron/issues/93</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0f74397feed403903833e8ee6879e932fb646d23"><pre>Merge pull request #241493 from Julow/ocaml-odig-init

odig: Init at 0.0.9</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cdd726e1deb44c031ee8975528d6b283ed8cf021"><pre>Merge pull request #257939 from mweinelt/firefox-118.0.1

firefox: 118.0.1, 115.3.1esr, 119.0b2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cdd726e1deb44c031ee8975528d6b283ed8cf021"><pre>Merge pull request #257939 from mweinelt/firefox-118.0.1

firefox: 118.0.1, 115.3.1esr, 119.0b2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cdd726e1deb44c031ee8975528d6b283ed8cf021"><pre>Merge pull request #257939 from mweinelt/firefox-118.0.1

firefox: 118.0.1, 115.3.1esr, 119.0b2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cdd726e1deb44c031ee8975528d6b283ed8cf021"><pre>Merge pull request #257939 from mweinelt/firefox-118.0.1

firefox: 118.0.1, 115.3.1esr, 119.0b2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cdd726e1deb44c031ee8975528d6b283ed8cf021"><pre>Merge pull request #257939 from mweinelt/firefox-118.0.1

firefox: 118.0.1, 115.3.1esr, 119.0b2</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/248a83fffc10b627da67fa6b25d2c13fc7542628...cdd726e1deb44c031ee8975528d6b283ed8cf021