### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700130609,
-        "narHash": "sha256-pFtz286KaVHUmBOQztMNSgvT7hxcDe409vnDJxWQH7A=",
+        "lastModified": 1703078263,
+        "narHash": "sha256-udAQ81WFQmxYNv+m2wPn8N8UY4vrzLFld7/Ujbz1/Ic=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54f00576aa6139a9d54062d0edc2fb31423f0ffb",
+        "rev": "42841c10e5967007541bbf23423b216882923940",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54f00576aa6139a9d54062d0edc2fb31423f0ffb",
+        "rev": "42841c10e5967007541bbf23423b216882923940",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=54f00576aa6139a9d54062d0edc2fb31423f0ffb";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=42841c10e5967007541bbf23423b216882923940";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/c60d7e0c77b281edd12ceab4f2f889ed67cfb836"><pre>ocamlPackages.camlp5: 8.00.05 → 8.02.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c6ae3f37a15eb4cf5de67294421e11bda283aaed"><pre>orpie: use default version of OCaml</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f3770720e15f06686fded2d737c833e695a838a8"><pre>ocamlPackages.zipc: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c06cd5bfe25c58cda4cc9601e54394c7ee83546a"><pre>ocamlPackages.syslog: 1.5 → 2.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2e5eaaa6f52e20b1ce4023f1a972be4111c33859"><pre>ocamlPackages.atd: 2.11.0 → 2.15.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/38232bc5288375fb46099cf0665bf8d736e948c4"><pre>ocamlPackages.inotify: 2.4.1 -> 2.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e3695de873a9dffea44632fe17cc4cc8fa1bb9ab"><pre>ocamlPackages.iter: 1.7 -> 1.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f5da19d226c9524dc15d8ca64dc6c2f9d59aea8c"><pre>ocamlPackages.caqti*: improve meta.license

See #269788.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c4ffc83975e38459202145f18528aa602744775f"><pre>ocamlPackages.bap: use LLVM 14

This fixes build after https://github.com/NixOS/nixpkgs/pull/241692</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6007641aff774f573a421d726a1cb2d38dd4903d"><pre>dune_3: 3.11.1 -> 3.12.0

Diff: https://github.com/ocaml/dune/compare/None...3.12.0

Changelog: https://github.com/ocaml/dune/raw/3.12.0/CHANGES.md</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2c01cd06afc2e327343b047e27e172ba488d98f8"><pre>dune_3: 3.12.0 -> 3.12.1

Diff: https://github.com/ocaml/dune/compare/3.12.0...3.12.1

Changelog: https://github.com/ocaml/dune/blob/3.12.1/CHANGES.md</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/147eabb0f47b6cf6be50ae5a1ffb021f33088526"><pre>ocamlPackages.readline: init at 0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bb9f1fc46e188a24e4f1abe342f214c37c9c7eb1"><pre>ocamlPackages.fiber: unstable-2023-02-28 -> 3.7.0

https://github.com/ocaml-dune/fiber/releases/tag/3.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d45c30f1c611395bd5a77c480ce015a0485b865b"><pre>ocamlPackages.tls: 0.17.1 → 0.17.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0ee8802f859ff6d0e690618d0b172b209a845a47"><pre>ocamlPackages.merlin: 4.12 → 4.13

The range of supported versions of OCaml for each versions of Merlin is
no longer monotonic and can\'t be expressed with \`lib.versionAtLeast\`
easily.
The latest version of Merlin is now explicitly mapped for each version
of OCaml.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7cb40bcdcc813097a36ad65781f8adfb68e9a5fe"><pre>ocamlPackages.merlin: Drop unused source hashes

The set of required source versions is now explicit, unused versions can
be removed without fears.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/54f00576aa6139a9d54062d0edc2fb31423f0ffb...42841c10e5967007541bbf23423b216882923940

#### Error

Error occurred, there could be relevant commits missing