### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696826630,
-        "narHash": "sha256-oGU94vo6pkzGbaSsPHjpHtOUg6b7nL8v3xATnrcw3cQ=",
+        "lastModified": 1696962420,
+        "narHash": "sha256-F82r0XbLyfNRn2NJUz+hJRcoOpMBkfUQ+4KIlS5/zQA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a9c737c587d2c34d63c5b3cb53c6ab0705bdf4f",
+        "rev": "69926af81f20e4d4f71d16f18a1802776fc734e3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a9c737c587d2c34d63c5b3cb53c6ab0705bdf4f",
+        "rev": "69926af81f20e4d4f71d16f18a1802776fc734e3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5a9c737c587d2c34d63c5b3cb53c6ab0705bdf4f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=69926af81f20e4d4f71d16f18a1802776fc734e3";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/1d4048e952f533481de7e211a177ac2c6a56bda5"><pre>ocamlPackages.pprint: disable for OCaml < 4.03</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/642a5f2a7b09039183236a3d66d885b1178ad1c7"><pre>ocamlPackages.zelus-gtk: disable for OCaml < 4.10</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/458728abe00dfd4dcd1a6618721dda8b586624c6"><pre>Merge pull request #260165 from vbgl/ocaml-cleaning-2023-10-10

ocamlPackages.{pprint,zelus-gtk}: disable for early versions of OCaml</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/69926af81f20e4d4f71d16f18a1802776fc734e3"><pre>Merge pull request #260203 from wegank/cryptoverif-bump

cryptoverif: 2.05 -> 2.07</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/69926af81f20e4d4f71d16f18a1802776fc734e3"><pre>Merge pull request #260203 from wegank/cryptoverif-bump

cryptoverif: 2.05 -> 2.07</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5a9c737c587d2c34d63c5b3cb53c6ab0705bdf4f...69926af81f20e4d4f71d16f18a1802776fc734e3