### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708494689,
-        "narHash": "sha256-7AVzwWeIC2rG6CdqRbbu3ON8EP5of6q5fGyg8MvbXmg=",
+        "lastModified": 1708673722,
+        "narHash": "sha256-FPbPhA727wuVkmR21Va6scRjAmj4pk3U8blteaXB/Hg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79597053bebcbccd1991157c3292c3705307220c",
+        "rev": "92cf4feb2b9091466a82b27e4bb045cbccc2ba09",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79597053bebcbccd1991157c3292c3705307220c",
+        "rev": "92cf4feb2b9091466a82b27e4bb045cbccc2ba09",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=79597053bebcbccd1991157c3292c3705307220c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=92cf4feb2b9091466a82b27e4bb045cbccc2ba09";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/1e59729b4aadfb8f3d613170f0728b05cd463de1"><pre>ocamlPackages.oseq: 0.5 -> 0.5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0103c333d62fc60a912cf322e2f23f70b75708bd"><pre>ocamlPackages.logs: allow overriding logs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bde5f2f4f20d80b875709931896fa0a4084a7497"><pre>ocamlPackages.core: 0.16.1 → 0.16.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fcc8a48e119129c37af24036986957b47b743447"><pre>Merge pull request #290291 from anmonteiro/anmonteiro/fix-logs-override

ocamlPackages.logs: allow overriding logs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/643acb4173529a2d2e70a196c677a1afd1f2389f"><pre>Merge pull request #290365 from vbgl/ocaml-core-0.16.2

ocamlPackages.core: 0.16.1 → 0.16.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4c7ba0061aaec6c2c2f57f05bb566235f42719c3"><pre>Merge pull request #285952 from r-ryantm/auto-update/ocamlPackages.oseq

ocamlPackages.oseq: 0.5 -> 0.5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/92cf4feb2b9091466a82b27e4bb045cbccc2ba09"><pre>Merge pull request #290626 from r-ryantm/auto-update/python311Packages.google-cloud-firestore

python311Packages.google-cloud-firestore: 2.14.0 -> 2.15.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/92cf4feb2b9091466a82b27e4bb045cbccc2ba09"><pre>Merge pull request #290626 from r-ryantm/auto-update/python311Packages.google-cloud-firestore

python311Packages.google-cloud-firestore: 2.14.0 -> 2.15.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/92cf4feb2b9091466a82b27e4bb045cbccc2ba09"><pre>Merge pull request #290626 from r-ryantm/auto-update/python311Packages.google-cloud-firestore

python311Packages.google-cloud-firestore: 2.14.0 -> 2.15.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/79597053bebcbccd1991157c3292c3705307220c...92cf4feb2b9091466a82b27e4bb045cbccc2ba09