### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704177376,
-        "narHash": "sha256-6AV8TWX/juwV8delRDtlbUzi1X8irrtCfrtcYByVhCs=",
+        "lastModified": 1704310041,
+        "narHash": "sha256-PlcdGPCLT0KjVPmmStN7v4Pj808uPMfl7PX4dXHi62g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2e36d8af3b7c465311f11913b7dedd209633c84",
+        "rev": "382614ec619514fbc48dd9c60f043c4087798ddf",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2e36d8af3b7c465311f11913b7dedd209633c84",
+        "rev": "382614ec619514fbc48dd9c60f043c4087798ddf",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e2e36d8af3b7c465311f11913b7dedd209633c84";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=382614ec619514fbc48dd9c60f043c4087798ddf";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1850,6 +1850,10 @@ with oself;
 
   ocaml_pcre = osuper.ocaml_pcre.override { pcre = pcre-oc; };
 
+  otfed = osuper.otfed.overrideAttrs (o: {
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [ stdio ];
+  });
+
   # These require crowbar which is still not compatible with newer cmdliner.
   pecu = disableTests osuper.pecu;
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a8cdcb9427def647e707056002cf0e06019239e9"><pre>ocamlPackages.js_of_ocaml: 5.4.0 -> 5.5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b722b9ddffa719177373d0f1f299c8528e5fed85"><pre>ocamlPackages.logs: Optional dependency on lwt and cmdliner

These are optional dependencies for the library. Making them optional is
useful to reduce the size of other packages.

By default, the dependencies are all provided and the output is
unchanged.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a03ab9b7a7860128678df59263c44f357c6815c"><pre>ocamlPackages.mdx: Reduce closure size

Disable the optional dependencies of the logs library: js_of_ocaml, lwt
Mdx is a binary tool so this is unlikely to cause a problem.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c58d90c2cf2132385bb124cc033207b2ff36bdae"><pre>ocamlPackages.otfed: init at 0.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/382614ec619514fbc48dd9c60f043c4087798ddf"><pre>Merge pull request #278161 from r-ryantm/auto-update/miriway

miriway: unstable-2023-11-22 -> unstable-2024-01-01</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/382614ec619514fbc48dd9c60f043c4087798ddf"><pre>Merge pull request #278161 from r-ryantm/auto-update/miriway

miriway: unstable-2023-11-22 -> unstable-2024-01-01</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/382614ec619514fbc48dd9c60f043c4087798ddf"><pre>Merge pull request #278161 from r-ryantm/auto-update/miriway

miriway: unstable-2023-11-22 -> unstable-2024-01-01</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/382614ec619514fbc48dd9c60f043c4087798ddf"><pre>Merge pull request #278161 from r-ryantm/auto-update/miriway

miriway: unstable-2023-11-22 -> unstable-2024-01-01</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e2e36d8af3b7c465311f11913b7dedd209633c84...382614ec619514fbc48dd9c60f043c4087798ddf