### PR TITLE
fix logs package failing to build in static

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1236,9 +1236,9 @@ with oself;
     '';
   });
 
-  logs = (osuper.logs.override { jsooSupport = false; }).overrideAttrs (_: {
+  logs = (osuper.logs.override { jsooSupport = false; }).overrideAttrs (o: {
     pname = "logs";
-    propagatedBuildInputs = [ ];
+    propagatedBuildInputs = o.propagatedBuildInputs ++[topkg ];
   });
 
   logs-ppx = callPackage ./logs-ppx { };

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1238,7 +1238,6 @@ with oself;
 
   logs = (osuper.logs.override { jsooSupport = false; }).overrideAttrs (o: {
     pname = "logs";
-    propagatedBuildInputs = o.propagatedBuildInputs ++[topkg ];
   });
 
   logs-ppx = callPackage ./logs-ppx { };


### PR DESCRIPTION
logs was failing to build when using pkgsStatic because it was missing topkg. I saw we were overriding the propergatedBuildInputs to nothing. Removing that seems to have fixed things.
```
error: builder for '/nix/store/nznpgpr6mj6pf4r5jd113ld1zajv8fd1-ocaml5.1.1-logs-0.7.0-x86_64-unknown-linux-musl.drv' failed with exit code 2;
       last 10 log lines:
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > No such package: topkg
       > File "./pkg/pkg.ml", line 4, characters 5-10:
       > 4 | open Topkg
       >          ^^^^^
       > Error: Unbound module Topkg
 ````