### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718083092,
-        "narHash": "sha256-EQsPXycAbmby4meQUNLYfFaGOiqz2J9AlwFRV4UiHnY=",
+        "lastModified": 1718267761,
+        "narHash": "sha256-cNvy96/8JSSAQ7/o10ZzQSr+AUelhW4pcNPPYDbhS9o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa1ebdaf49a606e21c06e0f6ed7aece9a41831c3",
+        "rev": "21d22ef2ea511a82e20654d20ed493cef5690084",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa1ebdaf49a606e21c06e0f6ed7aece9a41831c3",
+        "rev": "21d22ef2ea511a82e20654d20ed493cef5690084",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=aa1ebdaf49a606e21c06e0f6ed7aece9a41831c3";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=21d22ef2ea511a82e20654d20ed493cef5690084";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -329,13 +329,6 @@ with oself;
     };
   };
 
-  ca-certs-nss = osuper.ca-certs-nss.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/ca-certs-nss/releases/download/v3.98/ca-certs-nss-3.98.tbz;
-      sha256 = "15x6gg0cil2fl9hk72lmlqavmrbfr5gnazny0plisa5pqz7xqprp";
-    };
-  });
-
   camlimages = osuper.camlimages.overrideAttrs (o: {
     buildInputs = o.buildInputs ++ [ findlib ];
   });
@@ -1180,18 +1173,6 @@ with oself;
     # https://github.com/NixOS/nixpkgs/blob/f6ed1c3c/pkgs/top-level/ocaml-packages.nix#L1035-L1037
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ result cmdliner ];
   });
-
-  memprof-limits = buildDunePackage {
-    pname = "memprof-limits";
-    version = "0.2.1";
-    src = fetchFromGitLab {
-      owner = "gadmm";
-      repo = "memprof-limits";
-      rev = "v0.2.1";
-      hash = "sha256-Pmuln5TihPoPZuehZlqPfERif6lf7O+0454kW9y3aKc=";
-    };
-    doCheck = true;
-  };
 
   mirage-crypto-pk = osuper.mirage-crypto-pk.override { gmp = gmp-oc; };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1819,16 +1819,51 @@ with oself;
 
   ppx_cstruct = disableTests osuper.ppx_cstruct;
 
-  ppx_cstubs = osuper.ppx_cstubs.overrideAttrs (o: {
-    buildInputs = o.buildInputs ++ [ findlib ];
+  ppx_cstubs = buildDunePackage {
+    pname = "ppx_cstubs";
+    version = "0.7.0";
+    minimalOCamlVersion = "4.08";
+
+    src = fetchFromGitHub {
+      owner = "fdopen";
+      repo = "ppx_cstubs";
+      rev = "0.7.0";
+      hash = "sha256-qMmwRWCIfNyhCQYPKLiufnb57sTR3P+WInOqtPDywFs=";
+    };
+
+    # patches = [ ./ppxlib.patch ];
     postPatch = ''
+      substituteInPlace src/internal/ppxc__script_real.ml \
+      --replace 'C_content_make ()' 'C_content_make (struct end)'
+
       ${lib.optionalString (lib.versionOlder "5.2" ocaml.version) ''
-        substituteInPlace src/custom/ppx_cstubs_custom.cppo.ml \
-        --replace-fail "init_code fun_code" "init_code" \
-        --replace-fail "can_free = fun_code = []" "can_free = fun_code"
-        ''}
+      substituteInPlace src/custom/ppx_cstubs_custom.cppo.ml \
+      --replace-fail "init_code fun_code" "init_code" \
+      --replace-fail "can_free = fun_code = []" "can_free = fun_code"
+      ''}
     '';
-  });
+
+    nativeBuildInputs = [ cppo ];
+
+    buildInputs = [
+      bigarray-compat
+      containers
+      findlib
+      integers
+      num
+      ppxlib
+      re
+    ];
+
+    propagatedBuildInputs = [ ctypes ];
+
+    meta = with lib; {
+      homepage = "https://github.com/fdopen/ppx_cstubs";
+      description = "Preprocessor for easier stub generation with ocaml-ctypes";
+      license = licenses.lgpl21Plus;
+      maintainers = [ lib.maintainers.anmonteiro ];
+    };
+  };
 
   ppx_jsx_embed = callPackage ./ppx_jsx_embed { };
 
@@ -2056,7 +2091,10 @@ with oself;
     buildInputs = o.buildInputs ++ [ dune-configurator ];
   });
 
-  stdcompat = osuper.stdcompat.overrideAttrs (_: {
+  stdcompat = buildDunePackage {
+    pname = "stdcompat";
+    version = "19-dev";
+
     src = fetchFromGitHub {
       owner = "thierry-martinez";
       repo = "stdcompat";
@@ -2064,7 +2102,15 @@ with oself;
       rev = "58b6d90fc53333f5e8112d42f96093802678c030";
       hash = "sha256-7xfcCVOOMaZ5dwgTtSn0YAkZg9tdqvn1tNMqsIL4ZfA=";
     };
-  });
+
+    dontConfigure = true;
+
+    meta = {
+      homepage = "https://github.com/thierry-martinez/stdcompat";
+      license = lib.licenses.bsd2;
+      maintainers = [ lib.maintainers.anmonteiro ];
+    };
+  };
 
   stdlib-random = buildDunePackage {
     pname = "stdlib-random";

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -262,8 +262,8 @@ in
         src = fetchFromGitHub {
           owner = "anmonteiro";
           repo = "relay";
-          rev = "9284868941e42e4877365c8ed4b1dbe8eddc87e5";
-          hash = "sha256-xWqIGBOQ32ygDY+9/O5EKj+YMMKL1/2OWW2Qf1LzcDs=";
+          rev = "75652adf7142bb043eaf11143fffcc557ab8cc68";
+          hash = "sha256-Y0tsePP91M6996JROnWHVD9AZqqPQhdATvxC1aV/6ws=";
           sparseCheckout = [ "compiler" ];
         };
         dontBuild = true;


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/15427ed7cd752ac09afc20c979b7aa543035c647"><pre>ocamlPackages.memprof-limits: init at 0.2.1 (#318800)

Signed-off-by: Ali Caglayan <alizter@gmail.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7b6cb1fec0b5b0433b5dd9a7c85fb70c01526b2a"><pre>ocamlPackages.ca-certs-nss: 3.98 -> 3.101</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1b9c3e0fd6403f9341bad5ffc37c3a5a91ff3c41"><pre>ocamlPackages.stdcompat: disable for OCaml ≥ 5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b4aca0dd3239a02dc311661e567ee109d3e99da9"><pre>ocamlPackages.torch: mark as broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b206de3bfcdad680160c3ebaa69f99b67429c7a5"><pre>ocamlPackages.ppx_stubs: disable for OCaml ≥ 5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d913a66f27204962d7c3f42c8bb8e8aee89785c4"><pre>ocaml: remove left-over builder.sh

This file was last used in 3.08.0.nix removed in #114848 3 years ago.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/69acb0010c9d8c47419e295782fe1ea7f66aee36"><pre>Merge pull request #319085 from r-ryantm/auto-update/ocamlPackages.ca-certs-nss

ocamlPackages.ca-certs-nss: 3.98 -> 3.101</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/aa1ebdaf49a606e21c06e0f6ed7aece9a41831c3...21d22ef2ea511a82e20654d20ed493cef5690084