### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719233611,
-        "narHash": "sha256-YZO/PDjf9js7lQsSCLFMMFRCbgIKzasGA2y1NVRIQR8=",
+        "lastModified": 1719269760,
+        "narHash": "sha256-FWzbmvxTyohbLisIDCAvW0ISz/cu7Mrh8JMykSRoI8s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "36e8d8a53b253019a3b325015be47196c278afb7",
+        "rev": "4c547b66635455ad061d4beecaf1805810dc0428",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "36e8d8a53b253019a3b325015be47196c278afb7",
+        "rev": "4c547b66635455ad061d4beecaf1805810dc0428",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=36e8d8a53b253019a3b325015be47196c278afb7";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=4c547b66635455ad061d4beecaf1805810dc0428";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/b4bb2e8dcade56795c3d827ea3ca54df6e4215f2"><pre>ocamlformat_0_19_0 - 0_22_4: Require ocamlPackages_4_14

OCamlformat versions below 0.23.0 do not build with the default
\'ocamlPackages\'.

This can be tested like this:

    set -e
    nix-build . -A ocamlformat_0_25_1
    nix-build . -A ocamlformat_0_24_1
    nix-build . -A ocamlformat_0_23_0
    nix-build . -A ocamlformat_0_22_4
    nix-build . -A ocamlformat_0_21_0
    nix-build . -A ocamlformat_0_20_1
    nix-build . -A ocamlformat_0_20_0
    nix-build . -A ocamlformat_0_19_0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/36e8d8a53b253019a3b325015be47196c278afb7...4c547b66635455ad061d4beecaf1805810dc0428