### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718770573,
-        "narHash": "sha256-tnNrZhmle3RE6DtLFADO+nRy0QuzQp4ztVK0R4tUHSA=",
+        "lastModified": 1719036971,
+        "narHash": "sha256-t1g+Iq3wRWLkB1VAvdqmud9gjhedqgoaaRHd7YsC0JA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "31a131649c0bcd9d7d9b87786b3fbb54b4dbe6e0",
+        "rev": "165dfa10e2983708c5eae03a1f02674b5d03208a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "31a131649c0bcd9d7d9b87786b3fbb54b4dbe6e0",
+        "rev": "165dfa10e2983708c5eae03a1f02674b5d03208a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=31a131649c0bcd9d7d9b87786b3fbb54b4dbe6e0";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=165dfa10e2983708c5eae03a1f02674b5d03208a";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/5fa4d405272ea98dab145f0c9f7ea1dbb9c87c31"><pre>ocamlPackages.uri: set correct src hash

Ref #310112</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/40ae5e072c5f2ef7c5fc6bed799e5cd24a33edb4"><pre>build-support/ocaml: deprecate minimumOCamlVersion (#319907)

* ocamlPackages.wtf8: use minimalOCamlVersion

* ocamlPackages.ppx_yojson_conv: minimalOCamlVersion

* ocamlPackages.postgresql: use minimalOCamlVersion

* ocamlPackages.opti: use minimalOCamlVersion

* ocamlPackages.opam-repository: use minimalOCamlVersion

* ocamlPackages.opam-format: use minimalOCamlVersion

* ocamlPackages.lwt-dllist: use minimalOCamlVersion

* ocamlPackages.lacaml: use minimalOCamlVersion

* ocamlPackages.gnuplot: use minimalOCamlVersion

* ocamlPackages.fix: use minimalOCamlVersion

* ocamlPackages.eigen: use minimalOCamlVersion

* ocamlPackages.earley: use minimalOCamlVersion

* ocamlPackages.directories: use minimalOCamlVersion

* ocamlPackages.cpuid: use minimalOCamlVersion

* build-support/ocaml: deprecate minimumOCamlVersion

* build-support/ocaml: deprecate minimumOCamlVersion

---------

Co-authored-by: Vincent Laporte <Vincent.Laporte@gmail.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/165dfa10e2983708c5eae03a1f02674b5d03208a"><pre>Merge pull request #321675 from K900/kconfig-oof

linux/common-config: fix version conditionals</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/165dfa10e2983708c5eae03a1f02674b5d03208a"><pre>Merge pull request #321675 from K900/kconfig-oof

linux/common-config: fix version conditionals</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/31a131649c0bcd9d7d9b87786b3fbb54b4dbe6e0...165dfa10e2983708c5eae03a1f02674b5d03208a