### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704916437,
-        "narHash": "sha256-aE35YzfCrPPiBoCOKt0/GLd/Qar0Qq2VtUuC5XrY2Qk=",
+        "lastModified": 1705069489,
+        "narHash": "sha256-kXk4DUZS5uEdowgcv5PWVJ1s37xZKPvhpD/CFNdWMbs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5fcfdd4990ab907895fe9bcb1e2e4083d92ca670",
+        "rev": "391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5fcfdd4990ab907895fe9bcb1e2e4083d92ca670",
+        "rev": "391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5fcfdd4990ab907895fe9bcb1e2e4083d92ca670";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/da12d8043de14400f50c2ac0b278387044744227"><pre>ocamlPackages.macaque: remove at 0.7.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dec2122407ff585a2e2fb0847e5b436b50fe44d7"><pre>ocamlPackages.pgocaml: 4.3.0 → 4.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cec13baa2da61e8a217b5ac540d9196a7c28b018"><pre>ocamlPackages.uunf: 15.0.0 → 15.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8bf17d903dfc2386bfba8a2b86c23a350a8af473"><pre>ocamlPackages.trace: 0.3 → 0.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3aff652da4f5d93e66a1c32036b71876f0f03f61"><pre>mirage-crypto-rng: remove spurious mtime dependency

Also cleans up ocaml_lwt and duneVersion as per review.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/543e633c8fa043bb634d4b549b65300dfd772d38"><pre>ocamlPackages.metrics: 0.4.0 → 0.4.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c0096776f70735272eb31e25939cca7e00ffd743"><pre>Merge pull request #280200 from vbgl/ocaml-metrics-0.4.1

ocamlPackages.metrics: 0.4.0 → 0.4.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0389a68680a01ec9fb65d8db746748b68dd78b2b"><pre>Merge pull request #278855 from vbgl/ocaml-uunf-15.1.0

ocamlPackages.uunf: 15.0.0 → 15.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c34f9cf3abfb5183a43c2a0a86339af41cd2f391"><pre>Merge pull request #278772 from vbgl/ocaml-pgocaml-4.4.0

ocamlPackages.pgocaml: 4.3.0 → 4.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6cd98a7a7575e7ff7923b1c84259da0b43ba827e"><pre>Merge pull request #279671 from vbgl/ocaml-trace-0.5

ocamlPackages.trace: 0.3 → 0.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bbb0fe11fef1f1009eee7c99fbc92f674b4653b2"><pre>ocamlPackages.{async_ssl,ppx_accessor,streamable}: fix version</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5fcfdd4990ab907895fe9bcb1e2e4083d92ca670...391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d