### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715616897,
-        "narHash": "sha256-ncgLV/zSzXGx8XXEM8QlovDftzzcV11MnLeRUL63Szw=",
+        "lastModified": 1715777523,
+        "narHash": "sha256-S6g1OWbKXswOMoTssq3aOm4OhxhlKoIwEAXWmU57vts=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ed944be63682d0c5bc37e66f3c997390d0bbd8e",
+        "rev": "c029b7f004009923bbfc90bbc31263cd4b08759f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7ed944be63682d0c5bc37e66f3c997390d0bbd8e",
+        "rev": "c029b7f004009923bbfc90bbc31263cd4b08759f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=7ed944be63682d0c5bc37e66f3c997390d0bbd8e";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c029b7f004009923bbfc90bbc31263cd4b08759f";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -111,6 +111,7 @@ with oself;
       rev = "aa437168b258db97680021116af176c55e1bd53b";
       hash = "sha256-c+7+izYbrvMVjO03+rjSmahEISJq30SW2blw8PBpB7I=";
     };
+    patches = [ ];
   });
 
   angstrom = osuper.angstrom.overrideAttrs (_: {
@@ -1557,15 +1558,6 @@ with oself;
       substituteInPlace src/dune --replace-fail "libraries bytes" "libraries "
     '';
     buildInputs = o.buildInputs ++ [ findlib ];
-  });
-
-  ocp-index = osuper.ocp-index.overrideAttrs (_: {
-    src = fetchFromGitHub {
-      owner = "ocamlpro";
-      repo = "ocp-index";
-      rev = "1.3.6";
-      hash = "sha256-EgRpC58NBVFO1w0xx11CnonatU2H7bECsEk6Y4c/odY=";
-    };
   });
 
   ocplib-simplex = buildDunePackage {

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -34,18 +34,6 @@ let
         });
       });
 
-      ocamlPackages_5_2 = ocaml-ng.ocamlPackages_5_2.overrideScope (oself: osuper: {
-        ocaml = osuper.ocaml.overrideAttrs (_: {
-          src = super.fetchFromGitHub {
-            owner = "ocaml";
-            repo = "ocaml";
-            rev = "5.2.0";
-            hash = "sha256-cN5feAgjEX0ojyQaNWI5X4Q7HuccOmwLQsi9Khi8PB0=";
-          };
-          hardeningDisable = [ "strictoverflow" ];
-        });
-      });
-
       ocamlPackages_trunk = newOCamlScope {
         major_version = "5";
         minor_version = "3";


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/699ddd8f8eb11eff1b5af0e1ebc08f166a252fdc"><pre>ocaml-ng.ocamlPackages_5_2.ocaml: 5.2.0-β2 → 5.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3f4eb8209906ea77df8ea6431a5bf246f7d4c33a"><pre>ocamlPackages.ocaml-compiler-libs: 0.17.0 for OCaml ≥ 5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c802669245947bcd341c7c0572972d00eb798f3e"><pre>Merge pull request #311389 from vbgl/ocaml-5.2.0

ocaml-ng.ocamlPackages_5_2.ocaml: 5.2.0-β2 → 5.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bc4eacca8c7e764251c7640d065f60b300a742a8"><pre>ocamlPackages.ocp-index: 1.3.5 → 1.3.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/646c7f3be4b945500c20edb77e264c9ba75e073a"><pre>ocamlPackges.ppx_tools: fix evaluation for OCaml ≥ 5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2b9f51e102bea483b7fb80cdc07f14729d2bae72"><pre>ocamlPackages.alcotest: fix tests with OCaml 5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6d4e13e3f164e3d974bc03380f6b8d589510fce6"><pre>Merge pull request #311552 from vbgl/ocaml-52-etc

Small fixes for OCaml 5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1cc90fe92c408670ca9594d60463a1d4da7ff201"><pre>ocamlPackages.uring: 0.8 → 0.9

musl patch merged</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c029b7f004009923bbfc90bbc31263cd4b08759f"><pre>Merge pull request #307204 from NixOS/haskell-updates

haskellPackages: update stackage and hackage</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/7ed944be63682d0c5bc37e66f3c997390d0bbd8e...c029b7f004009923bbfc90bbc31263cd4b08759f