### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708494689,
-        "narHash": "sha256-7AVzwWeIC2rG6CdqRbbu3ON8EP5of6q5fGyg8MvbXmg=",
+        "lastModified": 1708535278,
+        "narHash": "sha256-WQHQ+311Mp8/L5+wB++6nnzeVscdF46hbAh/EwQdp/k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79597053bebcbccd1991157c3292c3705307220c",
+        "rev": "591f9cbebeef5dfdcb24997a3069d7f29c365ab9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79597053bebcbccd1991157c3292c3705307220c",
+        "rev": "591f9cbebeef5dfdcb24997a3069d7f29c365ab9",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=79597053bebcbccd1991157c3292c3705307220c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=591f9cbebeef5dfdcb24997a3069d7f29c365ab9";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/1e59729b4aadfb8f3d613170f0728b05cd463de1"><pre>ocamlPackages.oseq: 0.5 -> 0.5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0103c333d62fc60a912cf322e2f23f70b75708bd"><pre>ocamlPackages.logs: allow overriding logs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bde5f2f4f20d80b875709931896fa0a4084a7497"><pre>ocamlPackages.core: 0.16.1 → 0.16.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fcc8a48e119129c37af24036986957b47b743447"><pre>Merge pull request #290291 from anmonteiro/anmonteiro/fix-logs-override

ocamlPackages.logs: allow overriding logs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/643acb4173529a2d2e70a196c677a1afd1f2389f"><pre>Merge pull request #290365 from vbgl/ocaml-core-0.16.2

ocamlPackages.core: 0.16.1 → 0.16.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4c7ba0061aaec6c2c2f57f05bb566235f42719c3"><pre>Merge pull request #285952 from r-ryantm/auto-update/ocamlPackages.oseq

ocamlPackages.oseq: 0.5 -> 0.5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/591f9cbebeef5dfdcb24997a3069d7f29c365ab9"><pre>Merge pull request #290190 from cafkafk/fix-cargo-audit

cargo-audit: 0.18.3 -> 0.19.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/591f9cbebeef5dfdcb24997a3069d7f29c365ab9"><pre>Merge pull request #290190 from cafkafk/fix-cargo-audit

cargo-audit: 0.18.3 -> 0.19.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/591f9cbebeef5dfdcb24997a3069d7f29c365ab9"><pre>Merge pull request #290190 from cafkafk/fix-cargo-audit

cargo-audit: 0.18.3 -> 0.19.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/591f9cbebeef5dfdcb24997a3069d7f29c365ab9"><pre>Merge pull request #290190 from cafkafk/fix-cargo-audit

cargo-audit: 0.18.3 -> 0.19.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/79597053bebcbccd1991157c3292c3705307220c...591f9cbebeef5dfdcb24997a3069d7f29c365ab9