### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -4,7 +4,6 @@ let
     # not supported in 4.11+
     "bap"
     "lwt_camlp4"
-    "macaque"
     "config-file"
     "erm_xmpp"
     "ulex"

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -113,6 +113,8 @@ let
     "incr_dom_partial_render"
     "vg"
     "memtrace_viewer"
+
+    "binaryen"
   ];
 
   ocaml5Ignores = [
@@ -142,6 +144,8 @@ let
 
     # broken on macOS?
     "llvm"
+
+    "owl"
 
     "alsa"
     "mm"

--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704916437,
-        "narHash": "sha256-aE35YzfCrPPiBoCOKt0/GLd/Qar0Qq2VtUuC5XrY2Qk=",
+        "lastModified": 1705069489,
+        "narHash": "sha256-kXk4DUZS5uEdowgcv5PWVJ1s37xZKPvhpD/CFNdWMbs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5fcfdd4990ab907895fe9bcb1e2e4083d92ca670",
+        "rev": "391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5fcfdd4990ab907895fe9bcb1e2e4083d92ca670",
+        "rev": "391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5fcfdd4990ab907895fe9bcb1e2e4083d92ca670";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1340,16 +1340,6 @@ with oself;
     propagatedBuildInputs = [ ppxlib stdcompat findlib ];
   };
 
-  metrics = osuper.metrics.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/metrics/releases/download/v0.4.1/metrics-0.4.1.tbz;
-      sha256 = "0k8lqvrwfal5jwy45l0aq1hkrvjv0k30pv5hvc1n3l61nl7w5q3p";
-    };
-  });
-  metrics-unix = osuper.metrics-unix.overrideAttrs (_: {
-    postPatch = null;
-  });
-
   mew = osuper.mew.overrideAttrs (_: {
     propagatedBuildInputs = [ trie ];
     postPatch = ''
@@ -1850,15 +1840,6 @@ with oself;
   # These require crowbar which is still not compatible with newer cmdliner.
   pecu = disableTests osuper.pecu;
 
-  pgocaml = osuper.pgocaml.overrideAttrs (o: {
-    patches = [ ];
-    postPatch = ''
-      substituteInPlace src/dune --replace \
-        "(libraries calendar" \
-        "(libraries camlp-streams calendar"
-    '';
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ camlp-streams ];
-  });
   pg_query = callPackage ./pg_query { };
 
   binning = buildDunePackage {
@@ -2423,12 +2404,6 @@ with oself;
     src = builtins.fetchurl {
       url = https://erratique.ch/software/uucp/releases/uucp-15.1.0.tbz;
       sha256 = "11srn8zwba31zmj129v6l8sigdm9qrgcfd59vl1qmds70s44n7m9";
-    };
-  });
-  uunf = osuper.uunf.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://erratique.ch/software/uunf/releases/uunf-15.1.0.tbz;
-      sha256 = "1r296gz56prq7aa746gjzc6md6zz7m7yf6d368qscnamp1pszk0g";
     };
   });
   uuseg = osuper.uuseg.overrideAttrs (_: {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1828,6 +1828,7 @@ with oself;
   });
   owl = osuper.owl.overrideAttrs (o: {
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ eigen ];
+    doCheck = !stdenv.isLinux;
     meta = owl-base.meta;
   });
 

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -98,6 +98,12 @@ in
         src = "${nixpkgs}/pkgs/servers/sql/postgresql/locale-binary-path.patch";
         locale = "${if stdenv.isDarwin then super.darwin.adv_cmds else lib.getBin stdenv.cc.libc}/bin/locale";
       })
+      (super.fetchurl
+        # https://www.postgresql.org/message-id/CACpMh%2BDMZVHM%2BiDSyqdcpK8sr7jd_HxxLJRNvGTzcLBE0W07QA%40mail.gmail.com
+        {
+          url = "https://www.postgresql.org/message-id/attachment/152769/v1-0001-Make-PostgreSQL-work-with-newer-version-of-libxml.patch";
+          hash = "sha256-1j5mtG++hFmYwfS98PdN1SmNI4T86q4FXvKLz2VeJyg=";
+        })
     ] ++ lib.optionals stdenv.isLinux [
       "${nixpkgs}/pkgs/servers/sql/postgresql/patches/socketdir-in-run-13.patch"
     ];

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -127,6 +127,7 @@ in
 
   binaryen = super.binaryen.overrideAttrs (_: rec {
     version = "114";
+    patches = [ ];
 
     src = fetchFromGitHub {
       owner = "WebAssembly";
@@ -257,8 +258,8 @@ in
         src = fetchFromGitHub {
           owner = "anmonteiro";
           repo = "relay";
-          rev = "fa42044a06b50117d3d511c0ea7893d29058cdce";
-          hash = "sha256-DAGrgfl41w1v1llq82iyNcQSfuBCPhiTmn5WM9tqGkQ=";
+          rev = "a005a70d2542b043dcadd60895fcac0680e9ee7b";
+          hash = "sha256-q69n80QvF7m4dESzVj96JxU8RrZk/vYVina1+hX+2xk=";
           sparseCheckout = [ "compiler" ];
         };
         dontBuild = true;


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/da12d8043de14400f50c2ac0b278387044744227"><pre>ocamlPackages.macaque: remove at 0.7.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dec2122407ff585a2e2fb0847e5b436b50fe44d7"><pre>ocamlPackages.pgocaml: 4.3.0 → 4.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cec13baa2da61e8a217b5ac540d9196a7c28b018"><pre>ocamlPackages.uunf: 15.0.0 → 15.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8bf17d903dfc2386bfba8a2b86c23a350a8af473"><pre>ocamlPackages.trace: 0.3 → 0.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3aff652da4f5d93e66a1c32036b71876f0f03f61"><pre>mirage-crypto-rng: remove spurious mtime dependency

Also cleans up ocaml_lwt and duneVersion as per review.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/543e633c8fa043bb634d4b549b65300dfd772d38"><pre>ocamlPackages.metrics: 0.4.0 → 0.4.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c0096776f70735272eb31e25939cca7e00ffd743"><pre>Merge pull request #280200 from vbgl/ocaml-metrics-0.4.1

ocamlPackages.metrics: 0.4.0 → 0.4.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0389a68680a01ec9fb65d8db746748b68dd78b2b"><pre>Merge pull request #278855 from vbgl/ocaml-uunf-15.1.0

ocamlPackages.uunf: 15.0.0 → 15.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c34f9cf3abfb5183a43c2a0a86339af41cd2f391"><pre>Merge pull request #278772 from vbgl/ocaml-pgocaml-4.4.0

ocamlPackages.pgocaml: 4.3.0 → 4.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6cd98a7a7575e7ff7923b1c84259da0b43ba827e"><pre>Merge pull request #279671 from vbgl/ocaml-trace-0.5

ocamlPackages.trace: 0.3 → 0.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bbb0fe11fef1f1009eee7c99fbc92f674b4653b2"><pre>ocamlPackages.{async_ssl,ppx_accessor,streamable}: fix version</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5fcfdd4990ab907895fe9bcb1e2e4083d92ca670...391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d