### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697142613,
-        "narHash": "sha256-jplEwV6BqkvsqkhlWwHp/yrqTm0pKJ4l5VfEniTL6gs=",
+        "lastModified": 1697343899,
+        "narHash": "sha256-66Dosy7YYVhkesbHXB4xxZZ+2NOi9CmFDyHOI1ZTAbQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4183880e0e56f5a8dc55ef63df0cb64a7d5ea21f",
+        "rev": "982b24c40e743793c966b47b3bb3699881489ae0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4183880e0e56f5a8dc55ef63df0cb64a7d5ea21f",
+        "rev": "982b24c40e743793c966b47b3bb3699881489ae0",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=4183880e0e56f5a8dc55ef63df0cb64a7d5ea21f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=982b24c40e743793c966b47b3bb3699881489ae0";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1257,12 +1257,6 @@ with oself;
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ result ];
   });
 
-  mirage-crypto = osuper.mirage-crypto.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/mirage-crypto/releases/download/v0.11.2/mirage-crypto-0.11.2.tbz;
-      sha256 = "0r7pxlqz5x3cc8a1cwnh0phhlzqygh9h7k0k4mh4ld6wy2vprffn";
-    };
-  });
   mirage-crypto-pk = osuper.mirage-crypto-pk.override { gmp = gmp-oc; };
 
   # `mirage-fs` needs to be updated to match `mirage-kv`'s new interface
@@ -2040,13 +2034,6 @@ with oself;
   redis-sync = callPackage ./redis/sync.nix { };
 
   reenv = callPackage ./reenv { };
-
-  repr = osuper.repr.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/repr/releases/download/0.7.0/repr-0.7.0.tbz;
-      sha256 = "1b014p74l0mi3gk9klwv9mzip3p92rr0v0dnxqh0x2mzhpzcknla";
-    };
-  });
 
   resto-cohttp-server = osuper.resto-cohttp-server.overrideAttrs (_: {
     postPatch = ''


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/1a510fdf52b30be0d4521104fa227871917160f3"><pre>ocamlPackages.mirage-crypto: 0.11.1 -> 0.11.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d6eb597f322f82c84a8ccd8598a60a7322b4f1f"><pre>ocamlPackages.uring: 0.7 → 0.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9176d22aae9104532bdf729615090a2841e40cd7"><pre>ocamlPackages.repr: 0.6.0 → 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4b8b0d45a88b88888490747fad7b6a7591088230"><pre>Merge pull request #260826 from vbgl/ocaml-repr-0.7.0

ocamlPackages.repr: 0.6.0 → 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3b791240ce9e640472cf248b8ad286f9c9d39db"><pre>Merge pull request #260550 from r-ryantm/auto-update/ocamlPackages.mirage-crypto

ocamlPackages.mirage-crypto: 0.11.1 -> 0.11.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/982b24c40e743793c966b47b3bb3699881489ae0"><pre>Merge pull request #258114 from EsAu79p/init-aw-watcher-window-wayland</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/982b24c40e743793c966b47b3bb3699881489ae0"><pre>Merge pull request #258114 from EsAu79p/init-aw-watcher-window-wayland</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/982b24c40e743793c966b47b3bb3699881489ae0"><pre>Merge pull request #258114 from EsAu79p/init-aw-watcher-window-wayland</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/982b24c40e743793c966b47b3bb3699881489ae0"><pre>Merge pull request #258114 from EsAu79p/init-aw-watcher-window-wayland</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/4183880e0e56f5a8dc55ef63df0cb64a7d5ea21f...982b24c40e743793c966b47b3bb3699881489ae0