### PR TITLE
Update sources

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -563,10 +563,6 @@ with oself;
   session-cookie = callPackage ./cookie/session.nix { };
   session-cookie-lwt = callPackage ./cookie/session-lwt.nix { };
 
-  containers-data = osuper.containers-data.overrideAttrs (_: {
-    doCheck = false;
-  });
-
   # Not available for 4.12 and breaking the static build
   cooltt = null;
 
@@ -1054,9 +1050,21 @@ with oself;
     hardeningDisable = [ "strictoverflow" ];
   };
 
-  kafka_lwt = osuper.kafka_lwt.overrideAttrs (_: {
-    hardeningDisable = [ "strictoverflow" ];
-  });
+  kafka_lwt =
+    buildDunePackage rec {
+      pname = "kafka_lwt";
+      hardeningDisable = [ "strictoverflow" ];
+
+      inherit (kafka) version src;
+
+      buildInputs = [ cmdliner ];
+
+      propagatedBuildInputs = [ kafka lwt ];
+
+      meta = kafka.meta // {
+        description = "OCaml bindings for Kafka, Lwt bindings";
+      };
+    };
 
   # Added by the ocaml5.nix
   kcas = null;
@@ -1184,14 +1192,7 @@ with oself;
     propagatedBuildInputs = [ luv ];
   };
 
-  lwt = (osuper.lwt.override { libev = libev-oc; }).overrideAttrs (o: {
-    src = fetchFromGitHub {
-      owner = "ocsigen";
-      repo = "lwt";
-      rev = "5.7.0";
-      hash = "sha256-o0wPK6dPdnsr/LzwcSwbIGcL85wkDjdFuEcAxuS/UEs=";
-    };
-  });
+  lwt = (osuper.lwt.override { libev = libev-oc; });
 
   lwt-watcher = osuper.lwt-watcher.overrideAttrs (_: {
     src = builtins.fetchurl {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/ff910956e9ff28596537c604453c12c4bef5fd44"><pre>ocamlPackages.kafka_lwt: disable for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bbb8c88974f7d0eab87840826d75b4d8da3c3528"><pre>ocamlPackages.containers-data: disable tests with OCaml 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fa23afc15e0267cc2875c51a3de4c0408e7367fc"><pre>ocamlPackages.lwt: 5.6.1 → 5.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/558e80e961ee9e95c00c5a2b96890517c996cf91"><pre>Merge pull request #259327 from vbgl/ocaml-lwt-5.7.0

ocamlPackages.lwt: 5.6.1 → 5.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b7a3aaae3859cd1ffd4c4fd850bf45d0304f9033"><pre>Merge pull request #259460 from K900/test-eval-fixes

treewide: test eval fixes</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b7a3aaae3859cd1ffd4c4fd850bf45d0304f9033"><pre>Merge pull request #259460 from K900/test-eval-fixes

treewide: test eval fixes</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b7a3aaae3859cd1ffd4c4fd850bf45d0304f9033"><pre>Merge pull request #259460 from K900/test-eval-fixes

treewide: test eval fixes</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b7a3aaae3859cd1ffd4c4fd850bf45d0304f9033"><pre>Merge pull request #259460 from K900/test-eval-fixes

treewide: test eval fixes</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e462c9172c685f0839baaa54bb5b49276a23dab7...b7a3aaae3859cd1ffd4c4fd850bf45d0304f9033