### PR TITLE
overrideScope' -> overrideScope

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1953,7 +1953,7 @@ with oself;
 
   rtop = callPackage ./reason/rtop.nix { };
 
-  reason-native = osuper.reason-native.overrideScope' (rself: rsuper: {
+  reason-native = osuper.reason-native.overrideScope (rself: rsuper: {
     rely = rsuper.rely.overrideAttrs (_: {
       postPatch = ''
         substituteInPlace "src/rely/TestSuiteRunner.re" --replace "Pervasives." "Stdlib."

--- a/ocaml/esy/default.nix
+++ b/ocaml/esy/default.nix
@@ -33,7 +33,7 @@ let
 
   esyVersion = currentVersion;
 
-  esyOcamlPkgs = ocamlPackages.overrideScope' (self: super: rec {
+  esyOcamlPkgs = ocamlPackages.overrideScope (self: super: rec {
     alcotest = super.alcotest.overrideAttrs (_: {
       src = builtins.fetchurl {
         url = https://github.com/mirage/alcotest/releases/download/1.4.0/alcotest-mirage-1.4.0.tbz;

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -17,7 +17,7 @@ let
     "jst"
   ];
   newOCamlScope = { major_version, minor_version, patch_version, src, ... }@extraOpts:
-    ocaml-ng.ocamlPackages_4_13.overrideScope'
+    ocaml-ng.ocamlPackages_4_13.overrideScope
       (oself: osuper: {
         ocaml = (callPackage
           (import "${nixpkgs}/pkgs/development/compilers/ocaml/generic.nix" {
@@ -29,7 +29,7 @@ let
   custom-ocaml-ng =
     ocaml-ng //
     (if !(ocaml-ng ? "ocamlPackages_trunk") then {
-      ocamlPackages_4_14 = ocaml-ng.ocamlPackages_4_14.overrideScope' (oself: osuper: {
+      ocamlPackages_4_14 = ocaml-ng.ocamlPackages_4_14.overrideScope (oself: osuper: {
         ocaml = osuper.ocaml.overrideAttrs (_: {
           hardeningDisable = [ "strictoverflow" ];
         });
@@ -48,7 +48,7 @@ let
         };
       };
 
-      ocamlPackages_5_1 = ocaml-ng.ocamlPackages_5_1.overrideScope' (oself: osuper: {
+      ocamlPackages_5_1 = ocaml-ng.ocamlPackages_5_1.overrideScope (oself: osuper: {
         ocaml = osuper.ocaml.overrideAttrs (_: {
           src = super.fetchFromGitHub {
             owner = "ocaml";
@@ -59,7 +59,7 @@ let
         });
       });
 
-      ocamlPackages_jst = ocaml-ng.ocamlPackages_4_14.overrideScope' (oself: osuper: {
+      ocamlPackages_jst = ocaml-ng.ocamlPackages_4_14.overrideScope (oself: osuper: {
         ocaml = (callPackage
           (import "${nixpkgs}/pkgs/development/compilers/ocaml/generic.nix" {
             major_version = "4";
@@ -89,7 +89,7 @@ let
     } else { });
 
   overlaySinglePackageSet = pkgSet:
-    builtins.foldl' (acc: x: acc.overrideScope' x) pkgSet overlays;
+    builtins.foldl' (acc: x: acc.overrideScope x) pkgSet overlays;
 
   overlayOCamlPackages = version:
     lib.nameValuePair


### PR DESCRIPTION
looks like they've been the same since august 2023 and nixpkgs is now prompting users to use `overrideScope`