### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699263391,
-        "narHash": "sha256-gl4gNUR1GjIfI7aRYUr024nrK3Sxx3W3dRuS4LB56Zg=",
+        "lastModified": 1699354722,
+        "narHash": "sha256-abmqUReg4PsyQSwv4d0zjcWpMHrd3IFJiTb2tZpfF04=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cac8c76f21fccba39376504e18c23f7e18fd8419",
+        "rev": "cfbb29d76949ae53c457f152c52c173ea4bdd862",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cac8c76f21fccba39376504e18c23f7e18fd8419",
+        "rev": "cfbb29d76949ae53c457f152c52c173ea4bdd862",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=cac8c76f21fccba39376504e18c23f7e18fd8419";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=cfbb29d76949ae53c457f152c52c173ea4bdd862";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/573366e26755c0aaa711ed926c946a351b905a17"><pre>ocaml-top: remove unused dependencies</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2157c909d220c4a4314c3d4f872a405700a053b0"><pre>ocamlPackages.ocp-build: disable for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e1ccd228a129330ed3a4b7e2d2e3eb17247af7cc"><pre>ocamlPackages.ocamlify: disable for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/452cebfb5aac0ad67872106275eb977da214fa8a"><pre>ocamlPackages.pyml: 20220905 → 20231101

https://github.com/thierry-martinez/pyml/releases/tag/20231101
Diff: https://github.com/thierry-martinez/pyml/compare/20220905...20231101</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cfbb29d76949ae53c457f152c52c173ea4bdd862"><pre>skawarePackages.buildPackage: make sha256 optional

Fall back to fakeSha256 if unspecified, like many other fetcher
functions now do, to streamline packages / new updates.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cfbb29d76949ae53c457f152c52c173ea4bdd862"><pre>skawarePackages.buildPackage: make sha256 optional

Fall back to fakeSha256 if unspecified, like many other fetcher
functions now do, to streamline packages / new updates.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cfbb29d76949ae53c457f152c52c173ea4bdd862"><pre>skawarePackages.buildPackage: make sha256 optional

Fall back to fakeSha256 if unspecified, like many other fetcher
functions now do, to streamline packages / new updates.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cfbb29d76949ae53c457f152c52c173ea4bdd862"><pre>skawarePackages.buildPackage: make sha256 optional

Fall back to fakeSha256 if unspecified, like many other fetcher
functions now do, to streamline packages / new updates.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/cac8c76f21fccba39376504e18c23f7e18fd8419...cfbb29d76949ae53c457f152c52c173ea4bdd862