### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713021534,
-        "narHash": "sha256-Aqz8cY3NRUEFWqtLA6xxJBHD1B+CopZkMaVEFZxjX3I=",
+        "lastModified": 1713107505,
+        "narHash": "sha256-JZIwPyHhX7XzUTIyHNQSPmLdwVtQZ3zMGoXvtvaoZZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e546289ea912083149781d395778043053825db0",
+        "rev": "5f81b2812ea76d998cb25a3491cce03093326cb2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e546289ea912083149781d395778043053825db0",
+        "rev": "5f81b2812ea76d998cb25a3491cce03093326cb2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e546289ea912083149781d395778043053825db0";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=5f81b2812ea76d998cb25a3491cce03093326cb2";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/5380bb424c629f92cc60f103a255cb788476681f"><pre>ocamlPackages.result: use Dune 3

ocamlPackages.base_quickcheck: 0.12.0 → 0.12.1

ocamlPackages.janeStreet_0_12: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/41493b10d795e600c7679f3e42139f220ce32026"><pre>ocamlPackages.octavius: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8d5f73b5433682bc6259ba7b57fb6e4bb2e06b08"><pre>ocamlPackages.ppx_derivers: use Dune 3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3b0adbab6a78c5b23546d58f443aa62993d7b1f2"><pre>Merge pull request #303034 from vbgl/ocaml-result-dune-3

ocamlPackages.result: use Dune 3</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e546289ea912083149781d395778043053825db0...5f81b2812ea76d998cb25a3491cce03093326cb2