### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710861126,
-        "narHash": "sha256-q8fiy9mgUvTAt2OMjiVpQgDlykyGury9Fpsm0jekBfY=",
+        "lastModified": 1710938121,
+        "narHash": "sha256-AJBv/MEktbJ+sHf1G6rdPmde3IapsG/2/5TLsk6KfZk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2dcadb7087e38314cebb15af65f8f2a15d2940cc",
+        "rev": "66e2e75c671f9a674a28d340e59a0157efb6f905",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2dcadb7087e38314cebb15af65f8f2a15d2940cc",
+        "rev": "66e2e75c671f9a674a28d340e59a0157efb6f905",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=2dcadb7087e38314cebb15af65f8f2a15d2940cc";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=66e2e75c671f9a674a28d340e59a0157efb6f905";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2284,12 +2284,6 @@ with oself;
     };
   });
 
-  tyxml = osuper.tyxml.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/ocsigen/tyxml/releases/download/4.6.0/tyxml-4.6.0.tbz;
-      sha256 = "1p82r68lxk6wzxihzd620a6kzp27vn548j2cr970l4jfdcy6gsxz";
-    };
-  });
   tyxml-jsx = callPackage ./tyxml/jsx.nix { };
   tyxml-ppx = callPackage ./tyxml/ppx.nix { };
   tyxml-syntax = callPackage ./tyxml/syntax.nix { };


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/f224bf319635a9fc4339683f5f7fa06602a899a8"><pre>ocamlPackages.tyxml: 4.5.0 → 4.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/66e2e75c671f9a674a28d340e59a0157efb6f905"><pre>Merge pull request #297420 from fabaff/py-tree-sitter-remove

python311Packages.py-tree-sitter: remove, python311Packages.tree-sitter: 0.20.4 -> 0.21.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/66e2e75c671f9a674a28d340e59a0157efb6f905"><pre>Merge pull request #297420 from fabaff/py-tree-sitter-remove

python311Packages.py-tree-sitter: remove, python311Packages.tree-sitter: 0.20.4 -> 0.21.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/66e2e75c671f9a674a28d340e59a0157efb6f905"><pre>Merge pull request #297420 from fabaff/py-tree-sitter-remove

python311Packages.py-tree-sitter: remove, python311Packages.tree-sitter: 0.20.4 -> 0.21.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/66e2e75c671f9a674a28d340e59a0157efb6f905"><pre>Merge pull request #297420 from fabaff/py-tree-sitter-remove

python311Packages.py-tree-sitter: remove, python311Packages.tree-sitter: 0.20.4 -> 0.21.1</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/2dcadb7087e38314cebb15af65f8f2a15d2940cc...66e2e75c671f9a674a28d340e59a0157efb6f905