### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714145718,
-        "narHash": "sha256-imUdbvnjqEHGsMr2c5Y/Xd52wbnyy90sUVT4rTye0Ks=",
+        "lastModified": 1714203788,
+        "narHash": "sha256-wDz7eSOphXCS+vhNdhg3xFzcqcg63P98ZcsBTmYqGHU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf80486d25bdf7859196f4960f66edaf88eb7c64",
+        "rev": "9d3911e28686eae1dbbdadf6c5e6c260845c7be0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf80486d25bdf7859196f4960f66edaf88eb7c64",
+        "rev": "9d3911e28686eae1dbbdadf6c5e6c260845c7be0",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=cf80486d25bdf7859196f4960f66edaf88eb7c64";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=9d3911e28686eae1dbbdadf6c5e6c260845c7be0";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/80dffe120d96a72a9397347b3996f7dc98346a70"><pre>google-drive-ocamlfuse: 0.7.31 -> 0.7.32</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d99d437a592acc504ea446dbc40bd74b80ec01a"><pre>Merge pull request #303935 from r-ryantm/auto-update/google-drive-ocamlfuse

google-drive-ocamlfuse: 0.7.31 -> 0.7.32</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9d3911e28686eae1dbbdadf6c5e6c260845c7be0"><pre>Merge pull request #297566 from TomaSajt/use-strip-java-archives

treewide: use stripJavaArchivesHook in trivial cases</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/cf80486d25bdf7859196f4960f66edaf88eb7c64...9d3911e28686eae1dbbdadf6c5e6c260845c7be0