### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708494689,
-        "narHash": "sha256-7AVzwWeIC2rG6CdqRbbu3ON8EP5of6q5fGyg8MvbXmg=",
+        "lastModified": 1708807027,
+        "narHash": "sha256-NhM8lJRS0jr1uMXQGeUUC+7zd2PSz6TdDMxZWUz98nI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79597053bebcbccd1991157c3292c3705307220c",
+        "rev": "6d8aba54f305eb12a57d92ad4eaeb42049961f19",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79597053bebcbccd1991157c3292c3705307220c",
+        "rev": "6d8aba54f305eb12a57d92ad4eaeb42049961f19",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=79597053bebcbccd1991157c3292c3705307220c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=6d8aba54f305eb12a57d92ad4eaeb42049961f19";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/1e59729b4aadfb8f3d613170f0728b05cd463de1"><pre>ocamlPackages.oseq: 0.5 -> 0.5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0103c333d62fc60a912cf322e2f23f70b75708bd"><pre>ocamlPackages.logs: allow overriding logs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bde5f2f4f20d80b875709931896fa0a4084a7497"><pre>ocamlPackages.core: 0.16.1 → 0.16.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fcc8a48e119129c37af24036986957b47b743447"><pre>Merge pull request #290291 from anmonteiro/anmonteiro/fix-logs-override

ocamlPackages.logs: allow overriding logs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/643acb4173529a2d2e70a196c677a1afd1f2389f"><pre>Merge pull request #290365 from vbgl/ocaml-core-0.16.2

ocamlPackages.core: 0.16.1 → 0.16.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4c7ba0061aaec6c2c2f57f05bb566235f42719c3"><pre>Merge pull request #285952 from r-ryantm/auto-update/ocamlPackages.oseq

ocamlPackages.oseq: 0.5 -> 0.5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/18adbe41dccd210a8de3db5591ce326323788f69"><pre>ocamlPackages.eio: 0.14 → 0.15</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fb561a248dae2d2a668adfb6d217f5e729ab74d4"><pre>ocamlPackages.merlin: 4.13 → 4.14

This phases out versions 4.12, 4.13 and 4.13.1. Version 4.14 supporting
a wider range of OCaml versions.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/95a9c943b7b8c86d8798d7ceaedb85b2fd5c3492"><pre>ocamlPackages.type_id: Init at 0.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/efc0a80b20a495b8f1d2c79bb5802085118b072f"><pre>ocamlPackages.macaddr: 5.4.0 -> 5.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2bc7231a6dd52bb478cabf2975527ea133efc033"><pre>ocamlPackages.cohttp: 5.3.0 -> 5.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5a05ec0781998860900c7005bce1aec9635ce55f"><pre>Merge pull request #291143 from r-ryantm/auto-update/ocamlPackages.cohttp

ocamlPackages.cohttp: 5.3.0 -> 5.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/699c94699c51a5b934bc1c3b0d2ea93b9b8dd1a6"><pre>Merge pull request #291138 from r-ryantm/auto-update/ocamlPackages.macaddr

ocamlPackages.macaddr: 5.4.0 -> 5.5.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/79597053bebcbccd1991157c3292c3705307220c...6d8aba54f305eb12a57d92ad4eaeb42049961f19