### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718083092,
-        "narHash": "sha256-EQsPXycAbmby4meQUNLYfFaGOiqz2J9AlwFRV4UiHnY=",
+        "lastModified": 1718419000,
+        "narHash": "sha256-v4+aJpRDbJil691DXo5SydqowcB01B6E9+wFH/pNk6k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa1ebdaf49a606e21c06e0f6ed7aece9a41831c3",
+        "rev": "24b048f70e34020c93ed7c11491bc050ff6eb142",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa1ebdaf49a606e21c06e0f6ed7aece9a41831c3",
+        "rev": "24b048f70e34020c93ed7c11491bc050ff6eb142",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=aa1ebdaf49a606e21c06e0f6ed7aece9a41831c3";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=24b048f70e34020c93ed7c11491bc050ff6eb142";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/15427ed7cd752ac09afc20c979b7aa543035c647"><pre>ocamlPackages.memprof-limits: init at 0.2.1 (#318800)

Signed-off-by: Ali Caglayan <alizter@gmail.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7b6cb1fec0b5b0433b5dd9a7c85fb70c01526b2a"><pre>ocamlPackages.ca-certs-nss: 3.98 -> 3.101</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1b9c3e0fd6403f9341bad5ffc37c3a5a91ff3c41"><pre>ocamlPackages.stdcompat: disable for OCaml ≥ 5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b4aca0dd3239a02dc311661e567ee109d3e99da9"><pre>ocamlPackages.torch: mark as broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b206de3bfcdad680160c3ebaa69f99b67429c7a5"><pre>ocamlPackages.ppx_stubs: disable for OCaml ≥ 5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d913a66f27204962d7c3f42c8bb8e8aee89785c4"><pre>ocaml: remove left-over builder.sh

This file was last used in 3.08.0.nix removed in #114848 3 years ago.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/69acb0010c9d8c47419e295782fe1ea7f66aee36"><pre>Merge pull request #319085 from r-ryantm/auto-update/ocamlPackages.ca-certs-nss

ocamlPackages.ca-certs-nss: 3.98 -> 3.101</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a6a37c22b318ed773b2918a3cb6ce8a1e77254c4"><pre>ocamlPackages.apron: 0.9.14 → 0.9.15</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a887251577670332e068815a2f9d1c8a414b3cd1"><pre>ocamlPackages.ezjsonm-encoding: init at 2.0.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/aa1ebdaf49a606e21c06e0f6ed7aece9a41831c3...24b048f70e34020c93ed7c11491bc050ff6eb142