### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714513019,
-        "narHash": "sha256-QuNBYQvze8AWpbnH2Dv0dTKzafS10aSwKCFHVIPLsBQ=",
+        "lastModified": 1714556388,
+        "narHash": "sha256-Mxp8hX2gH30HoIQ+INvWY5P0sKBli8BmiGzZcKVD6co=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e273473c249f48dfadbf1318056d57f26aa5bf3",
+        "rev": "c10b1bb002e7414ecf7c9d9e5f7ebaeaeae32c92",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e273473c249f48dfadbf1318056d57f26aa5bf3",
+        "rev": "c10b1bb002e7414ecf7c9d9e5f7ebaeaeae32c92",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=0e273473c249f48dfadbf1318056d57f26aa5bf3";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c10b1bb002e7414ecf7c9d9e5f7ebaeaeae32c92";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/2367bf8bb488a774fc007950e6f5d91760ee99b5"><pre>ocamlPackages.ppx_cstruct: disable tests for OCaml ≥ 5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/28496bb2c5a6f90329a00e41c3787eec2b6be1b4"><pre>Merge pull request #307997 from vbgl/ocaml-ppx_cstruct-notest

ocamlPackages.ppx_cstruct: disable tests for OCaml ≥ 5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c10b1bb002e7414ecf7c9d9e5f7ebaeaeae32c92"><pre>Merge pull request #307832 from felschr/tor-browser-fontconfig-fix

{tor,mullvad}-browser: fix font config patch</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/0e273473c249f48dfadbf1318056d57f26aa5bf3...c10b1bb002e7414ecf7c9d9e5f7ebaeaeae32c92