### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710078301,
-        "narHash": "sha256-BQ3v+XPPz5dLiw2AqUEga++yfKRhqJANUqzqNL518pk=",
+        "lastModified": 1710171478,
+        "narHash": "sha256-1AWYcvvsmBj+FkiLagpwvGjVJFhkxu2t2gXPBiKue4U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73d699a6ff1e83df3fd6c1e60931e13667b8ae14",
+        "rev": "9336998b519fa62fa13ec0e2c770ff0178d6c3d6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73d699a6ff1e83df3fd6c1e60931e13667b8ae14",
+        "rev": "9336998b519fa62fa13ec0e2c770ff0178d6c3d6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=73d699a6ff1e83df3fd6c1e60931e13667b8ae14";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=9336998b519fa62fa13ec0e2c770ff0178d6c3d6";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -795,17 +795,6 @@ with oself;
     };
   });
 
-  eio = osuper.eio.overrideAttrs (o: {
-    src =
-      if lib.versionAtLeast ocaml.version "5.1" then
-        builtins.fetchurl
-          {
-            url = https://github.com/ocaml-multicore/eio/releases/download/v1.0/eio-1.0.tbz;
-            sha256 = "0bclc575czcvcsn9h92sp28cyqd22c5s4lk666gxwgcblffhs9ns";
-          }
-      else o.src;
-  });
-
   ezgzip = buildDunePackage rec {
     pname = "ezgzip";
     version = "0.2.3";


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/0825add7bd8beec313e0ea3a57c97f40b32cc839"><pre>ocamlPackages.eliom: 10.1.2 → 10.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aae884c8a6531ba617ee06e1bdf325a9e8734c77"><pre>liquidsoap: 2.2.3 → 2.2.4

ocamlPackages.cry: 1.0.1 → 1.0.2

Support for gstreamer in liquidsoap has been removed in nixpkgs as:
  - it does not build (see: liquidsoap PR 3769);
  - it is deprecated.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/998959464d6751ab6314ae16109505bf65bd9265"><pre>ocamlPackages.eio: 0.15 → 1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f692e9963d4d3a41e636ceacfc8d8e47ce7bd6fd"><pre>Merge pull request #294918 from toastal/ocaml-eio-1.0

ocamlPackages.eio: 0.15 → 1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/132352633b7b1eb2a8df69586247aa3b3b95da6d"><pre>Merge pull request #294231 from vbgl/ocaml-eliom-10.3.1

ocamlPackages.eliom: 10.1.2 → 10.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1165c1a5a1261bff9474a89d5cb5577ba95a8bd8"><pre>Merge pull request #294903 from vbgl/liquidsoap-2.2.4

liquidsoap: 2.2.3 → 2.2.4; ocamlPackages.cry: 1.0.1 → 1.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9336998b519fa62fa13ec0e2c770ff0178d6c3d6"><pre>Merge pull request #295011 from drupol/php/extensions/dom/fix-lower-bound

phpExtensions.dom: fix lowest extensions</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9336998b519fa62fa13ec0e2c770ff0178d6c3d6"><pre>Merge pull request #295011 from drupol/php/extensions/dom/fix-lower-bound

phpExtensions.dom: fix lowest extensions</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9336998b519fa62fa13ec0e2c770ff0178d6c3d6"><pre>Merge pull request #295011 from drupol/php/extensions/dom/fix-lower-bound

phpExtensions.dom: fix lowest extensions</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/73d699a6ff1e83df3fd6c1e60931e13667b8ae14...9336998b519fa62fa13ec0e2c770ff0178d6c3d6