### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713849260,
-        "narHash": "sha256-WtjeBo5ASr0fGUbFVXzvp5PNpGRFoF4iieYXMu3J6bI=",
+        "lastModified": 1713960115,
+        "narHash": "sha256-cgDgQ76uwzyiQ1jc326Oabfxfl9NeBfQeQ/MQCoLQl8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72bc2ea5d1a591c44c4b63f7f96f282508f7eb8f",
+        "rev": "8a30b52c5641c4317321c74efeae696341421267",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72bc2ea5d1a591c44c4b63f7f96f282508f7eb8f",
+        "rev": "8a30b52c5641c4317321c74efeae696341421267",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=72bc2ea5d1a591c44c4b63f7f96f282508f7eb8f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=8a30b52c5641c4317321c74efeae696341421267";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/8420bae6105680deae07dc4bb634b77df011b864"><pre>ber_metaocaml: 111 -> 114 (#303529)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e421acb18ab79f18c04c61d90fc7f23ee8483748"><pre>dune_3: 3.15.1 -> 3.15.2

Diff: https://github.com/ocaml/dune/compare/3.15.1...3.15.2

Changelog: https://github.com/ocaml/dune/raw/3.15.2/CHANGES.md</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/47108dafe28f9a0b0dcd8303e4c44e5b1421178e"><pre>ocamlPackages.ocaml-protoc-plugin: unbreak</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8a30b52c5641c4317321c74efeae696341421267"><pre>Merge pull request #306095 from K900/you-can-just-leave

Tarball job optimizations</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8a30b52c5641c4317321c74efeae696341421267"><pre>Merge pull request #306095 from K900/you-can-just-leave

Tarball job optimizations</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8a30b52c5641c4317321c74efeae696341421267"><pre>Merge pull request #306095 from K900/you-can-just-leave

Tarball job optimizations</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/72bc2ea5d1a591c44c4b63f7f96f282508f7eb8f...8a30b52c5641c4317321c74efeae696341421267