### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696589439,
-        "narHash": "sha256-Ye+flokLfswVz9PZEyJ5yGJ1VqmJe3bDgwWt9Z4MuqQ=",
+        "lastModified": 1696696958,
+        "narHash": "sha256-ZBV9KMsJfEyE3IPULbdtwQqOH6C7uIlo7t61ux5il7g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e462c9172c685f0839baaa54bb5b49276a23dab7",
+        "rev": "a1b4cc2f6a6a40f4d16045c9e3ffc89bb25e672c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e462c9172c685f0839baaa54bb5b49276a23dab7",
+        "rev": "a1b4cc2f6a6a40f4d16045c9e3ffc89bb25e672c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e462c9172c685f0839baaa54bb5b49276a23dab7";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=a1b4cc2f6a6a40f4d16045c9e3ffc89bb25e672c";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/ff910956e9ff28596537c604453c12c4bef5fd44"><pre>ocamlPackages.kafka_lwt: disable for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bbb8c88974f7d0eab87840826d75b4d8da3c3528"><pre>ocamlPackages.containers-data: disable tests with OCaml 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fa23afc15e0267cc2875c51a3de4c0408e7367fc"><pre>ocamlPackages.lwt: 5.6.1 → 5.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/558e80e961ee9e95c00c5a2b96890517c996cf91"><pre>Merge pull request #259327 from vbgl/ocaml-lwt-5.7.0

ocamlPackages.lwt: 5.6.1 → 5.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a1b4cc2f6a6a40f4d16045c9e3ffc89bb25e672c"><pre>Merge pull request #259519 from r-ryantm/auto-update/rshim-user-space

rshim-user-space: 2.0.9 -> 2.0.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a1b4cc2f6a6a40f4d16045c9e3ffc89bb25e672c"><pre>Merge pull request #259519 from r-ryantm/auto-update/rshim-user-space

rshim-user-space: 2.0.9 -> 2.0.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a1b4cc2f6a6a40f4d16045c9e3ffc89bb25e672c"><pre>Merge pull request #259519 from r-ryantm/auto-update/rshim-user-space

rshim-user-space: 2.0.9 -> 2.0.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a1b4cc2f6a6a40f4d16045c9e3ffc89bb25e672c"><pre>Merge pull request #259519 from r-ryantm/auto-update/rshim-user-space

rshim-user-space: 2.0.9 -> 2.0.11</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e462c9172c685f0839baaa54bb5b49276a23dab7...a1b4cc2f6a6a40f4d16045c9e3ffc89bb25e672c