### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700130609,
-        "narHash": "sha256-pFtz286KaVHUmBOQztMNSgvT7hxcDe409vnDJxWQH7A=",
+        "lastModified": 1701653742,
+        "narHash": "sha256-9bLa7tsNtFSsXZDC+XVHyT6auJxUY+gObkvnEgSV7TM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54f00576aa6139a9d54062d0edc2fb31423f0ffb",
+        "rev": "d08f6384a5d8e5cf28ab243752cd83eed2a5d700",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54f00576aa6139a9d54062d0edc2fb31423f0ffb",
+        "rev": "d08f6384a5d8e5cf28ab243752cd83eed2a5d700",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,8 @@
               inherit system;
               overlays = [ overlay ];
               config.allowUnfree = true;
+            } // nixpkgs.lib.optionalAttrs (system == "x86_64-darwin" ) {
+              config.replaceStdenv = { pkgs, ... }: pkgs.clang11Stdenv;
             } // attrs);
           in
             /*

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=54f00576aa6139a9d54062d0edc2fb31423f0ffb";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=d08f6384a5d8e5cf28ab243752cd83eed2a5d700";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/6253b5cd4ec52be249c67348b62c853a432e317f"><pre>ocamlPackages.cry: 0.6.7 -> 1.0.1

Diff: https://github.com/savonet/ocaml-cry/compare/v0.6.7...v1.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e85593621fda56fd3650b6711de4c34957e952a5"><pre>ocamlPackages.flac: 0.3.1 -> 0.5.0

Diff: https://github.com/savonet/ocaml-flac/compare/v0.3.1...v0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/64391b832668beb3fe315fc0feac6a173fb579bc"><pre>ocamlPackages.ffmpeg: 1.1.7 -> 1.1.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6f23ac0c18b5597c095651cac07ad6da63343c30"><pre>ocamlPackages.metadata: init at 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e3de8469478237f377e9e06edbd9b34c59f2c900"><pre>ocamlPackages.yaml: 3.1.0 → 3.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5354f24b3cf5196fe5bfe767d520ffb5d3aa2027"><pre>ocamlPackages.mldoc: 1.5.6 -> 1.5.8

Diff: https://github.com/logseq/mldoc/compare/2a700b2e4797e47505f423fd47dc07372bd7b04e...v1.5.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c757e9bd77b16ca2e03c89bf8bc9ecb28e0c06ad"><pre>ocaml-ng.ocamlPackages_5_1.riot: init at 0.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/73e2e4c0f3847155683aa390b281f2cff3257587"><pre>coqPackages.dpdgraph: remove for Coq < 8.7

ocamlgraph is no longer available for older versions of Coq</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c60d7e0c77b281edd12ceab4f2f889ed67cfb836"><pre>ocamlPackages.camlp5: 8.00.05 → 8.02.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c6ae3f37a15eb4cf5de67294421e11bda283aaed"><pre>orpie: use default version of OCaml</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f3770720e15f06686fded2d737c833e695a838a8"><pre>ocamlPackages.zipc: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c06cd5bfe25c58cda4cc9601e54394c7ee83546a"><pre>ocamlPackages.syslog: 1.5 → 2.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2e5eaaa6f52e20b1ce4023f1a972be4111c33859"><pre>ocamlPackages.atd: 2.11.0 → 2.15.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/54f00576aa6139a9d54062d0edc2fb31423f0ffb...d08f6384a5d8e5cf28ab243752cd83eed2a5d700

#### Error

Error occurred, there could be relevant commits missing