### PR TITLE
Add sherlodoc

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2150,6 +2150,8 @@ with oself;
   session = callPackage ./session { };
   session-redis-lwt = callPackage ./session/redis.nix { };
 
+  sherlodoc = callPackage ./sherlodoc {};
+
   sodium = buildDunePackage {
     pname = "sodium";
     version = "0.8+ahrefs";

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2150,7 +2150,7 @@ with oself;
   session = callPackage ./session { };
   session-redis-lwt = callPackage ./session/redis.nix { };
 
-  sherlodoc = callPackage ./sherlodoc {};
+  sherlodoc = callPackage ./sherlodoc { };
 
   sodium = buildDunePackage {
     pname = "sodium";

--- a/ocaml/sherlodoc/default.nix
+++ b/ocaml/sherlodoc/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  js_of_ocaml-compiler,
+  result,
+  tyxml,
+  ppx_blob,
+  lwt,
+  fpath,
+  decompress,
+  cmdliner,
+  brr,
+  bigstringaf,
+  base64,
+  odoc,
+  odoc-parser,
+  menhir,
+  fmt,
+  dream,
+  enableServe ? false,
+}:
+buildDunePackage {
+  pname = "sherlodoc";
+  version = "0.2";
+  src = fetchFromGitHub {
+    owner = "art-w";
+    repo = "sherlodoc";
+    rev = "0.2";
+    sha256 = "sha256-MEYKtlVoSYZhh4ernon1FHGFykfeCmv6qQi+cyy3LX8=";
+  };
+  nativeBuildInputs = [menhir js_of_ocaml-compiler];
+  propagatedBuildInputs =
+    [
+      result
+      tyxml
+      ppx_blob
+      lwt
+      fpath
+      decompress
+      cmdliner
+      brr
+      bigstringaf
+      base64
+      odoc
+      odoc-parser
+      fmt
+    ]
+    ++ lib.optional enableServe dream;
+}

--- a/ocaml/sherlodoc/default.nix
+++ b/ocaml/sherlodoc/default.nix
@@ -1,25 +1,26 @@
-{
-  lib,
-  fetchFromGitHub,
-  buildDunePackage,
-  js_of_ocaml-compiler,
-  result,
-  tyxml,
-  ppx_blob,
-  lwt,
-  fpath,
-  decompress,
-  cmdliner,
-  brr,
-  bigstringaf,
-  base64,
-  odoc,
-  odoc-parser,
-  menhir,
-  fmt,
-  dream,
-  enableServe ? false,
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, js_of_ocaml-compiler
+, result
+, tyxml
+, ppx_blob
+, lwt
+, fpath
+, decompress
+, cmdliner
+, brr
+, bigstringaf
+, base64
+, odoc
+, odoc-parser
+, menhir
+, fmt
+, dream
+, enableServe ? false
+,
 }:
+
 buildDunePackage {
   pname = "sherlodoc";
   version = "0.2";
@@ -29,22 +30,20 @@ buildDunePackage {
     rev = "0.2";
     sha256 = "sha256-MEYKtlVoSYZhh4ernon1FHGFykfeCmv6qQi+cyy3LX8=";
   };
-  nativeBuildInputs = [menhir js_of_ocaml-compiler];
-  propagatedBuildInputs =
-    [
-      result
-      tyxml
-      ppx_blob
-      lwt
-      fpath
-      decompress
-      cmdliner
-      brr
-      bigstringaf
-      base64
-      odoc
-      odoc-parser
-      fmt
-    ]
-    ++ lib.optional enableServe dream;
+  nativeBuildInputs = [ menhir js_of_ocaml-compiler ];
+  propagatedBuildInputs = [
+    result
+    tyxml
+    ppx_blob
+    lwt
+    fpath
+    decompress
+    cmdliner
+    brr
+    bigstringaf
+    base64
+    odoc
+    odoc-parser
+    fmt
+  ] ++ lib.optional enableServe dream;
 }


### PR DESCRIPTION
I want to add sherlodoc to the development shells of my projects, so I am trying to add the package to this overlay.

In this PR, I have added two variants of the package: `sherlodoc`, which can be used to rebuild an index, and `sherlodoc-server`, which also supports `sherlodoc serve` command but has an extra dependency on `dream`.

Executables from `menhir` and `js_of_ocaml-compiler` packages are required to build the package, but I don't know if `preBuild` is a proper workaround here.