### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705692095,
-        "narHash": "sha256-iJazHf0FQjuIplTEvDHMkByxQD1kyCp4Cm78krkf3N8=",
+        "lastModified": 1705936081,
+        "narHash": "sha256-koT6JZMFkA/EDZLSdkTa2LgEjM+JLKWWZyyARbh2yLE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b4ee3c3cc4b63315702e09858f6b517bdd249b3f",
+        "rev": "f048098f0b0945a9054e11ae5dba08b5688b0be1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b4ee3c3cc4b63315702e09858f6b517bdd249b3f",
+        "rev": "f048098f0b0945a9054e11ae5dba08b5688b0be1",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=b4ee3c3cc4b63315702e09858f6b517bdd249b3f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=f048098f0b0945a9054e11ae5dba08b5688b0be1";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -560,13 +560,6 @@ with oself;
       ];
     };
 
-  containers = osuper.containers.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/c-cube/ocaml-containers/releases/download/v3.13/containers-3.13.tbz;
-      sha256 = "1nmiaypm8xjk16m2mbz5s5a9gn7zn8p3k8r8kjanrs2159pghb9p";
-    };
-  });
-
   cookie = callPackage ./cookie { };
   session-cookie = callPackage ./cookie/session.nix { };
   session-cookie-lwt = callPackage ./cookie/session-lwt.nix { };


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/65d401f0b101a294dfd36ebcffa67375546ae586"><pre>ocamlPackages.containers: 3.12 -> 3.13.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7aecbfc5816872179930697130a8b683a97680ac"><pre>ocamlPackages.containers: set minimal ocaml version</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4873da366c63c39daaddf4e4313f30c793c0ff3e"><pre>framac: fix build with OCaml ≥ 5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2b2d034a08c086a56762c2b6c0f1220130d3e028"><pre>advi: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8a5dae5b07ceb1a26090317c8e8d30f72dd26c76"><pre>coccinelle: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8e5062ee6a6bc44778b5d8dd6647beec1f9ed22b"><pre>comby: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7ff05627922f6abd568f0bfa4df2f06567f3c171"><pre>coqPackages.compcert: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cf416a1feda70571b0bbb04bd5009cfed267c374"><pre>cubicle: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/92c8ee2bbbf83811afb0dbdaf80dc918008d17aa"><pre>flow: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c6dc2822d1ee7ded01bf26cf463b953276560f96"><pre>fstar: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8b796559f4b493cef56c02ec5c3abaf164c09e9f"><pre>guestfs-tools: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/527b3edd9dafb77120fd855a28a81064f50368d5"><pre>heptagon: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/27147978611cc70144076b2bb1724b9480c13d43"><pre>jackline: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2c91c5d218485d9bd02c30bde4a7944ad2ae7166"><pre>libbap: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9fc81aef622d9fc27038ec48c1d0719a5c2a9bdf"><pre>libguestfs: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/04466de6d45c83f5fdd08b21598dcc474542ef2a"><pre>liquidsoap: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/651da5ccee62b6b1f864aafbf3a2a6e2369edbeb"><pre>megam: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8aa86b260cbc11dc3c67a5573edcfa28f25e17ec"><pre>orpie: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1856a4f1c8717cdbca3f75c34f251b6082436ad2"><pre>python3Packages.bap: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/584621996e6fa5f2512ec29854fa2993cb017aa1"><pre>rml: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/297eb488f80cb0a16e5c10814868718098a446eb"><pre>satallax: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4a6871de1eb99b4d7e5e6a826b56425e80be6f15"><pre>satysfi: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/26b78cddf0fed026d0f2cce3b641fdcbc4f2173e"><pre>spark2014: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/71d6aaa13e15a56d64819657a2d2809ef8fb8228"><pre>supermin: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aa48b99b6c208d69e0d3dca00836d4ffbe86291e"><pre>teyjus: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dcfab24a6d87b1cc0ebebb5e2477a3d60e4312e0"><pre>virt-top: use OCaml 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cbd643e7f4d42ec3a7336d9dc7ced6279ac0f66b"><pre>ocaml: default to version 5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/823d7161d20c6cbae9ae67b77bc61196c635a3ff"><pre>Merge pull request #273279 from r-ryantm/auto-update/ocamlPackages.containers

ocamlPackages.containers: 3.12 -> 3.13.1</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/b4ee3c3cc4b63315702e09858f6b517bdd249b3f...f048098f0b0945a9054e11ae5dba08b5688b0be1