### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706275741,
-        "narHash": "sha256-53O2JHFdDTWHzTfLkZRAZVAk9ntChFhcTTnAtj6bJKE=",
+        "lastModified": 1706370590,
+        "narHash": "sha256-vq8hTMHsmPkBDaLR2i3m2nSmFObWmo7YwK51KQdI6RY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ac72b3ee2af9bab80d66addd9b237277cc975c5",
+        "rev": "3fb3707af869e32b0ad0676f589b16cc7711a376",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ac72b3ee2af9bab80d66addd9b237277cc975c5",
+        "rev": "3fb3707af869e32b0ad0676f589b16cc7711a376",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=7ac72b3ee2af9bab80d66addd9b237277cc975c5";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=3fb3707af869e32b0ad0676f589b16cc7711a376";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2328,13 +2328,6 @@ with oself;
     };
   });
 
-  type_eq = osuper.type_eq.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/skolemlabs/type_eq/releases/download/0.0.1/type_eq-0.0.1.tbz;
-      sha256 = "0zy7f7w56cy90hk2swbmlsh671l51w1lr2gzf98zyvc7vlbwgvz2";
-    };
-  });
-
   tyxml = osuper.tyxml.overrideAttrs (_: {
     src = builtins.fetchurl {
       url = https://github.com/ocsigen/tyxml/releases/download/4.6.0/tyxml-4.6.0.tbz;


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/8f34299f1b30e095daa7361e9472c518acd83235"><pre>ocamlPackages.type_eq: Fix build failure due to source tarball change

v0.0.1 of \`type_eq\` needed to be re-released, due to feedback from
\`opam-repository\`, which edited the \`type_eq.opam\` file. Due to this
change, the source tarball changed slightly, and its hash is now
different.

We need to update the hash in its \`nixpkgs\` definition.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3fb3707af869e32b0ad0676f589b16cc7711a376"><pre>Merge pull request #283898 from andersk/zulip

zulip: 5.10.4 → 5.10.5</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/7ac72b3ee2af9bab80d66addd9b237277cc975c5...3fb3707af869e32b0ad0676f589b16cc7711a376