### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715571466,
-        "narHash": "sha256-7o7OwQ7D35K7fsBaDjEqHfpbbg+EKhAtz93cHg3LXBw=",
+        "lastModified": 1715616897,
+        "narHash": "sha256-ncgLV/zSzXGx8XXEM8QlovDftzzcV11MnLeRUL63Szw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adc44ac0ee8454f4f51ef5dd1bdcc60080141e24",
+        "rev": "7ed944be63682d0c5bc37e66f3c997390d0bbd8e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adc44ac0ee8454f4f51ef5dd1bdcc60080141e24",
+        "rev": "7ed944be63682d0c5bc37e66f3c997390d0bbd8e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=adc44ac0ee8454f4f51ef5dd1bdcc60080141e24";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=7ed944be63682d0c5bc37e66f3c997390d0bbd8e";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/camlp5/default.nix
+++ b/ocaml/camlp5/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation
     owner = "camlp5";
     repo = "camlp5";
     rev = "8.03.00";
-    hash = "sha256-MXTG7qMjSD27bGTyY6eIc5RtjXTbSG0RWCKG4ibXxXM=";
+    hash = "sha256-hu/279gBvUc7Z4jM6EHiar6Wm4vjkGXl+7bxowj+vlM=";
   };
 
   nativeBuildInputs = [ ocaml findlib ];

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1620,10 +1620,6 @@ with oself;
   };
 
   odoc-parser = osuper.odoc-parser.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/ocaml/odoc/releases/download/2.4.2/odoc-2.4.2.tbz;
-      sha256 = "02x45ffakxv91yxmpqj87yasxfz00rd2ikx96zkk12pc4sxzsg2n";
-    };
     propagatedBuildInputs = [ astring camlp-streams ppx_expect ];
     postPatch = ''
       substituteInPlace src/parser/dune --replace-fail "result" ""
@@ -1789,14 +1785,6 @@ with oself;
     doCheck = true;
     checkInputs = [ alcotest ];
   };
-
-  # These require crowbar which is still not compatible with newer cmdliner.
-  pecu = osuper.pecu.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/pecu/releases/download/v0.7/pecu-0.7.tbz;
-      sha256 = "0y6pkz7bl63rhlhgdaizlkx4xnak95l6f02468yd6a34n6spfx5d";
-    };
-  });
 
   pg_query = callPackage ./pg_query { };
 
@@ -2260,13 +2248,6 @@ with oself;
       hash = "sha256-8e5NR69LyHnNdbDA/18OOYCUtsJW0h3mZkgxiQ85/QI=";
     };
     propagatedBuildInputs = [ ctypes integers ];
-  });
-
-  unstrctrd = osuper.unstrctrd.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/dinosaure/unstrctrd/releases/download/v0.4/unstrctrd-0.4.tbz;
-      sha256 = "090q28jynppia69n17lklr2m7bwy5kdzbgg75yaqx67amj39p2in";
-    };
   });
 
   uring = osuper.uring.overrideAttrs (_: {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/435a273fbb4ea9318be987d6a44af8a049ab0d03"><pre>ocamlPackages.pecu: 0.6 → 0.7</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/68f07ded7302ffa0d611a2af62dbbb6e9129a8b2"><pre>ocamlPackages.unstrctrd: 0.3 → 0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/65bfaad3cc771a1c6b34cf34f55a253495949e0f"><pre>ocamlPackages.odoc: 2.2.1 → 2.4.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e8cec63ebf1a8ad613329dec1f3f3166d049fed1"><pre>ocamlPackages.eliom: 10.3.1 → 10.4.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7ed944be63682d0c5bc37e66f3c997390d0bbd8e"><pre>Merge pull request #311374 from thillux/mtheil/update-mstflint

mstflint: 4.26.0-1 -> 4.28.0-1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7ed944be63682d0c5bc37e66f3c997390d0bbd8e"><pre>Merge pull request #311374 from thillux/mtheil/update-mstflint

mstflint: 4.26.0-1 -> 4.28.0-1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7ed944be63682d0c5bc37e66f3c997390d0bbd8e"><pre>Merge pull request #311374 from thillux/mtheil/update-mstflint

mstflint: 4.26.0-1 -> 4.28.0-1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7ed944be63682d0c5bc37e66f3c997390d0bbd8e"><pre>Merge pull request #311374 from thillux/mtheil/update-mstflint

mstflint: 4.26.0-1 -> 4.28.0-1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7ed944be63682d0c5bc37e66f3c997390d0bbd8e"><pre>Merge pull request #311374 from thillux/mtheil/update-mstflint

mstflint: 4.26.0-1 -> 4.28.0-1</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/adc44ac0ee8454f4f51ef5dd1bdcc60080141e24...7ed944be63682d0c5bc37e66f3c997390d0bbd8e