### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707217908,
-        "narHash": "sha256-5Dauh04xrEZqlokpYWftfVmDrljORnA48tGrRp+TURM=",
+        "lastModified": 1707303175,
+        "narHash": "sha256-qjgaicjmgzTBJd5QEpN7N0qVo5Z2IBF7jWw/nPb1OH8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3b0709da3eeed918323399c68b1fe4309b2ac483",
+        "rev": "5ef42fcd84b2baa16f43554f1c1f1d614e23ef9a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3b0709da3eeed918323399c68b1fe4309b2ac483",
+        "rev": "5ef42fcd84b2baa16f43554f1c1f1d614e23ef9a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=3b0709da3eeed918323399c68b1fe4309b2ac483";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=5ef42fcd84b2baa16f43554f1c1f1d614e23ef9a";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1081,6 +1081,16 @@ with oself;
   # Added by the ocaml5.nix
   kcas = null;
 
+  lablgtk3 = osuper.lablgtk3.overrideAttrs (_: {
+    # https://github.com/garrigue/lablgtk/pull/175
+    src = fetchFromGitHub {
+      owner = "garrigue";
+      repo = "lablgtk";
+      rev = "a9b64b9ed8a13855c672cde0a2d9f78687f4214b";
+      hash = "sha256-CRUIuZ4ILJ0GegrIVHkOg9migQz/OUEGWoN0V0Nb7vc=";
+    };
+  });
+
   lacaml = osuper.lacaml.overrideAttrs (_: {
     postPatch =
       if lib.versionAtLeast ocaml.version "5.0" then ''


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/5196cfabda9253c4f02948c4bbbff80911cf1af7"><pre>ocamlPackages.lablgtk3: 3.1.3 → 3.1.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/16e5d894040dd53752a86bb4431058c8de693600"><pre>ocamlPackages.lablgtk3-rsvg2: init at 3.1.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/36ee9fdad2ce8f10f0a013e17de0f6e05e364c6e"><pre>Merge pull request #285204 from vbgl/ocaml-lablgtk-3.1.4

ocamlPackages.lablgtk3: 3.1.3 → 3.1.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9d6ec0c45ae807995ea30293015c995764ad4b64"><pre>ocamlPackages.res: init at 5.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b141f3467b7c2a0aa04686bfd039031c01e7652c"><pre>ocamlPackages.capnp: init at 3.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ef42fcd84b2baa16f43554f1c1f1d614e23ef9a"><pre>Merge pull request #286832 from trofi/crda-removal-and-wireless-regdb-update

crda: remove package, wireless-regdb: 2023.09.01 -> 2024.01.23</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ef42fcd84b2baa16f43554f1c1f1d614e23ef9a"><pre>Merge pull request #286832 from trofi/crda-removal-and-wireless-regdb-update

crda: remove package, wireless-regdb: 2023.09.01 -> 2024.01.23</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ef42fcd84b2baa16f43554f1c1f1d614e23ef9a"><pre>Merge pull request #286832 from trofi/crda-removal-and-wireless-regdb-update

crda: remove package, wireless-regdb: 2023.09.01 -> 2024.01.23</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ef42fcd84b2baa16f43554f1c1f1d614e23ef9a"><pre>Merge pull request #286832 from trofi/crda-removal-and-wireless-regdb-update

crda: remove package, wireless-regdb: 2023.09.01 -> 2024.01.23</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ef42fcd84b2baa16f43554f1c1f1d614e23ef9a"><pre>Merge pull request #286832 from trofi/crda-removal-and-wireless-regdb-update

crda: remove package, wireless-regdb: 2023.09.01 -> 2024.01.23</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/3b0709da3eeed918323399c68b1fe4309b2ac483...5ef42fcd84b2baa16f43554f1c1f1d614e23ef9a