### PR TITLE
Format using nixfmt-rfc-style

### DIFF
--- a/ci/hydra.nix
+++ b/ci/hydra.nix
@@ -24,42 +24,43 @@ with filter;
   };
 
   build_top-level-packages =
-    { inherit (pkgs) melange-relay-compiler hermes; } //
-    (if stdenv.isLinux then {
-      inherit (pkgs) esy kubernetes;
-      hermes-musl64 = pkgs.pkgsCross.musl64.hermes;
-    } else { });
+    {
+      inherit (pkgs) melange-relay-compiler hermes;
+    }
+    // (
+      if stdenv.isLinux then
+        {
+          inherit (pkgs) esy kubernetes;
+          hermes-musl64 = pkgs.pkgsCross.musl64.hermes;
+        }
+      else
+        { }
+    );
 
-  arm64_4_14 = (if system == "x86_64-linux" then
-    crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "4_14"
-  else
-    { });
-
-  musl_4_14 = (if system == "x86_64-linux" then
-    crossTarget pkgs.pkgsCross.musl64 "4_14"
-  else
-    { }
+  arm64_4_14 = (
+    if system == "x86_64-linux" then
+      crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "4_14"
+    else
+      { }
   );
 
-  arm64_5_1 = (if system == "x86_64-linux" then
-    crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "5_1"
-  else
-    { });
+  musl_4_14 = (if system == "x86_64-linux" then crossTarget pkgs.pkgsCross.musl64 "4_14" else { });
 
-  musl_5_1 = (if system == "x86_64-linux" then
-    crossTarget pkgs.pkgsCross.musl64 "5_1"
-  else
-    { }
+  arm64_5_1 = (
+    if system == "x86_64-linux" then
+      crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "5_1"
+    else
+      { }
   );
 
-  arm64_5_2 = (if system == "x86_64-linux" then
-    crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "5_2"
-  else
-    { });
+  musl_5_1 = (if system == "x86_64-linux" then crossTarget pkgs.pkgsCross.musl64 "5_1" else { });
 
-  musl_5_2 = (if system == "x86_64-linux" then
-    crossTarget pkgs.pkgsCross.musl64 "5_2"
-  else
-    { }
+  arm64_5_2 = (
+    if system == "x86_64-linux" then
+      crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "5_2"
+    else
+      { }
   );
+
+  musl_5_2 = (if system == "x86_64-linux" then crossTarget pkgs.pkgsCross.musl64 "5_2" else { });
 }

--- a/ci/hydra_jobs.nix
+++ b/ci/hydra_jobs.nix
@@ -1,9 +1,12 @@
 # Heavily inspired by https://github.com/cleverca22/hydra-configs
-{ pulls ? ./simple-pr-dummy.json }:
+{
+  pulls ? ./simple-pr-dummy.json,
+}:
 
 let
   pkgs = import <nixpkgs> { };
-  makeSpec = contents:
+  makeSpec =
+    contents:
     builtins.derivation {
       name = "spec.json";
       system = "x86_64-linux";
@@ -51,4 +54,6 @@ let
   pull_requests = listToAttrs (mapAttrsToList makePr pr_data);
   jobsetsAttrs = pull_requests // primary_jobsets;
 in
-{ jobsets = makeSpec jobsetsAttrs; }
+{
+  jobsets = makeSpec jobsetsAttrs;
+}

--- a/cockroachdb/default.nix
+++ b/cockroachdb/default.nix
@@ -1,4 +1,8 @@
-{ callPackage, go_1_18, buildGo118Module }:
+{
+  callPackage,
+  go_1_18,
+  buildGo118Module,
+}:
 
 {
   cockroachdb-21_2_x = callPackage ./generic.nix (rec {

--- a/cockroachdb/generic.nix
+++ b/cockroachdb/generic.nix
@@ -1,21 +1,22 @@
-{ lib
-, src
-, stdenv
-, buildGoModule
-, fetchurl
-, fetchFromGitHub
-, cmake
-, xz
-, which
-, autoconf
-, ncurses6
-, libedit
-, libunwind
-, installShellFiles
-, removeReferencesTo
-, go
-, version
-, patches ? [ ]
+{
+  lib,
+  src,
+  stdenv,
+  buildGoModule,
+  fetchurl,
+  fetchFromGitHub,
+  cmake,
+  xz,
+  which,
+  autoconf,
+  ncurses6,
+  libedit,
+  libunwind,
+  installShellFiles,
+  removeReferencesTo,
+  go,
+  version,
+  patches ? [ ],
 }:
 
 buildGoModule rec {
@@ -30,8 +31,21 @@ buildGoModule rec {
     "-Wno-error=pessimizing-move"
   ];
 
-  nativeBuildInputs = [ installShellFiles cmake xz which autoconf ];
-  buildInputs = if stdenv.isDarwin then [ libunwind libedit ] else [ ncurses6 ];
+  nativeBuildInputs = [
+    installShellFiles
+    cmake
+    xz
+    which
+    autoconf
+  ];
+  buildInputs =
+    if stdenv.isDarwin then
+      [
+        libunwind
+        libedit
+      ]
+    else
+      [ ncurses6 ];
 
   inherit patches;
 
@@ -60,7 +74,10 @@ buildGoModule rec {
     runHook postInstall
   '';
 
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
   # fails with `GOFLAGS=-trimpath`
   allowGoReference = true;
@@ -73,6 +90,10 @@ buildGoModule rec {
     description = "A scalable, survivable, strongly-consistent SQL database";
     license = licenses.bsl11;
     # platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
-    maintainers = with maintainers; [ rushmorem thoughtpolice turion ];
+    maintainers = with maintainers; [
+      rushmorem
+      thoughtpolice
+      turion
+    ];
   };
 }

--- a/cross/default.nix
+++ b/cross/default.nix
@@ -4,8 +4,6 @@ self: super:
 
 super.lib.overlayOCamlPackages {
   inherit super;
-  overlays = super.callPackage ./ocaml.nix {
-    inherit buildPackages;
-  };
+  overlays = super.callPackage ./ocaml.nix { inherit buildPackages; };
   updateOCamlPackages = true;
 }

--- a/cross/ocaml-compiler.nix
+++ b/cross/ocaml-compiler.nix
@@ -1,14 +1,23 @@
-{ stdenv, lib, buildPackages, natocamlPackages, writeScriptBin, osuper }:
+{
+  stdenv,
+  lib,
+  buildPackages,
+  natocamlPackages,
+  writeScriptBin,
+  osuper,
+}:
 
 let
   natocaml = natocamlPackages.ocaml;
-  genWrapper = name: camlBin: writeScriptBin name ''
-    #!${buildPackages.stdenv.shell}
-    NEW_ARGS=""
+  genWrapper =
+    name: camlBin:
+    writeScriptBin name ''
+      #!${buildPackages.stdenv.shell}
+      NEW_ARGS=""
 
-    for ARG in "$@"; do NEW_ARGS="$NEW_ARGS \"$ARG\""; done
-    eval "${camlBin} $NEW_ARGS"
-  '';
+      for ARG in "$@"; do NEW_ARGS="$NEW_ARGS \"$ARG\""; done
+      eval "${camlBin} $NEW_ARGS"
+    '';
   ocamlcHostWrapper = genWrapper "ocamlcHost.wrapper" "${natocaml}/bin/ocamlc.opt -I ${natocaml}/lib/ocaml -I ${natocaml}/lib/ocaml/stublibs -I +unix -nostdlib ";
   ocamloptHostWrapper = genWrapper "ocamloptHost.wrapper" "${natocaml}/bin/ocamlopt.opt -I ${natocaml}/lib/ocaml -I +unix -nostdlib ";
 
@@ -16,114 +25,121 @@ let
   ocamloptTargetWrapper = genWrapper "ocamloptTarget.wrapper" "$BUILD_ROOT/ocamlopt.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
 
 in
-osuper.ocaml.overrideAttrs (o:
-let isOCaml5 = lib.versionOlder "5.0" o.version;
-in {
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
-  preConfigure = ''
-    configureFlagsArray+=("PARTIALLD=$LD -r" "ASPP=$CC -c")
-    installFlagsArray+=("OCAMLRUN=${natocaml}/bin/ocamlrun")
-  '';
-  configureFlags = o.configureFlags ++ [ "--disable-ocamldoc" ];
-  postConfigure = ''
-    cp Makefile.config Makefile.config.bak
-    echo 'SAK_CC=${buildPackages.stdenv.cc}/bin/gcc' >> Makefile.config
-    echo 'SAK_CFLAGS=$(OC_CFLAGS) $(OC_CPPFLAGS)' >> Makefile.config
-    echo 'SAK_LINK=$(SAK_CC) $(SAK_CFLAGS) $(OUTPUTEXE)$(1) $(2)' >> Makefile.config
-  '';
+osuper.ocaml.overrideAttrs (
+  o:
+  let
+    isOCaml5 = lib.versionOlder "5.0" o.version;
+  in
+  {
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+    preConfigure = ''
+      configureFlagsArray+=("PARTIALLD=$LD -r" "ASPP=$CC -c")
+      installFlagsArray+=("OCAMLRUN=${natocaml}/bin/ocamlrun")
+    '';
+    configureFlags = o.configureFlags ++ [ "--disable-ocamldoc" ];
+    postConfigure = ''
+      cp Makefile.config Makefile.config.bak
+      echo 'SAK_CC=${buildPackages.stdenv.cc}/bin/gcc' >> Makefile.config
+      echo 'SAK_CFLAGS=$(OC_CFLAGS) $(OC_CPPFLAGS)' >> Makefile.config
+      echo 'SAK_LINK=$(SAK_CC) $(SAK_CFLAGS) $(OUTPUTEXE)$(1) $(2)' >> Makefile.config
+    '';
 
-  buildPhase = ''
-    runHook preBuild
+    buildPhase = ''
+      runHook preBuild
 
-    OCAML_HOST=${natocaml}
-    OCAMLRUN="$OCAML_HOST/bin/ocamlrun"
-    OCAMLLEX="$OCAML_HOST/bin/ocamllex"
-    OCAMLYACC="$OCAML_HOST/bin/ocamlyacc"
-    CAMLDEP="$OCAML_HOST/bin/ocamlc"
-    DYNAMIC_LIBS="-I $OCAML_HOST/lib/ocaml/stublibs"
-    HOST_STATIC_LIBS="-I $OCAML_HOST/lib/ocaml"
-    TARGET_STATIC_LIBS="-I $PWD/stdlib -I $PWD/otherlibs/unix"
+      OCAML_HOST=${natocaml}
+      OCAMLRUN="$OCAML_HOST/bin/ocamlrun"
+      OCAMLLEX="$OCAML_HOST/bin/ocamllex"
+      OCAMLYACC="$OCAML_HOST/bin/ocamlyacc"
+      CAMLDEP="$OCAML_HOST/bin/ocamlc"
+      DYNAMIC_LIBS="-I $OCAML_HOST/lib/ocaml/stublibs"
+      HOST_STATIC_LIBS="-I $OCAML_HOST/lib/ocaml"
+      TARGET_STATIC_LIBS="-I $PWD/stdlib -I $PWD/otherlibs/unix"
 
-    HOST_MAKEFILE_CONFIG="$OCAML_HOST/lib/ocaml/Makefile.config"
-    get_host_variable () {
-      cat $HOST_MAKEFILE_CONFIG | grep "$1=" | awk -F '=' '{print $2}'
-    }
+      HOST_MAKEFILE_CONFIG="$OCAML_HOST/lib/ocaml/Makefile.config"
+      get_host_variable () {
+        cat $HOST_MAKEFILE_CONFIG | grep "$1=" | awk -F '=' '{print $2}'
+      }
 
-    NATDYNLINK=$(get_host_variable "NATDYNLINK")
-    NATDYNLINKOPTS=$(get_host_variable "NATDYNLINKOPTS")
+      NATDYNLINK=$(get_host_variable "NATDYNLINK")
+      NATDYNLINKOPTS=$(get_host_variable "NATDYNLINKOPTS")
 
 
-    make_caml () {
-      make ''${enableParallelBuilding:+-j $NIX_BUILD_CORES} ''${enableParallelBuilding:+-l $NIX_BUILD_CORES} \
-           CAMLDEP="$CAMLDEP -depend" \
-           OCAMLLEX="$OCAMLLEX" \
-           OCAMLYACC="$OCAMLYACC" CAMLYACC="$OCAMLYACC" \
-           CAMLRUN="$OCAMLRUN" OCAMLRUN="$OCAMLRUN" \
-           NEW_OCAMLRUN="$OCAMLRUN" \
-           CAMLC="$CAMLC" OCAMLC="$CAMLC" \
-           CAMLOPT="$CAMLOPT" OCAMLOPT="$CAMLOPT" \
-           $@
-    }
+      make_caml () {
+        make ''${enableParallelBuilding:+-j $NIX_BUILD_CORES} ''${enableParallelBuilding:+-l $NIX_BUILD_CORES} \
+             CAMLDEP="$CAMLDEP -depend" \
+             OCAMLLEX="$OCAMLLEX" \
+             OCAMLYACC="$OCAMLYACC" CAMLYACC="$OCAMLYACC" \
+             CAMLRUN="$OCAMLRUN" OCAMLRUN="$OCAMLRUN" \
+             NEW_OCAMLRUN="$OCAMLRUN" \
+             CAMLC="$CAMLC" OCAMLC="$CAMLC" \
+             CAMLOPT="$CAMLOPT" OCAMLOPT="$CAMLOPT" \
+             $@
+      }
 
-    make_host () {
-      CAMLC="${ocamlcHostWrapper}/bin/ocamlcHost.wrapper"
-      CAMLOPT="${ocamloptHostWrapper}/bin/ocamloptHost.wrapper"
+      make_host () {
+        CAMLC="${ocamlcHostWrapper}/bin/ocamlcHost.wrapper"
+        CAMLOPT="${ocamloptHostWrapper}/bin/ocamloptHost.wrapper"
 
-      make_caml \
-        NATDYNLINK="$NATDYNLINK" NATDYNLINKOPTS="$NATDYNLINKOPTS" \
-        "$@"
-    }
+        make_caml \
+          NATDYNLINK="$NATDYNLINK" NATDYNLINKOPTS="$NATDYNLINKOPTS" \
+          "$@"
+      }
 
-    make_target () {
-      CAMLC="${ocamlcTargetWrapper}/bin/ocamlcTarget.wrapper"
-      CAMLOPT="${ocamloptTargetWrapper}/bin/ocamloptTarget.wrapper"
+      make_target () {
+        CAMLC="${ocamlcTargetWrapper}/bin/ocamlcTarget.wrapper"
+        CAMLOPT="${ocamloptTargetWrapper}/bin/ocamloptTarget.wrapper"
 
-      make_caml BUILD_ROOT="$PWD" TARGET_OCAMLC="$TARGET_OCAMLC" TARGET_OCAMLOPT="$TARGET_OCAMLOPT" "$@"
-    }
+        make_caml BUILD_ROOT="$PWD" TARGET_OCAMLC="$TARGET_OCAMLC" TARGET_OCAMLOPT="$TARGET_OCAMLOPT" "$@"
+      }
 
-    make_host runtime coreall
-    make_host opt-core
-    make_host ocamlc.opt
-    make_host ocamlopt.opt
-    make_host compilerlibs/ocamltoplevel.cma otherlibraries \
-              ocamldebugger
-    make_host ocamllex.opt ocamltoolsopt \
-              ocamltoolsopt.opt ${if isOCaml5 then "othertools" else ""}
+      make_host runtime coreall
+      make_host opt-core
+      make_host ocamlc.opt
+      make_host ocamlopt.opt
+      make_host compilerlibs/ocamltoplevel.cma otherlibraries \
+                ocamldebugger
+      make_host ocamllex.opt ocamltoolsopt \
+                ocamltoolsopt.opt ${if isOCaml5 then "othertools" else ""}
 
-    rm $(find . | grep -E '\.cm.?.$')
-    make_target -C stdlib all allopt
-    make_target ocaml ocamlc
-    make_target ocamlopt
-    make_target otherlibraries otherlibrariesopt ocamltoolsopt \
-                driver/main.cmx driver/optmain.cmx
+      rm $(find . | grep -E '\.cm.?.$')
+      make_target -C stdlib all allopt
+      make_target ocaml ocamlc
+      make_target ocamlopt
+      make_target otherlibraries otherlibrariesopt ocamltoolsopt \
+                  driver/main.cmx driver/optmain.cmx
 
-    # build the compiler shared libraries with the target `zstd.npic.o`
-    cp Makefile.config.bak Makefile.config
-    echo 'SAK_CC=${stdenv.cc.targetPrefix}gcc' >> Makefile.config
-    make_target compilerlibs/ocamlcommon.cmxa \
-                compilerlibs/ocamlbytecomp.cmxa \
-                compilerlibs/ocamloptcomp.cmxa
-    ${if isOCaml5 then "make_target othertools" else ""}
+      # build the compiler shared libraries with the target `zstd.npic.o`
+      cp Makefile.config.bak Makefile.config
+      echo 'SAK_CC=${stdenv.cc.targetPrefix}gcc' >> Makefile.config
+      make_target compilerlibs/ocamlcommon.cmxa \
+                  compilerlibs/ocamlbytecomp.cmxa \
+                  compilerlibs/ocamloptcomp.cmxa
+      ${if isOCaml5 then "make_target othertools" else ""}
 
-    runHook postBuild
-  '';
-  installTargets = o.installTargets ++ [ "installoptopt" ];
-  postInstall = "cp ${natocaml}/bin/ocamlyacc $out/bin/ocamlyacc";
-  patches = [
-    (if lib.versionOlder "5.2" o.version
-    then ./cross_5_2.patch
-    else if lib.versionOlder "5.1" o.version
-    then ./cross_5_1.patch
-    else if isOCaml5
-    then ./cross_5_00.patch
-    else if lib.versionOlder "4.14" o.version
-    then ./cross_4_14.patch
-    else if lib.versionOlder "4.13" o.version
-    then ./cross_4_13.patch
-    else if lib.versionOlder "4.12" o.version
-    then ./cross_4_12.patch
-    else if lib.versionOlder "4.11" o.version
-    then ./cross_4_11.patch
-    else throw "OCaml ${o.version} not supported for cross-compilation")
-  ];
-})
+      runHook postBuild
+    '';
+    installTargets = o.installTargets ++ [ "installoptopt" ];
+    postInstall = "cp ${natocaml}/bin/ocamlyacc $out/bin/ocamlyacc";
+    patches = [
+      (
+        if lib.versionOlder "5.2" o.version then
+          ./cross_5_2.patch
+        else if lib.versionOlder "5.1" o.version then
+          ./cross_5_1.patch
+        else if isOCaml5 then
+          ./cross_5_00.patch
+        else if lib.versionOlder "4.14" o.version then
+          ./cross_4_14.patch
+        else if lib.versionOlder "4.13" o.version then
+          ./cross_4_13.patch
+        else if lib.versionOlder "4.12" o.version then
+          ./cross_4_12.patch
+        else if lib.versionOlder "4.11" o.version then
+          ./cross_4_11.patch
+        else
+          throw "OCaml ${o.version} not supported for cross-compilation"
+      )
+    ];
+  }
+)

--- a/default.nix
+++ b/default.nix
@@ -1,22 +1,17 @@
-{ system ? builtins.currentSystem
-, extraOverlays ? [ ]
-, ...
+{
+  system ? builtins.currentSystem,
+  extraOverlays ? [ ],
+  ...
 }@args:
 
 # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
 
 let
-  flake = (import
-    (
-      fetchTarball {
-        url = https://github.com/edolstra/flake-compat/archive/b4a3401.tar.gz;
-        sha256 = "1qc703yg0babixi6wshn5wm2kgl5y1drcswgszh4xxzbrwkk9sv7";
-      }
-    )
-    { src = ./.; }
-  ).defaultNix;
+  flake =
+    (import (fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/b4a3401.tar.gz";
+      sha256 = "1qc703yg0babixi6wshn5wm2kgl5y1drcswgszh4xxzbrwkk9sv7";
+    }) { src = ./.; }).defaultNix;
 in
 
-flake.makePkgs {
-  inherit system extraOverlays;
-}
+flake.makePkgs { inherit system extraOverlays; }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,12 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
     let
       overlay = import ./overlay nixpkgs;
     in
@@ -19,39 +24,57 @@
       {
         lib = nixpkgs.lib;
 
-        hydraJobs = builtins.listToAttrs (map
-          (system: {
-            name = system;
-            value = import ./ci/hydra.nix {
-              inherit system;
-              pkgs = self.legacyPackages.${system};
-            };
-          })
-          [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ]);
-
-        makePkgs = { system, extraOverlays ? [ ], ... }@attrs:
-          let
-            pkgs = import nixpkgs ({
-              inherit system;
-              overlays = [ overlay ];
-              config = {
-                allowUnfree = true;
-              } // nixpkgs.lib.optionalAttrs (system == "x86_64-darwin") {
-                config.replaceStdenv = { pkgs, ... }: pkgs.clang11Stdenv;
+        hydraJobs = builtins.listToAttrs (
+          map
+            (system: {
+              name = system;
+              value = import ./ci/hydra.nix {
+                inherit system;
+                pkgs = self.legacyPackages.${system};
               };
-            } // attrs);
+            })
+            [
+              "x86_64-linux"
+              "x86_64-darwin"
+              "aarch64-darwin"
+            ]
+        );
+
+        makePkgs =
+          {
+            system,
+            extraOverlays ? [ ],
+            ...
+          }@attrs:
+          let
+            pkgs = import nixpkgs (
+              {
+                inherit system;
+                overlays = [ overlay ];
+                config =
+                  {
+                    allowUnfree = true;
+                  }
+                  // nixpkgs.lib.optionalAttrs (system == "x86_64-darwin") {
+                    config.replaceStdenv = { pkgs, ... }: pkgs.clang11Stdenv;
+                  };
+              }
+              // attrs
+            );
           in
-            /*
+          /*
             You might read
             https://nixos.org/manual/nixpkgs/stable/#sec-overlays-argument and
             want to change this but because of how we're doing overlays we will
             be overriding any extraOverlays if we don't use `appendOverlays`
-            */
+          */
           pkgs.appendOverlays extraOverlays;
 
         overlays.default = final: prev: overlay final prev;
       }
-      (flake-utils.lib.eachDefaultSystem (system: {
-        legacyPackages = self.makePkgs { inherit system; };
-      }));
+      (
+        flake-utils.lib.eachDefaultSystem (system: {
+          legacyPackages = self.makePkgs { inherit system; };
+        })
+      );
 }

--- a/ocaml/archi/async.nix
+++ b/ocaml/archi/async.nix
@@ -1,7 +1,14 @@
-{ buildDunePackage, archi, async }:
+{
+  buildDunePackage,
+  archi,
+  async,
+}:
 
 buildDunePackage {
   pname = "archi-async";
   inherit (archi) version src;
-  propagatedBuildInputs = [ archi async ];
+  propagatedBuildInputs = [
+    archi
+    async
+  ];
 }

--- a/ocaml/archi/default.nix
+++ b/ocaml/archi/default.nix
@@ -1,4 +1,9 @@
-{ fetchFromGitHub, buildDunePackage, alcotest, hmap }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  alcotest,
+  hmap,
+}:
 
 buildDunePackage {
   pname = "archi";

--- a/ocaml/archi/eio.nix
+++ b/ocaml/archi/eio.nix
@@ -1,7 +1,14 @@
-{ buildDunePackage, archi, eio }:
+{
+  buildDunePackage,
+  archi,
+  eio,
+}:
 
 buildDunePackage {
   pname = "archi-eio";
   inherit (archi) version src;
-  propagatedBuildInputs = [ archi eio ];
+  propagatedBuildInputs = [
+    archi
+    eio
+  ];
 }

--- a/ocaml/archi/lwt.nix
+++ b/ocaml/archi/lwt.nix
@@ -1,7 +1,14 @@
-{ buildDunePackage, archi, lwt }:
+{
+  buildDunePackage,
+  archi,
+  lwt,
+}:
 
 buildDunePackage {
   pname = "archi-lwt";
   inherit (archi) version src;
-  propagatedBuildInputs = [ archi lwt ];
+  propagatedBuildInputs = [
+    archi
+    lwt
+  ];
 }

--- a/ocaml/binaryen/default.nix
+++ b/ocaml/binaryen/default.nix
@@ -1,4 +1,11 @@
-{ lib, pkgs, fetchFromGitHub, buildDunePackage, dune-configurator, js_of_ocaml }:
+{
+  lib,
+  pkgs,
+  fetchFromGitHub,
+  buildDunePackage,
+  dune-configurator,
+  js_of_ocaml,
+}:
 
 buildDunePackage rec {
   pname = "binaryen";

--- a/ocaml/camlp5/default.nix
+++ b/ocaml/camlp5/default.nix
@@ -1,20 +1,20 @@
-{ stdenv
-, fetchFromGitHub
-, ocaml
-, findlib
-, camlp-streams
-, fmt
-, fix
-, lib
-, perl
-, bos
-, ocaml_pcre
-, re
-, rresult
+{
+  stdenv,
+  fetchFromGitHub,
+  ocaml,
+  findlib,
+  camlp-streams,
+  fmt,
+  fix,
+  lib,
+  perl,
+  bos,
+  ocaml_pcre,
+  re,
+  rresult,
 }:
 
-stdenv.mkDerivation
-{
+stdenv.mkDerivation {
   pname = "camlp5";
   version = "8.02.00";
 
@@ -25,7 +25,10 @@ stdenv.mkDerivation
     hash = "sha256-hu/279gBvUc7Z4jM6EHiar6Wm4vjkGXl+7bxowj+vlM=";
   };
 
-  nativeBuildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [
+    ocaml
+    findlib
+  ];
   buildInputs = [ perl ];
   propagatedBuildInputs = [
     bos

--- a/ocaml/conan/cli.nix
+++ b/ocaml/conan/cli.nix
@@ -1,7 +1,18 @@
-{ buildDunePackage, conan, conan-database, conan-unix, dune-site }:
+{
+  buildDunePackage,
+  conan,
+  conan-database,
+  conan-unix,
+  dune-site,
+}:
 
 buildDunePackage {
   inherit (conan) version src;
   pname = "conan-cli";
-  propagatedBuildInputs = [ conan conan-database conan-unix dune-site ];
+  propagatedBuildInputs = [
+    conan
+    conan-database
+    conan-unix
+    dune-site
+  ];
 }

--- a/ocaml/conan/default.nix
+++ b/ocaml/conan/default.nix
@@ -1,30 +1,35 @@
-{ buildDunePackage
-, alcotest
-, crowbar
-, fmt
-, rresult
-, mirage
-, mirage-unix
-, mirage-bootvar-unix
-, mirage-console-unix
-, mirage-clock-unix
-, mirage-logs
-, mirage-runtime
-, re
-, uutf
-, ptime
+{
+  buildDunePackage,
+  alcotest,
+  crowbar,
+  fmt,
+  rresult,
+  mirage,
+  mirage-unix,
+  mirage-bootvar-unix,
+  mirage-console-unix,
+  mirage-clock-unix,
+  mirage-logs,
+  mirage-runtime,
+  re,
+  uutf,
+  ptime,
 }:
 
 buildDunePackage {
   pname = "conan";
   version = "0.0.1";
   src = builtins.fetchurl {
-    url = https://github.com/mirage/conan/releases/download/v0.0.5/conan-0.0.5.tbz;
+    url = "https://github.com/mirage/conan/releases/download/v0.0.5/conan-0.0.5.tbz";
     sha256 = "13zvay99i8pbzi2d1c24ppd9z9szj6nhdy7g6n8bx9zgl6k9rbh4";
   };
 
   doCheck = false;
-  propagatedBuildInputs = [ re uutf ptime ];
+  propagatedBuildInputs = [
+    re
+    uutf
+    ptime
+  ];
   checkInputs = [
     alcotest
     crowbar

--- a/ocaml/conan/lwt.nix
+++ b/ocaml/conan/lwt.nix
@@ -1,7 +1,16 @@
-{ buildDunePackage, conan, lwt, bigstringaf }:
+{
+  buildDunePackage,
+  conan,
+  lwt,
+  bigstringaf,
+}:
 
 buildDunePackage {
   pname = "conan-lwt";
   inherit (conan) version src;
-  propagatedBuildInputs = [ conan lwt bigstringaf ];
+  propagatedBuildInputs = [
+    conan
+    lwt
+    bigstringaf
+  ];
 }

--- a/ocaml/cookie/default.nix
+++ b/ocaml/cookie/default.nix
@@ -1,4 +1,11 @@
-{ fetchFromGitHub, lib, buildDunePackage, uri, ptime, astring }:
+{
+  fetchFromGitHub,
+  lib,
+  buildDunePackage,
+  uri,
+  ptime,
+  astring,
+}:
 
 buildDunePackage {
   pname = "cookie";
@@ -11,7 +18,11 @@ buildDunePackage {
     sha256 = "sha256-souA7AOa59tu4Tdh7UEZm67YAz+1aR3asRZxk35WcHA=";
   };
 
-  propagatedBuildInputs = [ uri ptime astring ];
+  propagatedBuildInputs = [
+    uri
+    ptime
+    astring
+  ];
 
   meta = {
     description = "Cookie parsing and serialization for OCaml";

--- a/ocaml/cookie/session-lwt.nix
+++ b/ocaml/cookie/session-lwt.nix
@@ -1,10 +1,19 @@
-{ lib, buildDunePackage, cookie, session-cookie, lwt }:
+{
+  lib,
+  buildDunePackage,
+  cookie,
+  session-cookie,
+  lwt,
+}:
 
 buildDunePackage {
   pname = "session-cookie-lwt";
   inherit (cookie) src version;
 
-  propagatedBuildInputs = [ session-cookie lwt ];
+  propagatedBuildInputs = [
+    session-cookie
+    lwt
+  ];
 
   postPatch = ''
     substituteInPlace session-cookie-lwt/dune --replace-fail "result" ""

--- a/ocaml/cookie/session.nix
+++ b/ocaml/cookie/session.nix
@@ -1,10 +1,18 @@
-{ lib, buildDunePackage, cookie, session }:
+{
+  lib,
+  buildDunePackage,
+  cookie,
+  session,
+}:
 
 buildDunePackage {
   pname = "session-cookie";
   inherit (cookie) src version;
 
-  propagatedBuildInputs = [ cookie session ];
+  propagatedBuildInputs = [
+    cookie
+    session
+  ];
 
   meta = {
     description = "Session handling based on Cookie parsing and serialization for OCaml";

--- a/ocaml/dataloader/default.nix
+++ b/ocaml/dataloader/default.nix
@@ -5,7 +5,7 @@ buildDunePackage {
   version = "0.0.1-dev";
 
   src = builtins.fetchurl {
-    url = https://github.com/anmonteiro/ocaml-dataloader/archive/c2e6d7d057d4453b36511a5d293e9ab502755484.tar.gz;
+    url = "https://github.com/anmonteiro/ocaml-dataloader/archive/c2e6d7d057d4453b36511a5d293e9ab502755484.tar.gz";
     sha256 = "1w4wnwx854358wymdd26xkccyl3lql4j3k3lbr57bd7rv5xpplwq";
   };
 }

--- a/ocaml/dataloader/lwt.nix
+++ b/ocaml/dataloader/lwt.nix
@@ -1,8 +1,15 @@
-{ buildDunePackage, dataloader, lwt }:
+{
+  buildDunePackage,
+  dataloader,
+  lwt,
+}:
 
 buildDunePackage {
   pname = "dataloader-lwt";
   inherit (dataloader) version src;
 
-  propagatedBuildInputs = [ dataloader lwt ];
+  propagatedBuildInputs = [
+    dataloader
+    lwt
+  ];
 }

--- a/ocaml/decimal/default.nix
+++ b/ocaml/decimal/default.nix
@@ -4,7 +4,7 @@ buildDunePackage {
   pname = "decimal";
   version = "1.0.0";
   src = builtins.fetchurl {
-    url = https://github.com/yawaramin/ocaml-decimal/releases/download/v1.0.1/decimal-1.0.1.tbz;
+    url = "https://github.com/yawaramin/ocaml-decimal/releases/download/v1.0.1/decimal-1.0.1.tbz";
     sha256 = "1yagcm207s32cqp9jm3460p1ra1fa7l2zfp65gcsy0bkciyxi5wj";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1,61 +1,62 @@
-{ nixpkgs
-, autoconf
-, autoreconfHook
-, bzip2
-, automake
-, bash
-, buildPackages
-, cmake
-, fetchpatch
-, fetchFromBitbucket
-, fetchFromGitHub
-, fetchFromGitLab
-, fzf
-, git
-, libgsl
-, kerberos
-, lib
-, libargon2
-, libcxx
-, libvirt
-, libpq
-, libev-oc
-, libffi-oc
-, linuxHeaders
-, llvmPackages
-, lz4-oc
-, net-snmp
-, nodejs_latest
-, pcre-oc
-, sqlite-oc
-, makeWrapper
-, darwin
-, stdenv
-, super-opaline
-, gmp-oc
-, openssl-oc
-, oniguruma-lib
-, pam
-, pkg-config
-, python3
-, python3Packages
-, lmdb
-, curl
-, libsodium
-, cairo
-, gtk2
-, rdkafka-oc
-, zlib-oc
-, unzip
-, freetype
-, fontconfig
-, libxkbcommon
-, libxcb
-, xorg
-, zstd-oc
-, mercurial
-, gnutar
-, coreutils
+{
+  nixpkgs,
+  autoconf,
+  autoreconfHook,
+  bzip2,
+  automake,
+  bash,
+  buildPackages,
+  cmake,
+  fetchpatch,
+  fetchFromBitbucket,
+  fetchFromGitHub,
+  fetchFromGitLab,
+  fzf,
+  git,
+  libgsl,
+  kerberos,
+  lib,
+  libargon2,
+  libcxx,
+  libvirt,
+  libpq,
+  libev-oc,
+  libffi-oc,
+  linuxHeaders,
+  llvmPackages,
+  lz4-oc,
+  net-snmp,
+  nodejs_latest,
+  pcre-oc,
+  sqlite-oc,
+  makeWrapper,
+  darwin,
+  stdenv,
+  super-opaline,
+  gmp-oc,
+  openssl-oc,
+  oniguruma-lib,
+  pam,
+  pkg-config,
+  python3,
+  python3Packages,
+  lmdb,
+  curl,
+  libsodium,
+  cairo,
+  gtk2,
+  rdkafka-oc,
+  zlib-oc,
+  unzip,
+  freetype,
+  fontconfig,
+  libxkbcommon,
+  libxcb,
+  xorg,
+  zstd-oc,
+  mercurial,
+  gnutar,
+  coreutils,
 }:
 
 oself: osuper:
@@ -64,23 +65,29 @@ let
   nativeCairo = cairo;
   nativeGit = git;
   lmdb-pkg = lmdb;
-  disableTests = d: d.overrideAttrs (_: { doCheck = false; });
-  addBase = p: p.overrideAttrs (o: {
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ oself.base ];
-  });
-  addStdio = p: p.overrideAttrs (o: {
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ oself.stdio ];
-  });
+  disableTests =
+    d:
+    d.overrideAttrs (_: {
+      doCheck = false;
+    });
+  addBase =
+    p:
+    p.overrideAttrs (o: {
+      propagatedBuildInputs = o.propagatedBuildInputs ++ [ oself.base ];
+    });
+  addStdio =
+    p:
+    p.overrideAttrs (o: {
+      propagatedBuildInputs = o.propagatedBuildInputs ++ [ oself.stdio ];
+    });
 
   # Jane Street
   janePackage_0_16 =
-    oself.callPackage "${nixpkgs}/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix" {
-      defaultVersion = "0.16.0";
-    };
+    oself.callPackage "${nixpkgs}/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix"
+      { defaultVersion = "0.16.0"; };
   janePackage_0_17 =
-    oself.callPackage "${nixpkgs}/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix" {
-      defaultVersion = "0.17.0";
-    };
+    oself.callPackage "${nixpkgs}/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix"
+      { defaultVersion = "0.17.0"; };
 
   janeStreet_0_16 = import ./janestreet-0.16.nix {
     self = oself;
@@ -96,7 +103,8 @@ let
       linuxHeaders
       nixpkgs
       pam
-      net-snmp;
+      net-snmp
+      ;
     zstd = zstd-oc;
   };
   janeStreet_0_17 = import ./janestreet-0.17.nix {
@@ -113,24 +121,18 @@ let
       linuxHeaders
       nixpkgs
       pam
-      net-snmp;
+      net-snmp
+      ;
     zstd = zstd-oc;
   };
-
 
 in
 
 with oself;
 
 {
-  janePackage =
-    if lib.versionAtLeast ocaml.version "5.1" then
-      janePackage_0_17
-    else janePackage_0_16;
-  janeStreet =
-    if lib.versionAtLeast ocaml.version "5.1" then
-      janeStreet_0_17
-    else janeStreet_0_16;
+  janePackage = if lib.versionAtLeast ocaml.version "5.1" then janePackage_0_17 else janePackage_0_16;
+  janeStreet = if lib.versionAtLeast ocaml.version "5.1" then janeStreet_0_17 else janeStreet_0_16;
 
   alcotest = osuper.alcotest.overrideAttrs (_: {
     # https://github.com/mirage/alcotest/pull/402
@@ -157,26 +159,39 @@ with oself;
     pname = "ansi";
     version = "0.7.0";
     src = builtins.fetchurl {
-      url = https://github.com/ocurrent/ansi/releases/download/0.7.0/ansi-0.7.0.tbz;
+      url = "https://github.com/ocurrent/ansi/releases/download/0.7.0/ansi-0.7.0.tbz";
       sha256 = "1958wiwba3699qxyhrqy30g2b7m82i2avnaa38lx3izb3q9nlav7";
     };
-    propagatedBuildInputs = [ fmt astring tyxml ];
+    propagatedBuildInputs = [
+      fmt
+      astring
+      tyxml
+    ];
   };
 
   argon2 = buildDunePackage {
     pname = "argon2";
     version = "1.0.2";
     src = builtins.fetchurl {
-      url = https://github.com/Khady/ocaml-argon2/releases/download/1.0.2/argon2-1.0.2.tbz;
+      url = "https://github.com/Khady/ocaml-argon2/releases/download/1.0.2/argon2-1.0.2.tbz";
       sha256 = "01gjs2b0nzyjfjz1aay8f209jlpr1880qizk96kn8kqgi5bhwfrl";
     };
-    propagatedBuildInputs = [ ctypes dune-configurator ctypes-foreign result libargon2 ];
+    propagatedBuildInputs = [
+      ctypes
+      dune-configurator
+      ctypes-foreign
+      result
+      libargon2
+    ];
   };
 
   atdts = buildDunePackage {
     pname = "atdts";
     inherit (atdgen-codec-runtime) version src;
-    propagatedBuildInputs = [ atd cmdliner ];
+    propagatedBuildInputs = [
+      atd
+      cmdliner
+    ];
   };
 
   archi = callPackage ./archi { };
@@ -186,10 +201,14 @@ with oself;
     pname = "async-uri";
     version = "0.4.0";
     src = builtins.fetchurl {
-      url = https://github.com/vbmithr/async-uri/releases/download/0.4.0/async-uri-0.4.0.tbz;
+      url = "https://github.com/vbmithr/async-uri/releases/download/0.4.0/async-uri-0.4.0.tbz";
       sha256 = "16hz01g42aj0zvjqjadg3x4j1jvd279c4vbc2f6zcjvm0dzmlbs0";
     };
-    propagatedBuildInputs = [ async_ssl uri uri-sexp ];
+    propagatedBuildInputs = [
+      async_ssl
+      uri
+      uri-sexp
+    ];
   };
 
   multiformats = buildDunePackage {
@@ -201,28 +220,32 @@ with oself;
       rev = "380208ded45bc33cfadc5de6709846b3a8b84615";
       sha256 = "sha256-OuGBf8LdoiuC9OkTObwP5sgT6LXVtdTCsPbg8T1OHt8=";
     };
-    propagatedBuildInputs = [ ppx_jane ppx_deriving core_kernel stdint digestif ];
+    propagatedBuildInputs = [
+      ppx_jane
+      ppx_deriving
+      core_kernel
+      stdint
+      digestif
+    ];
   };
 
   backoff = buildDunePackage {
     pname = "backoff";
     version = "0.1.0";
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-multicore/backoff/releases/download/0.1.0/backoff-0.1.0.tbz;
+      url = "https://github.com/ocaml-multicore/backoff/releases/download/0.1.0/backoff-0.1.0.tbz";
       sha256 = "0013ikss0nq6yi8yjpkx67qnnpb3g6l8m386vqsd344y49war90i";
     };
   };
 
-  bap = callPackage "${nixpkgs}/pkgs/development/ocaml-modules/bap" {
-    inherit (llvmPackages) llvm;
-  };
+  bap = callPackage "${nixpkgs}/pkgs/development/ocaml-modules/bap" { inherit (llvmPackages) llvm; };
   ppx_bap = callPackage "${nixpkgs}/pkgs/development/ocaml-modules/ppx_bap" { };
 
   base32 = buildDunePackage {
     pname = "base32";
     version = "dev";
     src = builtins.fetchurl {
-      url = https://gitlab.com/public.dream/dromedar/ocaml-base32/-/archive/main/ocaml-base32-main.tar.gz;
+      url = "https://gitlab.com/public.dream/dromedar/ocaml-base32/-/archive/main/ocaml-base32-main.tar.gz";
       sha256 = "0babid89q3vpgvq10cw233k9xzblsk89vh02ymviblgfjhm92lk5";
     };
   };
@@ -232,7 +255,7 @@ with oself;
     version = "0.5.0";
 
     src = builtins.fetchurl {
-      url = https://github.com/mirage/bechamel/releases/download/v0.5.0/bechamel-0.5.0.tbz;
+      url = "https://github.com/mirage/bechamel/releases/download/v0.5.0/bechamel-0.5.0.tbz";
       sha256 = "0s68bsfa4j8y69pfxlylc9qrfkgrifc849rmcyh2x9jz752ab6ig";
     };
     propagatedBuildInputs = [ fmt ];
@@ -263,7 +286,7 @@ with oself;
 
   bigarray-compat = osuper.bigarray-compat.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/bigarray-compat/releases/download/v1.1.0/bigarray-compat-1.1.0.tbz;
+      url = "https://github.com/mirage/bigarray-compat/releases/download/v1.1.0/bigarray-compat-1.1.0.tbz";
       sha256 = "1m8q6ywik6h0wrdgv8ah2s617y37n1gdj4qvc86yi12winj6ji23";
     };
   });
@@ -288,7 +311,10 @@ with oself;
 
   bisect_ppx = osuper.bisect_ppx.overrideAttrs (_: {
     buildInputs = [ ];
-    propagatedBuildInputs = [ ppxlib cmdliner ];
+    propagatedBuildInputs = [
+      ppxlib
+      cmdliner
+    ];
   });
 
   bos = osuper.bos.overrideAttrs (_: {
@@ -311,7 +337,10 @@ with oself;
       sha256 = "sha256-jBFEkLN2fbC3LxTu7C0iuhvNg64duuckBHWZoBxrV/U=";
     };
 
-    autoreconfFlags = [ "-I" "." ];
+    autoreconfFlags = [
+      "-I"
+      "."
+    ];
 
     nativeBuildInputs = [
       autoreconfHook
@@ -319,9 +348,7 @@ with oself;
       findlib
     ];
 
-    propagatedBuildInputs = [
-      bzip2
-    ];
+    propagatedBuildInputs = [ bzip2 ];
 
     strictDeps = true;
 
@@ -371,7 +398,10 @@ with oself;
   };
 
   camomile = osuper.camomile.overrideAttrs (o: {
-    propagatedBuildInputs = [ camlp-streams dune-site ];
+    propagatedBuildInputs = [
+      camlp-streams
+      dune-site
+    ];
     checkInputs = [ stdlib-random ];
     dontConfigure = true;
     doCheck = true;
@@ -380,7 +410,7 @@ with oself;
 
   coin = osuper.coin.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/coin/releases/download/v0.1.4/coin-0.1.4.tbz;
+      url = "https://github.com/mirage/coin/releases/download/v0.1.4/coin-0.1.4.tbz";
       sha256 = "0069qqswd1ik5ay3d5q1v1pz0ql31kblfsnv0ax0z8jwvacp3ack";
     };
   });
@@ -394,9 +424,18 @@ with oself;
   cairo2-gtk = buildDunePackage {
     pname = "cairo2-gtk";
     inherit (cairo2) version src;
-    nativeBuildInputs = [ nativeCairo pkg-config ];
-    buildInputs = [ dune-configurator gtk2.dev ];
-    propagatedBuildInputs = [ cairo2 lablgtk ];
+    nativeBuildInputs = [
+      nativeCairo
+      pkg-config
+    ];
+    buildInputs = [
+      dune-configurator
+      gtk2.dev
+    ];
+    propagatedBuildInputs = [
+      cairo2
+      lablgtk
+    ];
   };
 
   cmarkit = osuper.cmarkit.overrideAttrs (_: {
@@ -406,10 +445,15 @@ with oself;
   caqti = osuper.caqti.overrideAttrs (o: {
     version = "2.1.1";
     src = builtins.fetchurl {
-      url = https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz;
+      url = "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz";
       sha256 = "02h9hfak85r6i80v7cc3h973zz2zs55cwchqzhbijr7285gm6fj8";
     };
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ ipaddr mtime dune-site lwt-dllist ];
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [
+      ipaddr
+      mtime
+      dune-site
+      lwt-dllist
+    ];
     doCheck = false;
   });
 
@@ -421,10 +465,9 @@ with oself;
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ findlib ];
   });
 
-
   carton = osuper.carton.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/robur-coop/carton/releases/download/0.7.2/carton-0.7.2.tbz;
+      url = "https://github.com/robur-coop/carton/releases/download/0.7.2/carton-0.7.2.tbz";
       sha256 = "14mndljn8a375mgb4r83ynqa17kca5sxkj8gv5ycxn2d8iamhya6";
     };
     patches = [ ];
@@ -434,7 +477,7 @@ with oself;
     pname = "clz";
     version = "0.1.0";
     src = builtins.fetchurl {
-      url = https://github.com/mseri/ocaml-clz/releases/download/0.1.0/clz-0.1.0.tbz;
+      url = "https://github.com/mseri/ocaml-clz/releases/download/0.1.0/clz-0.1.0.tbz";
       sha256 = "08n6qf5g470qx8xhvaizd061qcb3bndvb3c8b9p8cg98n3jpms4q";
     };
     propagatedBuildInputs = [
@@ -450,37 +493,57 @@ with oself;
     pname = "colombe";
     version = "0.8.1";
     src = builtins.fetchurl {
-      url = https://github.com/mirage/colombe/releases/download/v0.8.1/colombe-0.8.1.tbz;
+      url = "https://github.com/mirage/colombe/releases/download/v0.8.1/colombe-0.8.1.tbz";
       sha256 = "0c4mplcdx2dw82f1lzhiw79bfa7krad0fgyqsxd4virvb4a6703q";
     };
-    propagatedBuildInputs = [ ipaddr fmt angstrom emile ];
+    propagatedBuildInputs = [
+      ipaddr
+      fmt
+      angstrom
+      emile
+    ];
   };
   sendmail = buildDunePackage {
     pname = "sendmail";
     inherit (colombe) version src;
-    propagatedBuildInputs = [ colombe tls ke rresult base64 ];
+    propagatedBuildInputs = [
+      colombe
+      tls
+      ke
+      rresult
+      base64
+    ];
   };
   sendmail-lwt = buildDunePackage {
     pname = "sendmail-lwt";
     inherit (colombe) version src;
-    propagatedBuildInputs = [ sendmail lwt tls-lwt ];
+    propagatedBuildInputs = [
+      sendmail
+      lwt
+      tls-lwt
+    ];
   };
 
   received = buildDunePackage {
     pname = "received";
     version = "0.5.2";
     src = builtins.fetchurl {
-      url = https://github.com/mirage/colombe/releases/download/received-v0.5.2/colombe-received-v0.5.2.tbz;
+      url = "https://github.com/mirage/colombe/releases/download/received-v0.5.2/colombe-received-v0.5.2.tbz";
       sha256 = "1gig5kpkp9rfgnvkrgm7n89vdrkjkbbzpd7xcf90dja8mkn7d606";
     };
-    propagatedBuildInputs = [ angstrom emile mrmime colombe ];
+    propagatedBuildInputs = [
+      angstrom
+      emile
+      mrmime
+      colombe
+    ];
   };
 
   http = buildDunePackage {
     pname = "http";
     version = "n/a";
     src = builtins.fetchurl {
-      url = https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_beta2/cohttp-v6.0.0_beta2.tbz;
+      url = "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_beta2/cohttp-v6.0.0_beta2.tbz";
       sha256 = "05xh4hvjy90mqslwd0q6sa2h99f0p7vb4cf0f911nhc0sn5yrv4h";
     };
     doCheck = false;
@@ -488,12 +551,14 @@ with oself;
 
   cohttp = osuper.cohttp.overrideAttrs (o: {
     inherit (http) src version;
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ http logs ];
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [
+      http
+      logs
+    ];
     doCheck = false;
   });
   cohttp-lwt-jsoo = disableTests osuper.cohttp-lwt-jsoo;
   cohttp-top = disableTests osuper.cohttp-top;
-
 
   conan = callPackage ./conan { };
   conan-lwt = callPackage ./conan/lwt.nix { };
@@ -503,7 +568,7 @@ with oself;
 
   conduit = osuper.conduit.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/ocaml-conduit/releases/download/v6.2.3/conduit-6.2.3.tbz;
+      url = "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.3/conduit-6.2.3.tbz";
       sha256 = "0y9y89jafndxr8spnindqa97w0p1asix0k88sr3z5cc52jxq8iis";
     };
   });
@@ -514,11 +579,11 @@ with oself;
   confero =
     let
       allkeys_txt = builtins.fetchurl {
-        url = https://www.unicode.org/Public/UCA/15.0.0/allkeys.txt;
+        url = "https://www.unicode.org/Public/UCA/15.0.0/allkeys.txt";
         sha256 = "0xvmfw9sgcmaqs33w31vcmgqabkb2ls146pb9hvidbfl4isj49qq";
       };
       collationTest = builtins.fetchurl {
-        url = https://www.unicode.org/Public/UCA/15.0.0/CollationTest.zip;
+        url = "https://www.unicode.org/Public/UCA/15.0.0/CollationTest.zip";
         sha256 = "013w1s3nwalyid9n092my9ri1j0kzc35bphzbrdcaz6l22ph81f3";
       };
     in
@@ -605,7 +670,10 @@ with oself;
   decoders-yojson = buildDunePackage {
     pname = "decoders-yojson";
     inherit (oself.decoders) src version;
-    propagatedBuildInputs = [ decoders yojson ];
+    propagatedBuildInputs = [
+      decoders
+      yojson
+    ];
   };
 
   rfc1951 = buildDunePackage {
@@ -616,7 +684,7 @@ with oself;
 
   digestif = osuper.digestif.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/digestif/releases/download/v1.2.0/digestif-1.2.0.tbz;
+      url = "https://github.com/mirage/digestif/releases/download/v1.2.0/digestif-1.2.0.tbz";
       sha256 = "0255nb9wjpkdh9v0w9p5y5s79zcqcdg3wsw0cx9nd6i7zv56h0f3";
     };
     postPatch = ''
@@ -626,7 +694,7 @@ with oself;
 
   dns = osuper.dns.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz;
+      url = "https://github.com/mirage/ocaml-dns/releases/download/v8.0.0/dns-8.0.0.tbz";
       sha256 = "0kl5v0kwkc4l4yay52iz3f9wafijca0cm13cn9d539xzqldhd0h8";
     };
   });
@@ -639,10 +707,13 @@ with oself;
 
   domainslib = osuper.domainslib.overrideAttrs (o: {
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-multicore/domainslib/releases/download/0.5.1/domainslib-0.5.1.tbz;
+      url = "https://github.com/ocaml-multicore/domainslib/releases/download/0.5.1/domainslib-0.5.1.tbz";
       sha256 = "00axhfwyyjzqvsb3ff3giy0nswdyw2jzrmn56sbl96frlpxmvhi8";
     };
-    propagatedBuildInputs = [ domain-local-await saturn ];
+    propagatedBuildInputs = [
+      domain-local-await
+      saturn
+    ];
     checkInputs = [
       qcheck
       qcheck-multicoretests-util
@@ -656,7 +727,9 @@ with oself;
   dream-pure = callPackage ./dream/pure.nix { };
   dream-httpaf = callPackage ./dream/httpaf.nix { };
   dream =
-    let mf = multipart_form.override { upstream = true; }; in
+    let
+      mf = multipart_form.override { upstream = true; };
+    in
     callPackage ./dream {
       multipart_form = mf;
       multipart_form-lwt = multipart_form-lwt.override { multipart_form = mf; };
@@ -668,25 +741,25 @@ with oself;
 
   dune_1 = dune;
 
-  dune =
-    if lib.versionOlder "4.06" ocaml.version
-    then oself.dune_2
-    else osuper.dune_1;
+  dune = if lib.versionOlder "4.06" ocaml.version then oself.dune_2 else osuper.dune_1;
 
   dune_2 = dune_3;
 
   dune_3 = osuper.dune_3.overrideAttrs (o: {
     version = "3.16.0";
     src = builtins.fetchurl {
-      url = https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz;
+      url = "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz";
       sha256 = "19mxz5s1wisnh0dqryryi3ak4jvkkwrp8kf308g158wcj7kxv0al";
     };
     nativeBuildInputs = o.nativeBuildInputs ++ [ makeWrapper ];
     postFixup =
-      if stdenv.isDarwin then ''
-        wrapProgram $out/bin/dune \
-          --suffix PATH : "${darwin.sigtool}/bin"
-      '' else "";
+      if stdenv.isDarwin then
+        ''
+          wrapProgram $out/bin/dune \
+            --suffix PATH : "${darwin.sigtool}/bin"
+        ''
+      else
+        "";
   });
 
   dune-build-info = osuper.dune-build-info.overrideAttrs (_: {
@@ -702,7 +775,13 @@ with oself;
   });
   dune-rpc = osuper.dune-rpc.overrideAttrs (_: {
     buildInputs = [ ];
-    propagatedBuildInputs = [ stdune ordering pp xdg dyn ];
+    propagatedBuildInputs = [
+      stdune
+      ordering
+      pp
+      xdg
+      dyn
+    ];
     inherit (dyn) preBuild;
   });
   dune-rpc-lwt = callPackage ./dune/rpc-lwt.nix { };
@@ -711,7 +790,10 @@ with oself;
     preBuild = "rm -rf vendor/csexp vendor/pp";
   });
   dune-action-plugin = osuper.dune-action-plugin.overrideAttrs (o: {
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp dune-rpc ];
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [
+      pp
+      dune-rpc
+    ];
     inherit (dyn) preBuild;
   });
   dune-glob = osuper.dune-glob.overrideAttrs (o: {
@@ -727,13 +809,21 @@ with oself;
     inherit (dyn) preBuild;
   });
   fiber = osuper.fiber.overrideAttrs (o: {
-    propagatedBuildInputs = [ dyn stdune ];
+    propagatedBuildInputs = [
+      dyn
+      stdune
+    ];
     preBuild = "";
   });
   fiber-lwt = buildDunePackage {
     pname = "fiber-lwt";
     inherit (fiber) version src;
-    propagatedBuildInputs = [ pp fiber lwt stdune ];
+    propagatedBuildInputs = [
+      pp
+      fiber
+      lwt
+      stdune
+    ];
   };
   stdune = osuper.stdune.overrideAttrs (o: {
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp ];
@@ -743,19 +833,32 @@ with oself;
     inherit (dyn) preBuild;
   });
 
-  dune-release = osuper.dune-release.overrideAttrs (o:
+  dune-release = osuper.dune-release.overrideAttrs (
+    o:
     let
-      runtimeInputs =
-        [ opam findlib nativeGit mercurial bzip2 gnutar coreutils ];
+      runtimeInputs = [
+        opam
+        findlib
+        nativeGit
+        mercurial
+        bzip2
+        gnutar
+        coreutils
+      ];
     in
     {
-      nativeBuildInputs = [ makeWrapper ocaml dune ] ++ runtimeInputs;
+      nativeBuildInputs = [
+        makeWrapper
+        ocaml
+        dune
+      ] ++ runtimeInputs;
       checkInputs = [ alcotest ] ++ runtimeInputs;
       preFixup = ''
         wrapProgram $out/bin/dune-release \
           --prefix PATH : "${lib.makeBinPath runtimeInputs}"
       '';
-    });
+    }
+  );
 
   ezgzip = buildDunePackage rec {
     pname = "ezgzip";
@@ -767,7 +870,12 @@ with oself;
       sha256 = "sha256-OQ4JT1pYkeJbi8iMGpcFp8j0DawZCguFfWQmJCwgUXQ=";
     };
 
-    propagatedBuildInputs = [ rresult astring ocplib-endian camlzip ];
+    propagatedBuildInputs = [
+      rresult
+      astring
+      ocplib-endian
+      camlzip
+    ];
   };
 
   facile = buildDunePackage rec {
@@ -794,14 +902,13 @@ with oself;
 
   ffmpeg-avdevice = osuper.ffmpeg-avdevice.overrideAttrs (o: {
     propagatedBuildInputs =
-      o.propagatedBuildInputs ++
-      lib.optionals stdenv.isDarwin
-        (with darwin.apple_sdk.frameworks; [ AVFoundation ]);
+      o.propagatedBuildInputs
+      ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ AVFoundation ]);
   });
 
   fix = osuper.fix.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://anmonteiro.s3.eu-west-3.amazonaws.com/fix-20230505.tar.gz;
+      url = "https://anmonteiro.s3.eu-west-3.amazonaws.com/fix-20230505.tar.gz";
       sha256 = "06q8h71q9j1jcr1gprr1ykigb9l4y6zil6c7i9p0b0f4qkyhcvrj";
     };
   });
@@ -820,7 +927,10 @@ with oself;
       sha256 = "18wpyxblz9jh5bfp0hpffnd0q8cq1b0dqp0f36vhqydfknlnpx8y";
     };
 
-    nativeBuildInputs = [ ocaml findlib ];
+    nativeBuildInputs = [
+      ocaml
+      findlib
+    ];
     strictDeps = true;
     installTargets = [ "ocamlfind-install" ];
     createFindlibDestdir = true;
@@ -837,12 +947,15 @@ with oself;
   };
 
   gettext-camomile = osuper.gettext-camomile.overrideAttrs (_: {
-    propagatedBuildInputs = [ camomile ocaml_gettext ];
+    propagatedBuildInputs = [
+      camomile
+      ocaml_gettext
+    ];
   });
 
   git = osuper.git.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/ocaml-git/releases/download/3.16.1/git-3.16.1.tbz;
+      url = "https://github.com/mirage/ocaml-git/releases/download/3.16.1/git-3.16.1.tbz";
       sha256 = "00s8ja50mqka6wm6z2hxry78647wc5gcdkfrqr42ykcyrp6bsdf0";
     };
     postPatch = "";
@@ -854,9 +967,7 @@ with oself;
   gluten-mirage = callPackage ./gluten/mirage.nix { };
   gluten-async = callPackage ./gluten/async.nix { };
   gluten-eio =
-    if lib.versionAtLeast ocaml.version "5.0" then
-      callPackage ./gluten/eio.nix { }
-    else null;
+    if lib.versionAtLeast ocaml.version "5.0" then callPackage ./gluten/eio.nix { } else null;
 
   graphql_parser = callPackage ./graphql/parser.nix { };
   graphql = callPackage ./graphql { };
@@ -866,12 +977,16 @@ with oself;
   graphql_ppx = callPackage ./graphql_ppx { };
   graphql-cohttp = osuper.graphql-cohttp.overrideAttrs (o: {
     # https://github.com/NixOS/nixpkgs/pull/170664
-    nativeBuildInputs = [ ocaml dune findlib crunch ];
+    nativeBuildInputs = [
+      ocaml
+      dune
+      findlib
+      crunch
+    ];
   });
 
   gstreamer = osuper.gstreamer.overrideAttrs (o: {
-    buildInputs = o.buildInputs ++
-    lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ];
+    buildInputs = o.buildInputs ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ];
   });
 
   hacl-star = osuper.hacl-star.overrideAttrs (_: {
@@ -884,7 +999,7 @@ with oself;
 
   happy-eyeballs = osuper.happy-eyeballs.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/robur-coop/happy-eyeballs/releases/download/v1.1.0/happy-eyeballs-1.1.0.tbz;
+      url = "https://github.com/robur-coop/happy-eyeballs/releases/download/v1.1.0/happy-eyeballs-1.1.0.tbz";
       sha256 = "1hfw9xdi04jgg30d837jpblmpwlcmdnncz4w6fybgxgcw6wp0rnf";
     };
   });
@@ -930,23 +1045,29 @@ with oself;
 
     dontUseCmakeConfigure = true;
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-multicore/hdr_histogram_ocaml/releases/download/v0.0.3/hdr_histogram-0.0.3.tbz;
+      url = "https://github.com/ocaml-multicore/hdr_histogram_ocaml/releases/download/v0.0.3/hdr_histogram-0.0.3.tbz";
       sha256 = "05d4w4a5x9kgyx02px2biggkbs8id4xlij2w7gfj663ppc1jr49d";
     };
 
     nativeBuildInputs = [ cmake ];
-    propagatedBuildInputs = [ zlib-oc ctypes ];
+    propagatedBuildInputs = [
+      zlib-oc
+      ctypes
+    ];
   };
 
   hilite = buildDunePackage {
     pname = "hilite";
     version = "0.5.0";
     src = builtins.fetchurl {
-      url = https://github.com/patricoferris/hilite/releases/download/v0.5.0/hilite-0.5.0.tbz;
+      url = "https://github.com/patricoferris/hilite/releases/download/v0.5.0/hilite-0.5.0.tbz";
       sha256 = "092q0lbpjjbv9szhp9lv0jczf5rr1gqv0wfynv3w9gqhpw5mb2j9";
     };
 
-    propagatedBuildInputs = [ cmarkit textmate-language ];
+    propagatedBuildInputs = [
+      cmarkit
+      textmate-language
+    ];
   };
 
   httpun-types = callPackage ./httpun/types.nix { };
@@ -976,7 +1097,7 @@ with oself;
 
   ipaddr = osuper.ipaddr.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz;
+      url = "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz";
       sha256 = "0cw1431idd54v067p3mqbxhsgsx5mixl9ywgmak3g92cvczl6c4y";
     };
   });
@@ -1027,7 +1148,7 @@ with oself;
     pname = "iostream";
     version = "0.1";
     src = builtins.fetchurl {
-      url = https://github.com/c-cube/ocaml-iostream/releases/download/v0.2.2/iostream-0.2.2.tbz;
+      url = "https://github.com/c-cube/ocaml-iostream/releases/download/v0.2.2/iostream-0.2.2.tbz";
       sha256 = "17c2wg6cyhi030vw922p3h6z525h5x2amz2lij6gx96c1zr2a9vd";
     };
   };
@@ -1036,7 +1157,7 @@ with oself;
     pname = "iso639";
     version = "0.0.5";
     src = builtins.fetchurl {
-      url = https://github.com/paurkedal/ocaml-iso639/releases/download/v0.0.5/iso639-v0.0.5.tbz;
+      url = "https://github.com/paurkedal/ocaml-iso639/releases/download/v0.0.5/iso639-v0.0.5.tbz";
       sha256 = "11bk38m5wsh3g4pr1px3865w8p42n0cq401pnrgpgyl25zdfamk0";
     };
   };
@@ -1059,54 +1180,61 @@ with oself;
   jsonrpc = osuper.jsonrpc.overrideAttrs (o: {
     src =
       if (lib.versionOlder "5.2" ocaml.version) then
-        fetchFromGitHub
-          {
-            owner = "ocaml";
-            repo = "ocaml-lsp";
-            rev = "0573158a2bdbe891d6d0026c922d9cfdca55bcf8";
-            hash = "sha256-aSLIu1Vzg7OJYMh2GgbbpIVhLKT5FHXp6Gq4AE/txfE=";
-          }
-      else o.src;
+        fetchFromGitHub {
+          owner = "ocaml";
+          repo = "ocaml-lsp";
+          rev = "0573158a2bdbe891d6d0026c922d9cfdca55bcf8";
+          hash = "sha256-aSLIu1Vzg7OJYMh2GgbbpIVhLKT5FHXp6Gq4AE/txfE=";
+        }
+      else
+        o.src;
   });
 
-  kafka = (osuper.kafka.override {
-    rdkafka = rdkafka-oc;
-    zlib = zlib-oc;
-  }).overrideAttrs (o: {
-    src = fetchFromGitHub {
-      owner = "anmonteiro";
-      repo = "ocaml-kafka";
-      # https://github.com/anmonteiro/ocaml-kafka/tree/anmonteiro/eio
-      rev = "b3497434003a63be349fd413b3f4a7bd9613e33b";
-      hash = "sha256-vinwVYDCHdPXvQ4z4nMnaV/9q8fboF6qKp7XHtV3Ow8=";
-    };
-    nativeBuildInputs = o.nativeBuildInputs ++ [ pkg-config ];
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ dune-configurator ];
-    hardeningDisable = [ "strictoverflow" ];
-  });
+  kafka =
+    (osuper.kafka.override {
+      rdkafka = rdkafka-oc;
+      zlib = zlib-oc;
+    }).overrideAttrs
+      (o: {
+        src = fetchFromGitHub {
+          owner = "anmonteiro";
+          repo = "ocaml-kafka";
+          # https://github.com/anmonteiro/ocaml-kafka/tree/anmonteiro/eio
+          rev = "b3497434003a63be349fd413b3f4a7bd9613e33b";
+          hash = "sha256-vinwVYDCHdPXvQ4z4nMnaV/9q8fboF6qKp7XHtV3Ow8=";
+        };
+        nativeBuildInputs = o.nativeBuildInputs ++ [ pkg-config ];
+        propagatedBuildInputs = o.propagatedBuildInputs ++ [ dune-configurator ];
+        hardeningDisable = [ "strictoverflow" ];
+      });
 
   kafka_async = buildDunePackage {
     pname = "kafka_async";
     inherit (kafka) src version;
-    propagatedBuildInputs = [ async kafka ];
+    propagatedBuildInputs = [
+      async
+      kafka
+    ];
     hardeningDisable = [ "strictoverflow" ];
   };
 
-  kafka_lwt =
-    buildDunePackage rec {
-      pname = "kafka_lwt";
-      hardeningDisable = [ "strictoverflow" ];
+  kafka_lwt = buildDunePackage rec {
+    pname = "kafka_lwt";
+    hardeningDisable = [ "strictoverflow" ];
 
-      inherit (kafka) version src;
+    inherit (kafka) version src;
 
-      buildInputs = [ cmdliner ];
+    buildInputs = [ cmdliner ];
 
-      propagatedBuildInputs = [ kafka lwt ];
+    propagatedBuildInputs = [
+      kafka
+      lwt
+    ];
 
-      meta = kafka.meta // {
-        description = "OCaml bindings for Kafka, Lwt bindings";
-      };
+    meta = kafka.meta // {
+      description = "OCaml bindings for Kafka, Lwt bindings";
     };
+  };
 
   # Added by the ocaml5.nix
   kcas = null;
@@ -1124,9 +1252,12 @@ with oself;
 
   lacaml = osuper.lacaml.overrideAttrs (_: {
     postPatch =
-      if lib.versionAtLeast ocaml.version "5.0" then ''
-        substituteInPlace src/dune --replace-fail " bigarray" ""
-      '' else "";
+      if lib.versionAtLeast ocaml.version "5.0" then
+        ''
+          substituteInPlace src/dune --replace-fail " bigarray" ""
+        ''
+      else
+        "";
   });
 
   lev = buildDunePackage {
@@ -1142,21 +1273,31 @@ with oself;
   };
   lev-fiber =
     if lib.versionAtLeast osuper.ocaml.version "4.14" then
-      buildDunePackage
-        {
-          pname = "lev-fiber";
-          inherit (lev) version src;
-          propagatedBuildInputs = [ lev dyn fiber stdune ];
-          checkInputs = [ ppx_expect ];
-        } else null;
+      buildDunePackage {
+        pname = "lev-fiber";
+        inherit (lev) version src;
+        propagatedBuildInputs = [
+          lev
+          dyn
+          fiber
+          stdune
+        ];
+        checkInputs = [ ppx_expect ];
+      }
+    else
+      null;
   lev-fiber-csexp =
     if lib.versionAtLeast osuper.ocaml.version "4.14" then
-      buildDunePackage
-        {
-          pname = "lev-fiber";
-          inherit (lev) version src;
-          propagatedBuildInputs = [ lev-fiber csexp ];
-        } else null;
+      buildDunePackage {
+        pname = "lev-fiber";
+        inherit (lev) version src;
+        propagatedBuildInputs = [
+          lev-fiber
+          csexp
+        ];
+      }
+    else
+      null;
 
   lilv = osuper.lilv.overrideAttrs (o: {
     postPatch = ''
@@ -1175,7 +1316,10 @@ with oself;
       sha256 = "sha256-NbiM7xNpuihzqAMiAaYXVeItspWufnr1/e3WZEkMhsA=";
     };
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ lmdb-pkg dune-configurator ];
+    buildInputs = [
+      lmdb-pkg
+      dune-configurator
+    ];
     propagatedBuildInputs = [ bigstringaf ];
   };
 
@@ -1183,10 +1327,13 @@ with oself;
     pname = "lutils";
     version = "1.51.3";
     src = builtins.fetchurl {
-      url = https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/-/archive/1.51.3/lutils-1.51.3.tar.gz;
+      url = "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/-/archive/1.51.3/lutils-1.51.3.tar.gz";
       sha256 = "0brbv0hzddac8v9kfm97i81d0x9nnlfpmwgk0mzc2vpy3p3vd315";
     };
-    propagatedBuildInputs = [ num camlp-streams ];
+    propagatedBuildInputs = [
+      num
+      camlp-streams
+    ];
 
     postPatch = ''
       substituteInPlace lib/dune --replace-fail "(libraries " "(libraries camlp-streams "
@@ -1214,7 +1361,7 @@ with oself;
 
   lwt-watcher = osuper.lwt-watcher.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://gitlab.com/nomadic-labs/lwt-watcher/-/archive/70f826c503cc094ed2de3aa81fa385ea9fddb903.tar.gz;
+      url = "https://gitlab.com/nomadic-labs/lwt-watcher/-/archive/70f826c503cc094ed2de3aa81fa385ea9fddb903.tar.gz";
       sha256 = "0q1qdmagldhwrcqiinsfag6zxcn5wbvn2p10wpyi8rgk27q3l8sk";
     };
   });
@@ -1225,16 +1372,23 @@ with oself;
     pname = "lz4";
     version = "1.3.0";
     src = builtins.fetchurl {
-      url = https://github.com/whitequark/ocaml-lz4/releases/download/v1.3.0/lz4-1.3.0.tbz;
+      url = "https://github.com/whitequark/ocaml-lz4/releases/download/v1.3.0/lz4-1.3.0.tbz";
       sha256 = "13i4fjvhybnys1x7fjf5k07abq9khh68zr4pqy72si0n740d5frw";
     };
-    propagatedBuildInputs = [ dune-configurator ctypes lz4-oc ];
+    propagatedBuildInputs = [
+      dune-configurator
+      ctypes
+      lz4-oc
+    ];
   };
 
   markup-lwt = buildDunePackage {
     pname = "markup-lwt";
     inherit (markup) src version;
-    propagatedBuildInputs = [ markup lwt ];
+    propagatedBuildInputs = [
+      markup
+      lwt
+    ];
   };
 
   matrix-common = callPackage ./matrix { };
@@ -1246,7 +1400,10 @@ with oself;
     # `logs` override, which breaks anything that uses logs (with OCaml package
     # conflicts)
     # https://github.com/NixOS/nixpkgs/blob/f6ed1c3c/pkgs/top-level/ocaml-packages.nix#L1035-L1037
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ result cmdliner ];
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [
+      result
+      cmdliner
+    ];
   });
 
   mirage-channel = disableTests osuper.mirage-channel;
@@ -1256,7 +1413,7 @@ with oself;
 
   mirage-runtime = osuper.mirage-runtime.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/mirage/releases/download/v4.5.1/mirage-4.5.1.tbz;
+      url = "https://github.com/mirage/mirage/releases/download/v4.5.1/mirage-4.5.1.tbz";
       sha256 = "033yhprafg792c3adlr9na3yb08nzv0j3xvb4ky740y0mbj0pq41";
     };
   });
@@ -1265,48 +1422,61 @@ with oself;
     pname = "mirage-kv-unix";
     version = "3.0.0";
     src = builtins.fetchurl {
-      url = https://github.com/mirage/mirage-kv-unix/releases/download/v3.0.0/mirage-kv-unix-3.0.0.tbz;
+      url = "https://github.com/mirage/mirage-kv-unix/releases/download/v3.0.0/mirage-kv-unix-3.0.0.tbz";
       sha256 = "1ian5bb4xhxv902lnn94pzwncqy89asyvmkr8jyrzqml3575923y";
     };
     propagatedBuildInputs = [ mirage-kv ];
     doCheck = true;
-    checkInputs = [ alcotest cstruct mirage-clock-unix ];
+    checkInputs = [
+      alcotest
+      cstruct
+      mirage-clock-unix
+    ];
   };
 
   mirage-kv-mem = buildDunePackage {
     pname = "mirage-kv-mem";
     version = "3.2.1";
     src = builtins.fetchurl {
-      url = https://github.com/mirage/mirage-kv-mem/releases/download/v3.2.1/mirage-kv-mem-3.2.1.tbz;
+      url = "https://github.com/mirage/mirage-kv-mem/releases/download/v3.2.1/mirage-kv-mem-3.2.1.tbz";
       sha256 = "07qr508kb4v9acybncz395p0mnlakib3r8wx5gk7sxdxhmic1z59";
     };
-    propagatedBuildInputs = [ optint mirage-kv fmt ptime mirage-clock ];
+    propagatedBuildInputs = [
+      optint
+      mirage-kv
+      fmt
+      ptime
+      mirage-clock
+    ];
   };
 
   mirage-flow = osuper.mirage-flow.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/mirage-flow/releases/download/v4.0.2/mirage-flow-4.0.2.tbz;
+      url = "https://github.com/mirage/mirage-flow/releases/download/v4.0.2/mirage-flow-4.0.2.tbz";
       sha256 = "0npvxbg7mlxwpgc2lhbl4si913yw4piicm234jyp7rqv5vfy6ra8";
     };
   });
 
   mirage-logs = osuper.mirage-logs.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/mirage-logs/releases/download/v2.1.0/mirage-logs-2.1.0.tbz;
+      url = "https://github.com/mirage/mirage-logs/releases/download/v2.1.0/mirage-logs-2.1.0.tbz";
       sha256 = "1fww8q0an84wiqfwycqlv9chc52a9apf6swbiqk28h1v1jrc52mf";
     };
   });
 
   mirage-vnetif = osuper.mirage-vnetif.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/mirage-vnetif/releases/download/v0.6.2/mirage-vnetif-0.6.2.tbz;
+      url = "https://github.com/mirage/mirage-vnetif/releases/download/v0.6.2/mirage-vnetif-0.6.2.tbz";
       sha256 = "08j58plmrzzyx50ibpvzdzdyiljfxxhl02xb3lhjd131yjndr2ja";
     };
   });
 
   miou = osuper.miou.overrideAttrs {
     doCheck = true;
-    checkInputs = [ dscheck fmt ];
+    checkInputs = [
+      dscheck
+      fmt
+    ];
   };
 
   mustache = osuper.mustache.overrideAttrs (o: {
@@ -1334,11 +1504,13 @@ with oself;
 
   melange =
     # No version supported on 5.0
-    if (lib.versionAtLeast ocaml.version "4.14" && !(lib.versionAtLeast ocaml.version "5.0"))
-    || lib.versionAtLeast ocaml.version "5.1"
+    if
+      (lib.versionAtLeast ocaml.version "4.14" && !(lib.versionAtLeast ocaml.version "5.0"))
+      || lib.versionAtLeast ocaml.version "5.1"
     then
       callPackage ./melange { }
-    else null;
+    else
+      null;
 
   menhirCST = buildDunePackage {
     pname = "menhirCST";
@@ -1349,22 +1521,20 @@ with oself;
   });
   menhirLib = osuper.menhirLib.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://anmonteiro.s3.eu-west-3.amazonaws.com/menhir-20231231.tar.gz;
+      url = "https://anmonteiro.s3.eu-west-3.amazonaws.com/menhir-20231231.tar.gz";
       sha256 = "1xn7760ahcf22y2ix597dh1wj7bc70x7fzj4vj73wch77imraffz";
     };
   });
 
   merlin-extend = osuper.merlin-extend.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/let-def/merlin-extend/releases/download/v0.6.1/merlin-extend-0.6.1.tbz;
+      url = "https://github.com/let-def/merlin-extend/releases/download/v0.6.1/merlin-extend-0.6.1.tbz";
       sha256 = "1mza1djw7gzpjpk7v30mwayxqfn9mjzk5ca8b6d14bfvblslpj2y";
     };
   });
 
   merlin-lib =
-    if lib.versionAtLeast ocaml.version "4.14" then
-      callPackage ./merlin/lib.nix { }
-    else null;
+    if lib.versionAtLeast ocaml.version "4.14" then callPackage ./merlin/lib.nix { } else null;
   dot-merlin-reader = callPackage ./merlin/dot-merlin.nix { };
   merlin = callPackage ./merlin { };
 
@@ -1377,7 +1547,11 @@ with oself;
       rev = "26e20714348607cec5d978808e666ed414ba092b";
       hash = "sha256-5h7uFPbVtp8A0PbTc+JGlv8H/6xQ1QjwNeRiImAHcfU=";
     };
-    propagatedBuildInputs = [ ppxlib stdcompat findlib ];
+    propagatedBuildInputs = [
+      ppxlib
+      stdcompat
+      findlib
+    ];
   };
 
   mew = osuper.mew.overrideAttrs (_: {
@@ -1388,8 +1562,7 @@ with oself;
   });
 
   minisat = osuper.minisat.overrideAttrs (_: {
-    NIX_CFLAGS_COMPILE =
-      lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
+    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
   });
 
   morbig = osuper.morbig.overrideAttrs (_: {
@@ -1407,7 +1580,7 @@ with oself;
 
   mimic = osuper.mimic.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/dinosaure/mimic/releases/download/0.0.9/mimic-0.0.9.tbz;
+      url = "https://github.com/dinosaure/mimic/releases/download/0.0.9/mimic-0.0.9.tbz";
       sha256 = "17z2d55i2ffk6pnp1hyn6pvzfskas6jqa224hnkj5aa8np7g2kcm";
     };
   });
@@ -1415,15 +1588,23 @@ with oself;
   mimic-happy-eyeballs = buildDunePackage {
     pname = "mimic-happy-eyeballs";
     inherit (mimic) version src;
-    propagatedBuildInputs = [ mimic dns-client-mirage happy-eyeballs-mirage ];
+    propagatedBuildInputs = [
+      mimic
+      dns-client-mirage
+      happy-eyeballs-mirage
+    ];
   };
 
   mrmime = osuper.mrmime.overrideAttrs (o: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/mrmime/releases/download/v0.6.1/mrmime-0.6.1.tbz;
+      url = "https://github.com/mirage/mrmime/releases/download/v0.6.1/mrmime-0.6.1.tbz";
       sha256 = "05mh0avl2w8n3mkiax62iqjwf2001rg6qvl7ri499fzk2gpjnfqg";
     };
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ hxd jsonm cmdliner ];
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [
+      hxd
+      jsonm
+      cmdliner
+    ];
     doCheck = true;
   });
 
@@ -1506,16 +1687,18 @@ with oself;
   });
 
   ocaml-index =
-    if lib.versionAtLeast ocaml.version "5.2" then
-      callPackage ./ocaml-index { }
-    else null;
+    if lib.versionAtLeast ocaml.version "5.2" then callPackage ./ocaml-index { } else null;
 
   ocaml-protoc-plugin = osuper.ocaml-protoc-plugin.overrideAttrs (o: {
     src = builtins.fetchurl {
-      url = https://github.com/andersfugmann/ocaml-protoc-plugin/releases/download/6.1.0/ocaml-protoc-plugin-6.1.0.tbz;
+      url = "https://github.com/andersfugmann/ocaml-protoc-plugin/releases/download/6.1.0/ocaml-protoc-plugin-6.1.0.tbz";
       sha256 = "0yy5d2ih21inx02gdylcscp30gd9vvrm7ky1abyzahcypz3x2m32";
     };
-    buildInputs = o.buildInputs ++ [ ptime base64 dune-configurator ];
+    buildInputs = o.buildInputs ++ [
+      ptime
+      base64
+      dune-configurator
+    ];
   });
 
   ocamlformat = osuper.ocamlformat.overrideAttrs (_: {
@@ -1545,9 +1728,7 @@ with oself;
     '';
   });
 
-  ocaml_libvirt = osuper.ocaml_libvirt.override {
-    libvirt = disableTests libvirt;
-  };
+  ocaml_libvirt = osuper.ocaml_libvirt.override { libvirt = disableTests libvirt; };
 
   ez_subst = buildDunePackage {
     pname = "ez_subst";
@@ -1569,7 +1750,11 @@ with oself;
       rev = "v0.4.3";
       sha256 = "sha256-l1JQrMxZsk+CuTDNmoKvzDO/8kGJOY3C8WGetprgR1M=";
     };
-    propagatedBuildInputs = [ cmdliner ez_subst ocplib_stuff ];
+    propagatedBuildInputs = [
+      cmdliner
+      ez_subst
+      ocplib_stuff
+    ];
   };
 
   ocaml-migrate-types = callPackage ./ocaml-migrate-types { };
@@ -1583,7 +1768,7 @@ with oself;
     # link myocamlbuild programs)
     postFixup = ''
       wrapProgram $out/bin/ocamlbuild \
-        --suffix PATH : "${ buildPackages.stdenv.cc }/bin"
+        --suffix PATH : "${buildPackages.stdenv.cc}/bin"
     '';
   });
 
@@ -1598,22 +1783,30 @@ with oself;
       sha256 = "sha256-PghULCfekMhs88a2F+RJtJFoBJxi80ieDiKzhWukJw4=";
     };
 
-    buildInputs = lib.optionals (! stdenv.isDarwin) [
-      freetype
-      fontconfig
-      libxkbcommon
-      libxcb
-      xorg.xcbutilkeysyms
-      xorg.xcbutilimage
-    ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-      AppKit
-      Foundation
-      Carbon
-      Cocoa
-      CoreGraphics
-    ]);
+    buildInputs =
+      lib.optionals (!stdenv.isDarwin) [
+        freetype
+        fontconfig
+        libxkbcommon
+        libxcb
+        xorg.xcbutilkeysyms
+        xorg.xcbutilimage
+      ]
+      ++ lib.optionals stdenv.isDarwin (
+        with darwin.apple_sdk.frameworks;
+        [
+          AppKit
+          Foundation
+          Carbon
+          Cocoa
+          CoreGraphics
+        ]
+      );
 
-    propagatedBuildInputs = [ dune-configurator react ];
+    propagatedBuildInputs = [
+      dune-configurator
+      react
+    ];
   };
 
   ocaml-lsp = osuper.ocaml-lsp.overrideAttrs (o: {
@@ -1647,7 +1840,7 @@ with oself;
     pname = "ocplib-simplex";
     version = "0.5.1";
     src = builtins.fetchurl {
-      url = https://github.com/OCamlPro/ocplib-simplex/releases/download/v0.5.1/ocplib-simplex-0.5.1.tbz;
+      url = "https://github.com/OCamlPro/ocplib-simplex/releases/download/v0.5.1/ocplib-simplex-0.5.1.tbz";
       sha256 = "1kqkslhka5r07nm53cspghpb818bi0gb5i9pbm90rrhq9nz19j55";
     };
 
@@ -1666,10 +1859,13 @@ with oself;
 
     # `String.sub Sys.ocaml_version 0 6` doesn't work on OCaml 5.0
     postPatch =
-      if lib.versionAtLeast ocaml.version "5.0" then ''
-        substituteInPlace ./src/ocplib_stuff/dune \
-          --replace-fail "failwith \"Wrong ocaml version\"" "\"5.0.0\""
-      '' else "";
+      if lib.versionAtLeast ocaml.version "5.0" then
+        ''
+          substituteInPlace ./src/ocplib_stuff/dune \
+            --replace-fail "failwith \"Wrong ocaml version\"" "\"5.0.0\""
+        ''
+      else
+        "";
   };
 
   ocurl = osuper.ocurl.overrideAttrs (_: {
@@ -1680,7 +1876,7 @@ with oself;
     pname = "odep";
     version = "0.2.2";
     src = builtins.fetchurl {
-      url = https://github.com/sim642/odep/releases/download/0.2.1/odep-0.2.1.tbz;
+      url = "https://github.com/sim642/odep/releases/download/0.2.1/odep-0.2.1.tbz";
       sha256 = "0snwz7fg46bab9xhg19lfdmw57zcc06q939zih1qjq97rrcyiqgs";
     };
     propagatedBuildInputs = [
@@ -1695,7 +1891,11 @@ with oself;
   };
 
   odoc-parser = osuper.odoc-parser.overrideAttrs (_: {
-    propagatedBuildInputs = [ astring camlp-streams ppx_expect ];
+    propagatedBuildInputs = [
+      astring
+      camlp-streams
+      ppx_expect
+    ];
     postPatch = ''
       substituteInPlace src/parser/dune --replace-fail "result" ""
     '';
@@ -1711,18 +1911,23 @@ with oself;
 
   omd = osuper.omd.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/ocaml/omd/releases/download/2.0.0.alpha4/omd-2.0.0.alpha4.tbz;
+      url = "https://github.com/ocaml/omd/releases/download/2.0.0.alpha4/omd-2.0.0.alpha4.tbz";
       sha256 = "076zc9mbz9698lcx5fw0hvllbv4n29flglz64n15n02vhybrd5lk";
     };
     preBuild = "";
-    propagatedBuildInputs = [ uutf uucp uunf dune-build-info ];
+    propagatedBuildInputs = [
+      uutf
+      uucp
+      uunf
+      dune-build-info
+    ];
   });
 
   oniguruma = buildDunePackage {
     pname = "oniguruma";
     version = "0.1.2";
     src = builtins.fetchurl {
-      url = https://github.com/alan-j-hu/ocaml-oniguruma/releases/download/0.1.2/oniguruma-0.1.2.tbz;
+      url = "https://github.com/alan-j-hu/ocaml-oniguruma/releases/download/0.1.2/oniguruma-0.1.2.tbz";
       sha256 = "0rc70nwgx4bqm3h7rar2pmnh543np67rw5m8f6gwzhrwvbykzxp3";
     };
     buildInputs = [ dune-configurator ];
@@ -1753,7 +1958,7 @@ with oself;
     pname = "0install-solver";
     version = "2.18";
     src = builtins.fetchurl {
-      url = https://github.com/0install/0install/releases/download/v2.18/0install-2.18.tbz;
+      url = "https://github.com/0install/0install/releases/download/v2.18/0install-2.18.tbz";
       sha256 = "1hr0k47cxqcsycxhmn2ajaakfwnap1m24p068k5xy9hsihqlp334";
     };
   };
@@ -1761,28 +1966,46 @@ with oself;
     pname = "opam-0install-cudf";
     version = "0.4.3";
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.4.3/opam-0install-cudf-0.4.3.tbz;
+      url = "https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.4.3/opam-0install-cudf-0.4.3.tbz";
       sha256 = "12jv2kk6fkapa04w4f0c6iy5lfw9hcy23ghfyn7pk3x5vnyhx7nm";
     };
-    propagatedBuildInputs = [ cudf x0install-solver ];
+    propagatedBuildInputs = [
+      cudf
+      x0install-solver
+    ];
   };
 
   opam-client = buildDunePackage {
     pname = "opam-client";
     inherit (opam-format) src version meta;
     configureFlags = [ "--disable-checks" ];
-    propagatedBuildInputs = [ cmdliner base64 re opam-repository opam-solver opam-state ];
+    propagatedBuildInputs = [
+      cmdliner
+      base64
+      re
+      opam-repository
+      opam-solver
+      opam-state
+    ];
   };
   opam = buildDunePackage {
     pname = "opam";
     inherit (opam-format) src version meta;
     nativeBuildInputs = [ curl ];
     configureFlags = [ "--disable-checks" ];
-    propagatedBuildInputs = [ cmdliner opam-client ];
+    propagatedBuildInputs = [
+      cmdliner
+      opam-client
+    ];
   };
   opam-core = osuper.opam-core.overrideAttrs (o: {
     inherit (opam-format) src version meta;
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ uutf swhid_core jsonm sha ];
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [
+      uutf
+      swhid_core
+      jsonm
+      sha
+    ];
   });
   opam-repository = osuper.opam-repository.overrideAttrs (o: {
     configureFlags = [ "--disable-checks" ];
@@ -1791,7 +2014,12 @@ with oself;
     pname = "opam-solver";
     inherit (opam-format) src version meta;
     configureFlags = [ "--disable-checks" ];
-    propagatedBuildInputs = [ opam-0install-cudf re dose3 opam-format ];
+    propagatedBuildInputs = [
+      opam-0install-cudf
+      re
+      dose3
+      opam-format
+    ];
   };
   opam-format = osuper.opam-format.overrideAttrs (_: {
     src = fetchFromGitHub {
@@ -1805,7 +2033,10 @@ with oself;
       description = "A package manager for OCaml";
       homepage = "https://opam.ocaml.org/";
       changelog = "https://github.com/ocaml/opam/raw/${version}/CHANGES";
-      maintainers = [ maintainers.henrytill maintainers.marsam ];
+      maintainers = [
+        maintainers.henrytill
+        maintainers.marsam
+      ];
       license = licenses.lgpl21Only;
       platforms = platforms.all;
     };
@@ -1819,7 +2050,7 @@ with oself;
 
   eigen = osuper.eigen.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/owlbarn/eigen/releases/download/0.3.3/eigen-0.3.3.tbz;
+      url = "https://github.com/owlbarn/eigen/releases/download/0.3.3/eigen-0.3.3.tbz";
       sha256 = "1kiy0pg0a5cnf9zff0137lfgbk7nbs5yc9dimwqdr5lihbi88cd9";
     };
     buildInputs = [ dune-configurator ];
@@ -1854,7 +2085,7 @@ with oself;
     pname = "patch";
     version = "2.0.0";
     src = builtins.fetchurl {
-      url = https://github.com/hannesm/patch/releases/download/v2.0.0/patch-2.0.0.tbz;
+      url = "https://github.com/hannesm/patch/releases/download/v2.0.0/patch-2.0.0.tbz";
       sha256 = "0n75k3pjj4a9a8y7rxjlscjv15sy3chkibaqfdalr7fpr59lprdh";
     };
     doCheck = true;
@@ -1867,11 +2098,17 @@ with oself;
     pname = "plist-xml";
     version = "";
     src = builtins.fetchurl {
-      url = https://github.com/alan-j-hu/ocaml-plist-xml/releases/download/0.5.0/plist-xml-0.5.0.tbz;
+      url = "https://github.com/alan-j-hu/ocaml-plist-xml/releases/download/0.5.0/plist-xml-0.5.0.tbz";
       sha256 = "1hw3l8q8ip56niszh24yr6dijm7da2rrixdyviffyxv4c9dhd1di";
     };
     nativeBuildInputs = [ menhir ];
-    propagatedBuildInputs = [ menhirLib xmlm base64 cstruct iso8601 ];
+    propagatedBuildInputs = [
+      menhirLib
+      xmlm
+      base64
+      cstruct
+      iso8601
+    ];
   };
 
   postgresql = (osuper.postgresql.override { postgresql = libpq; }).overrideAttrs (o: {
@@ -1908,9 +2145,9 @@ with oself;
       --replace 'C_content_make ()' 'C_content_make (struct end)'
 
       ${lib.optionalString (lib.versionOlder "5.2" ocaml.version) ''
-      substituteInPlace src/custom/ppx_cstubs_custom.cppo.ml \
-      --replace-fail "init_code fun_code" "init_code" \
-      --replace-fail "can_free = fun_code = []" "can_free = fun_code"
+        substituteInPlace src/custom/ppx_cstubs_custom.cppo.ml \
+        --replace-fail "init_code fun_code" "init_code" \
+        --replace-fail "can_free = fun_code = []" "can_free = fun_code"
       ''}
     '';
 
@@ -1942,10 +2179,13 @@ with oself;
     pname = "ppx_optint";
     version = "0.2.0";
     src = builtins.fetchurl {
-      url = https://github.com/reynir/ppx_optint/releases/download/v0.2.0/ppx_optint-0.2.0.tbz;
+      url = "https://github.com/reynir/ppx_optint/releases/download/v0.2.0/ppx_optint-0.2.0.tbz";
       sha256 = "09casz0hzmhj8ajjq595a8aa1l567lzhiszjrv2d8q0jbr8zw19l";
     };
-    propagatedBuildInputs = [ optint ppxlib ];
+    propagatedBuildInputs = [
+      optint
+      ppxlib
+    ];
   };
 
   ppx_rapper = callPackage ./ppx_rapper { };
@@ -1954,7 +2194,7 @@ with oself;
 
   ppx_deriving = osuper.ppx_deriving.overrideAttrs (o: {
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-ppx/ppx_deriving/releases/download/v6.0.2/ppx_deriving-6.0.2.tbz;
+      url = "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v6.0.2/ppx_deriving-6.0.2.tbz";
       sha256 = "151bcg9nxcn8k91f77pizv8nq30bih9cj38igq24452ajg2wzfks";
     };
     buildInputs = [ ];
@@ -1977,7 +2217,7 @@ with oself;
     pname = "ppx_deriving_variant_string";
     version = "1.0.0";
     src = builtins.fetchurl {
-      url = https://github.com/ahrefs/ppx_deriving_variant_string/releases/download/1.0.1/ppx_deriving_variant_string-1.0.1.tbz;
+      url = "https://github.com/ahrefs/ppx_deriving_variant_string/releases/download/1.0.1/ppx_deriving_variant_string-1.0.1.tbz";
       sha256 = "01rgcg3x7yw81kfrv33h9sx0grqs0445ah4k18pf8f0g9hn3s9cx";
     };
     propagatedBuildInputs = [ ppxlib ];
@@ -1985,15 +2225,12 @@ with oself;
 
   ppx_deriving_yojson = osuper.ppx_deriving_yojson.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/download/v3.8.0/ppx_deriving_yojson-3.8.0.tbz;
+      url = "https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/download/v3.8.0/ppx_deriving_yojson-3.8.0.tbz";
       sha256 = "18f2w2cd9zkmpyffly2mlfkgnv5srh910jk650c0d3s1pr4cbjzx";
     };
   });
 
-  ppx_tools =
-    if lib.versionOlder "5.2" ocaml.version
-    then null
-    else osuper.ppx_tools;
+  ppx_tools = if lib.versionOlder "5.2" ocaml.version then null else osuper.ppx_tools;
 
   ppxlib = osuper.ppxlib.overrideAttrs (o: {
     propagatedBuildInputs = [
@@ -2076,7 +2313,7 @@ with oself;
 
   routes = osuper.routes.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/anuragsoni/routes/releases/download/2.0.0/routes-2.0.0.tbz;
+      url = "https://github.com/anuragsoni/routes/releases/download/2.0.0/routes-2.0.0.tbz";
       sha256 = "126nn0gbh12i7yf0qn01ryfp2qw0aj1xfk1vq42fa01biilrsqiv";
     };
   });
@@ -2085,7 +2322,7 @@ with oself;
     pname = "semver";
     version = "0.2.0";
     src = builtins.fetchurl {
-      url = https://github.com/rgrinberg/ocaml-semver/releases/download/0.2.1/semver-0.2.1.tbz;
+      url = "https://github.com/rgrinberg/ocaml-semver/releases/download/0.2.1/semver-0.2.1.tbz";
       sha256 = "1f4qyrzh8y72k96dyh8l8m2sb2sl5bhny9ijxgnppr0yv99c6g0a";
     };
   };
@@ -2097,7 +2334,7 @@ with oself;
 
   shared-memory-ring = osuper.shared-memory-ring.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/shared-memory-ring/releases/download/v3.2.1/shared-memory-ring-3.2.1.tbz;
+      url = "https://github.com/mirage/shared-memory-ring/releases/download/v3.2.1/shared-memory-ring-3.2.1.tbz";
       sha256 = "0cqqrwpmlb3mb1r2w9w7rrmni2q1ippa1kjn4vy4z8yhqfv6f9x9";
     };
   });
@@ -2121,7 +2358,10 @@ with oself;
         "ocamlfind query ctypes ctypes.stubs" \
         "ocamlfind query ctypes"
     '';
-    propagatedBuildInputs = [ ctypes libsodium ];
+    propagatedBuildInputs = [
+      ctypes
+      libsodium
+    ];
   };
 
   soundtouch = osuper.soundtouch.overrideAttrs (o: {
@@ -2184,11 +2424,11 @@ with oself;
     pname = "stdlib-random";
     version = "1.1.0";
     src = builtins.fetchurl {
-      url = https://github.com/ocaml/stdlib-random/releases/download/1.1.0/stdlib-random-1.1.0.tbz;
+      url = "https://github.com/ocaml/stdlib-random/releases/download/1.1.0/stdlib-random-1.1.0.tbz";
       sha256 = "0n95h57z0d9hf1y5a3v7bbci303wl63jn20ymnb8n2v8zs1034wb";
     };
     nativeBuildInputs = [ cppo ];
-    doCheck = ! lib.versionOlder "5.2" ocaml.version;
+    doCheck = !lib.versionOlder "5.2" ocaml.version;
   };
 
   subscriptions-transport-ws = callPackage ./subscriptions-transport-ws { };
@@ -2200,7 +2440,11 @@ with oself;
       url = "https://github.com/Cumulus/${pname}/releases/download/v${version}/syndic-v${version}.tbz";
       sha256 = "1i43yqg0i304vpiy3sf6kvjpapkdm6spkf83mj9ql1d4f7jg6c58";
     };
-    propagatedBuildInputs = [ xmlm uri ptime ];
+    propagatedBuildInputs = [
+      xmlm
+      uri
+      ptime
+    ];
   };
 
   taglib = osuper.taglib.overrideAttrs (o: {
@@ -2223,7 +2467,7 @@ with oself;
 
   tcpip = osuper.tcpip.overrideAttrs (o: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/mirage-tcpip/releases/download/v8.1.0/tcpip-8.1.0.tbz;
+      url = "https://github.com/mirage/mirage-tcpip/releases/download/v8.1.0/tcpip-8.1.0.tbz";
       sha256 = "1h59fm6vhsi27ar36m3n1mbx4kz39igkpxhjag3dv2q7z695vfl6";
     };
     checkInputs = o.checkInputs ++ [ mirage-crypto-rng ];
@@ -2233,7 +2477,7 @@ with oself;
     pname = "textmate-language";
     version = "0.3.4";
     src = builtins.fetchurl {
-      url = https://github.com/alan-j-hu/ocaml-textmate-language/releases/download/0.3.4/textmate-language-0.3.4.tbz;
+      url = "https://github.com/alan-j-hu/ocaml-textmate-language/releases/download/0.3.4/textmate-language-0.3.4.tbz";
       sha256 = "17c540ddzqzl8c72rzpm3id6ixi91cq5r8dmjvf0kzj6kjdgrg63";
     };
     propagatedBuildInputs = [ oniguruma ];
@@ -2249,7 +2493,7 @@ with oself;
 
   tls = osuper.tls.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirleft/ocaml-tls/releases/download/v0.17.5/tls-0.17.5.tbz;
+      url = "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.5/tls-0.17.5.tbz";
       sha256 = "06a8ms9ginhgbz22ybhgiiiisacwynix9a1555r8avrspxbqh449";
     };
 
@@ -2276,16 +2520,16 @@ with oself;
     '';
     NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
     propagatedBuildInputs =
-      o.propagatedBuildInputs ++
-      [ ctypes-foreign ] ++
-      lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Accelerate ];
+      o.propagatedBuildInputs
+      ++ [ ctypes-foreign ]
+      ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Accelerate ];
     doCheck = !stdenv.isDarwin;
     checkPhase = "dune runtest --profile=release";
   });
 
   trace = osuper.trace.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/c-cube/ocaml-trace/releases/download/v0.7/trace-0.7.tbz;
+      url = "https://github.com/c-cube/ocaml-trace/releases/download/v0.7/trace-0.7.tbz";
       sha256 = "0fckj3agx35smqpfq2vcn3zj3hghp682g22rjrn56j8bnclvxl7b";
     };
     propagatedBuildInputs = [ mtime ];
@@ -2298,13 +2542,16 @@ with oself;
     propagatedBuildInputs =
       o.propagatedBuildInputs
       ++ [ ctypes-foreign ]
-      ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-        Cocoa
-        CoreAudio
-        CoreVideo
-        AudioToolbox
-        ForceFeedback
-      ]);
+      ++ lib.optionals stdenv.isDarwin (
+        with darwin.apple_sdk.frameworks;
+        [
+          Cocoa
+          CoreAudio
+          CoreVideo
+          AudioToolbox
+          ForceFeedback
+        ]
+      );
   });
 
   tsdl-mixer = osuper.tsdl-mixer.overrideAttrs (_: {
@@ -2318,7 +2565,7 @@ with oself;
 
   tuntap = osuper.tuntap.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/ocaml-tuntap/releases/download/v2.0.1/tuntap-2.0.1.tbz;
+      url = "https://github.com/mirage/ocaml-tuntap/releases/download/v2.0.1/tuntap-2.0.1.tbz";
       sha256 = "1p8c9j32vzy59yavsis1rsb8i86wyhn5wzxb1rl5ki1vrjbh3ii7";
     };
   });
@@ -2334,7 +2581,10 @@ with oself;
       rev = "a36eec0aa612141ababbc8131a489bc6df7094a8";
       hash = "sha256-8e5NR69LyHnNdbDA/18OOYCUtsJW0h3mZkgxiQ85/QI=";
     };
-    propagatedBuildInputs = [ ctypes integers ];
+    propagatedBuildInputs = [
+      ctypes
+      integers
+    ];
   });
 
   uring = osuper.uring.overrideAttrs (_: {
@@ -2347,7 +2597,7 @@ with oself;
 
   uucp = osuper.uucp.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://erratique.ch/software/uucp/releases/uucp-15.1.0.tbz;
+      url = "https://erratique.ch/software/uucp/releases/uucp-15.1.0.tbz";
       sha256 = "11srn8zwba31zmj129v6l8sigdm9qrgcfd59vl1qmds70s44n7m9";
     };
   });
@@ -2358,7 +2608,7 @@ with oself;
 
   vchan = osuper.vchan.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/mirage/ocaml-vchan/releases/download/v6.0.2/vchan-6.0.2.tbz;
+      url = "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.2/vchan-6.0.2.tbz";
       sha256 = "1razkj2jbplj1midhaiqlflzvibcl0ylivvz34g8rf6nbbdbaj3y";
     };
     propagatedBuildInputs = [
@@ -2382,7 +2632,10 @@ with oself;
     ];
   });
   visitors = osuper.visitors.overrideAttrs (_: {
-    propagatedBuildInputs = [ ppxlib ppx_deriving ];
+    propagatedBuildInputs = [
+      ppxlib
+      ppx_deriving
+    ];
     postPatch = ''
       substituteInPlace runtime/dune --replace-fail '(libraries result)' ""
       substituteInPlace src/dune --replace-fail '(libraries result' "(libraries "
@@ -2394,7 +2647,7 @@ with oself;
     version = "0.2.1";
 
     src = builtins.fetchurl {
-      url = https://github.com/flowtype/ocaml-vlq/releases/download/v0.2.1/vlq-v0.2.1.tbz;
+      url = "https://github.com/flowtype/ocaml-vlq/releases/download/v0.2.1/vlq-v0.2.1.tbz";
       sha256 = "02wr9ph4q0nxmqgbc67ydf165hmrdv9b655krm2glc3ahb6larxi";
     };
 
@@ -2410,15 +2663,26 @@ with oself;
     pname = "websocket";
     version = "2.16";
     src = builtins.fetchurl {
-      url = https://github.com/vbmithr/ocaml-websocket/releases/download/2.16/websocket-2.16.tbz;
+      url = "https://github.com/vbmithr/ocaml-websocket/releases/download/2.16/websocket-2.16.tbz";
       sha256 = "1sy5gp40l476qmbn6d8cfw61pkg8b7pg1hrbsvdq9n6s7mlg888j";
     };
-    propagatedBuildInputs = [ cohttp astring base64 ocplib-endian conduit ];
+    propagatedBuildInputs = [
+      cohttp
+      astring
+      base64
+      ocplib-endian
+      conduit
+    ];
   };
   websocket-lwt-unix = buildDunePackage {
     pname = "websocket-lwt-unix";
     inherit (websocket) src version;
-    propagatedBuildInputs = [ lwt websocket cohttp-lwt-unix lwt_log ];
+    propagatedBuildInputs = [
+      lwt
+      websocket
+      cohttp-lwt-unix
+      lwt_log
+    ];
     doCheck = true;
 
     postPatch = ''
@@ -2458,7 +2722,7 @@ with oself;
 
   yaml = osuper.yaml.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/avsm/ocaml-yaml/releases/download/v3.2.0/yaml-3.2.0.tbz;
+      url = "https://github.com/avsm/ocaml-yaml/releases/download/v3.2.0/yaml-3.2.0.tbz";
       sha256 = "09w2l2inc0ymzd9l8gpx9pd4xlp5a4rn1qbi5dwndydr5352l3f5";
     };
   });
@@ -2468,7 +2732,13 @@ with oself;
   zarith = (osuper.zarith.override { gmp = gmp-oc; });
 
   zed = osuper.zed.overrideAttrs (o: {
-    propagatedBuildInputs = [ react uchar uutf uucp uuseg ];
+    propagatedBuildInputs = [
+      react
+      uchar
+      uutf
+      uucp
+      uuseg
+    ];
     postPatch = ''
       substituteInPlace src/dune --replace-fail "result" ""
     '';
@@ -2478,22 +2748,41 @@ with oself;
     pname = "zstd";
     version = "0.4";
     src = builtins.fetchurl {
-      url = https://github.com/ygrek/ocaml-zstd/releases/download/v0.4/zstd-0.4.tbz;
+      url = "https://github.com/ygrek/ocaml-zstd/releases/download/v0.4/zstd-0.4.tbz";
       sha256 = "0481m7rfk21n1wxqnczbpfmqkh8qky9wgvs9pl24xscmw91qd5n1";
     };
     nativeBuildInputs = [ pkg-config ];
-    propagatedBuildInputs = [ integers ctypes zstd-oc ];
+    propagatedBuildInputs = [
+      integers
+      ctypes
+      zstd-oc
+    ];
     doCheck = true;
     checkInputs = [ extlib ];
   };
-} // (if lib.versionAtLeast osuper.ocaml.version "5.1" then janeStreet_0_17 else janeStreet_0_16) // (
-  if lib.hasPrefix "5." osuper.ocaml.version
-  then (import ./ocaml5.nix { inherit oself osuper darwin fetchFromGitHub nodejs_latest; })
-  else { }
-) // (
-  if # No version supported on 5.0
+}
+// (if lib.versionAtLeast osuper.ocaml.version "5.1" then janeStreet_0_17 else janeStreet_0_16)
+// (
+  if lib.hasPrefix "5." osuper.ocaml.version then
+    (import ./ocaml5.nix {
+      inherit
+        oself
+        osuper
+        darwin
+        fetchFromGitHub
+        nodejs_latest
+        ;
+    })
+  else
+    { }
+)
+// (
+  # No version supported on 5.0
+  if
     (lib.versionAtLeast osuper.ocaml.version "4.14" && !(lib.versionAtLeast osuper.ocaml.version "5.0"))
     || lib.versionAtLeast osuper.ocaml.version "5.1"
-  then (import ./melange-packages.nix { inherit oself fetchFromGitHub; })
-  else { }
+  then
+    (import ./melange-packages.nix { inherit oself fetchFromGitHub; })
+  else
+    { }
 )

--- a/ocaml/dream-html/default.nix
+++ b/ocaml/dream-html/default.nix
@@ -1,4 +1,9 @@
-{ lib, buildDunePackage, fetchFromGitHub, dream }:
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  dream,
+}:
 
 buildDunePackage {
   pname = "dream-html";
@@ -14,8 +19,7 @@ buildDunePackage {
   propagatedBuildInputs = [ dream ];
 
   meta = {
-    description =
-      "Write HTML directly in your OCaml source files with editor support.";
+    description = "Write HTML directly in your OCaml source files with editor support.";
     license = lib.licenses.gpl3;
   };
 }

--- a/ocaml/dream-livereload/default.nix
+++ b/ocaml/dream-livereload/default.nix
@@ -1,12 +1,21 @@
-{ buildDunePackage, dream, lambdasoup, lwt_ppx }:
+{
+  buildDunePackage,
+  dream,
+  lambdasoup,
+  lwt_ppx,
+}:
 
 buildDunePackage rec {
   pname = "dream-livereload";
   version = "0.2.0";
   src = builtins.fetchurl {
-    url = https://github.com/tmattio/dream-livereload/releases/download/0.2.0/dream-livereload-0.2.0.tbz;
+    url = "https://github.com/tmattio/dream-livereload/releases/download/0.2.0/dream-livereload-0.2.0.tbz";
     sha256 = "1ppq4j823p57w7bmzclmlb035i1mhjwz86alwjr44bjv493h6rgr";
   };
 
-  propagatedBuildInputs = [ dream lambdasoup lwt_ppx ];
+  propagatedBuildInputs = [
+    dream
+    lambdasoup
+    lwt_ppx
+  ];
 }

--- a/ocaml/dream-serve/default.nix
+++ b/ocaml/dream-serve/default.nix
@@ -1,4 +1,12 @@
-{ lib, buildDunePackage, dream, lambdasoup, luv, lwt, lwt_ppx }:
+{
+  lib,
+  buildDunePackage,
+  dream,
+  lambdasoup,
+  luv,
+  lwt,
+  lwt_ppx,
+}:
 
 buildDunePackage rec {
   pname = "dream-serve";
@@ -9,7 +17,13 @@ buildDunePackage rec {
     sha256 = "0sqmy3jjy00laxh1skq69i7mn2lg14sa2ilap8yvjpz2bhgc7cvp";
   };
 
-  propagatedBuildInputs = [ dream lambdasoup luv lwt lwt_ppx ];
+  propagatedBuildInputs = [
+    dream
+    lambdasoup
+    luv
+    lwt
+    lwt_ppx
+  ];
 
   meta = {
     description = "Static site server with live reload";

--- a/ocaml/dream/default.nix
+++ b/ocaml/dream/default.nix
@@ -1,42 +1,43 @@
-{ lib
-, fetchFromGitHub
-, buildDunePackage
-, bigarray-compat
-, camlp-streams
-, caqti
-, caqti-lwt
-, cstruct
-, dream-httpaf
-, dream-pure
-, fmt
-, graphql_parser
-, graphql-lwt
-, lwt
-, lwt_ppx
-, lwt_ssl
-, logs
-, magic-mime
-, mirage-clock
-, mirage-crypto
-, mirage-crypto-rng-lwt
-, multipart_form
-, multipart_form-lwt
-, ptime
-, ssl
-, uri
-, yojson
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  bigarray-compat,
+  camlp-streams,
+  caqti,
+  caqti-lwt,
+  cstruct,
+  dream-httpaf,
+  dream-pure,
+  fmt,
+  graphql_parser,
+  graphql-lwt,
+  lwt,
+  lwt_ppx,
+  lwt_ssl,
+  logs,
+  magic-mime,
+  mirage-clock,
+  mirage-crypto,
+  mirage-crypto-rng-lwt,
+  multipart_form,
+  multipart_form-lwt,
+  ptime,
+  ssl,
+  uri,
+  yojson,
   # test-inputs
-, bisect_ppx
-, alcotest
-, crunch
-, lambdasoup
-, ppx_expect
-, ppx_yojson_conv_lib
-, reason
-, tyxml
-, tyxml-jsx
-, tyxml-ppx
-, ocaml
+  bisect_ppx,
+  alcotest,
+  crunch,
+  lambdasoup,
+  ppx_expect,
+  ppx_yojson_conv_lib,
+  reason,
+  tyxml,
+  tyxml-jsx,
+  tyxml-ppx,
+  ocaml,
 }:
 
 buildDunePackage rec {
@@ -70,9 +71,7 @@ buildDunePackage rec {
     yojson
   ];
 
-  buildInputs = [
-    bisect_ppx
-  ];
+  buildInputs = [ bisect_ppx ];
 
   checkInputs = [
     alcotest

--- a/ocaml/dream/httpaf.nix
+++ b/ocaml/dream/httpaf.nix
@@ -1,16 +1,17 @@
-{ lib
-, buildDunePackage
-, dream-pure
-, lwt
-, lwt_ppx
-, lwt_ssl
-, ssl
-, digestif
-, faraday
-, faraday-lwt-unix
-, psq
-, result
-, ke
+{
+  lib,
+  buildDunePackage,
+  dream-pure,
+  lwt,
+  lwt_ppx,
+  lwt_ssl,
+  ssl,
+  digestif,
+  faraday,
+  faraday-lwt-unix,
+  psq,
+  result,
+  ke,
 }:
 
 buildDunePackage rec {

--- a/ocaml/dream/pure.nix
+++ b/ocaml/dream/pure.nix
@@ -1,17 +1,18 @@
-{ lib
-, fetchFromGitHub
-, buildDunePackage
-, base64
-, bigstringaf
-, hmap
-, lwt
-, lwt_ppx
-, ptime
-, uri
-, ppx_expect
-, alcotest
-, ppx_yojson_conv_lib
-, bisect_ppx
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  base64,
+  bigstringaf,
+  hmap,
+  lwt,
+  lwt_ppx,
+  ptime,
+  uri,
+  ppx_expect,
+  alcotest,
+  ppx_yojson_conv_lib,
+  bisect_ppx,
 }:
 
 buildDunePackage rec {

--- a/ocaml/dune/rpc-lwt.nix
+++ b/ocaml/dune/rpc-lwt.nix
@@ -1,11 +1,24 @@
-{ lib, buildDunePackage, dune, dune-rpc, lwt, csexp, dyn, result }:
-
+{
+  lib,
+  buildDunePackage,
+  dune,
+  dune-rpc,
+  lwt,
+  csexp,
+  dyn,
+  result,
+}:
 
 buildDunePackage {
   pname = "dune-rpc-lwt";
   inherit (dune) src version;
 
-  propagatedBuildInputs = [ csexp dune-rpc lwt result ];
+  propagatedBuildInputs = [
+    csexp
+    dune-rpc
+    lwt
+    result
+  ];
   dontAddPrefix = true;
   inherit (dyn) preBuild;
 }

--- a/ocaml/eio-ssl/default.nix
+++ b/ocaml/eio-ssl/default.nix
@@ -1,4 +1,9 @@
-{ fetchFromGitHub, buildDunePackage, ssl, eio }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  ssl,
+  eio,
+}:
 
 buildDunePackage {
   pname = "eio-ssl";
@@ -9,5 +14,8 @@ buildDunePackage {
     rev = "5e83c3ffb2200affde9d900de02f6994dd6421da";
     hash = "sha256-rkk4OA+kq2jFuKwVtR9MRDtMXt7WYc9fBB+CgY+n6Kc=";
   };
-  propagatedBuildInputs = [ ssl eio ];
+  propagatedBuildInputs = [
+    ssl
+    eio
+  ];
 }

--- a/ocaml/eio/lwt_eio.nix
+++ b/ocaml/eio/lwt_eio.nix
@@ -1,12 +1,21 @@
-{ fetchFromGitHub, lib, buildDunePackage, lwt, eio }:
+{
+  fetchFromGitHub,
+  lib,
+  buildDunePackage,
+  lwt,
+  eio,
+}:
 
 buildDunePackage {
   pname = "lwt_eio";
   version = "0.5.1";
   src = builtins.fetchurl {
-    url = https://github.com/ocaml-multicore/lwt_eio/releases/download/v0.5.1/lwt_eio-0.5.1.tbz;
+    url = "https://github.com/ocaml-multicore/lwt_eio/releases/download/v0.5.1/lwt_eio-0.5.1.tbz";
     sha256 = "08bc9yxdzjll0ig1fnkr3wyk0bqx6nkncjfns2xd6m3qg226flkn";
   };
 
-  propagatedBuildInputs = [ lwt eio ];
+  propagatedBuildInputs = [
+    lwt
+    eio
+  ];
 }

--- a/ocaml/esy/default.nix
+++ b/ocaml/esy/default.nix
@@ -11,15 +11,16 @@
 #    }' \
 #  --pure
 
-{ callPackage
-, bash
-, binutils
-, coreutils
-, makeWrapper
-, lib
-, fetchFromGitHub
-, fetchFromGitLab
-, ocamlPackages
+{
+  callPackage,
+  bash,
+  binutils,
+  coreutils,
+  makeWrapper,
+  lib,
+  fetchFromGitHub,
+  fetchFromGitLab,
+  ocamlPackages,
 }:
 
 let
@@ -33,25 +34,25 @@ let
 
   esyVersion = currentVersion;
 
-  esyOcamlPkgs = ocamlPackages.overrideScope (self: super: rec {
-    alcotest = super.alcotest.overrideAttrs (_: {
-      src = builtins.fetchurl {
-        url = https://github.com/mirage/alcotest/releases/download/1.4.0/alcotest-mirage-1.4.0.tbz;
-        sha256 = "1h9yp44snb6sgm5g1x3wg4gwjscic7i56jf0j8jr07355pxwrami";
-      };
-      propagatedBuildInputs = with self; [
-        astring
-        cmdliner
-        fmt
-        uuidm
-        re
-        stdlib-shims
-        uutf
-      ];
-    });
+  esyOcamlPkgs = ocamlPackages.overrideScope (
+    self: super: rec {
+      alcotest = super.alcotest.overrideAttrs (_: {
+        src = builtins.fetchurl {
+          url = "https://github.com/mirage/alcotest/releases/download/1.4.0/alcotest-mirage-1.4.0.tbz";
+          sha256 = "1h9yp44snb6sgm5g1x3wg4gwjscic7i56jf0j8jr07355pxwrami";
+        };
+        propagatedBuildInputs = with self; [
+          astring
+          cmdliner
+          fmt
+          uuidm
+          re
+          stdlib-shims
+          uutf
+        ];
+      });
 
-    cmdliner =
-      super.cmdliner.overrideAttrs (_: {
+      cmdliner = super.cmdliner.overrideAttrs (_: {
         src = fetchFromGitHub {
           owner = "esy-ocaml";
           repo = "cmdliner";
@@ -61,40 +62,44 @@ let
         createFindlibDestdir = true;
       });
 
-    fmt = super.fmt.overrideAttrs (_: {
-      src = fetchFromGitHub {
-        owner = "dbuenzli";
-        repo = "fmt";
-        rev = "v0.8.10";
-        sha256 = "sha256-HKNy7fWS7PUhjYpKCEzXx+jAvdeYENPlzW4/FrhtyOU=";
-      };
-    });
+      fmt = super.fmt.overrideAttrs (_: {
+        src = fetchFromGitHub {
+          owner = "dbuenzli";
+          repo = "fmt";
+          rev = "v0.8.10";
+          sha256 = "sha256-HKNy7fWS7PUhjYpKCEzXx+jAvdeYENPlzW4/FrhtyOU=";
+        };
+      });
 
-    uuidm = super.uuidm.overrideAttrs (_: {
-      src = builtins.fetchurl {
-        url = "https://erratique.ch/software/uuidm/releases/uuidm-0.9.7.tbz";
-        sha256 = "1ivxb3hxn9bk62rmixx6px4fvn52s4yr1bpla7rgkcn8981v45r8";
-      };
+      uuidm = super.uuidm.overrideAttrs (_: {
+        src = builtins.fetchurl {
+          url = "https://erratique.ch/software/uuidm/releases/uuidm-0.9.7.tbz";
+          sha256 = "1ivxb3hxn9bk62rmixx6px4fvn52s4yr1bpla7rgkcn8981v45r8";
+        };
 
-    });
+      });
 
-    uunf = super.uunf.override { cmdlinerSupport = false; };
-    uuseg = super.uuseg.override { cmdlinerSupport = false; };
+      uunf = super.uunf.override { cmdlinerSupport = false; };
+      uuseg = super.uuseg.override { cmdlinerSupport = false; };
 
-    menhirLib = super.menhirLib.overrideAttrs (_: {
-      version = "20211012";
-      src = fetchFromGitLab {
-        domain = "gitlab.inria.fr";
-        owner = "fpottier";
-        repo = "menhir";
-        rev = "20211012";
-        sha256 = "sha256-gHw9LmA4xudm6iNPpop4VDi988ge4pHZFLaEva4qbiI=";
-      };
-    });
-    menhir = super.menhir.overrideAttrs (_: {
-      buildInputs = with self; [ menhirLib menhirSdk ];
-    });
-  });
+      menhirLib = super.menhirLib.overrideAttrs (_: {
+        version = "20211012";
+        src = fetchFromGitLab {
+          domain = "gitlab.inria.fr";
+          owner = "fpottier";
+          repo = "menhir";
+          rev = "20211012";
+          sha256 = "sha256-gHw9LmA4xudm6iNPpop4VDi988ge4pHZFLaEva4qbiI=";
+        };
+      });
+      menhir = super.menhir.overrideAttrs (_: {
+        buildInputs = with self; [
+          menhirLib
+          menhirSdk
+        ];
+      });
+    }
+  );
 in
 
 with esyOcamlPkgs;
@@ -128,7 +133,7 @@ let
     '';
 
     meta = {
-      homepage = https://github.com/andreypopp/esy-solve-cudf;
+      homepage = "https://github.com/andreypopp/esy-solve-cudf";
       description = "package.json workflow for native development with Reason/OCaml";
       license = lib.licenses.gpl3;
     };
@@ -243,7 +248,7 @@ buildDunePackage {
   '';
 
   meta = {
-    homepage = https://github.com/esy/esy;
+    homepage = "https://github.com/esy/esy";
     description = "package.json workflow for native development with Reason/OCaml";
     license = lib.licenses.bsd2;
   };

--- a/ocaml/flow_parser/default.nix
+++ b/ocaml/flow_parser/default.nix
@@ -1,4 +1,12 @@
-{ fetchFromGitHub, buildDunePackage, base, ppx_deriving, ppx_gen_rec, sedlex, wtf8 }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  base,
+  ppx_deriving,
+  ppx_gen_rec,
+  sedlex,
+  wtf8,
+}:
 
 buildDunePackage {
   pname = "flow_parser";

--- a/ocaml/gluten/async.nix
+++ b/ocaml/gluten/async.nix
@@ -1,8 +1,15 @@
-{ buildDunePackage, faraday-async, gluten }:
+{
+  buildDunePackage,
+  faraday-async,
+  gluten,
+}:
 
 buildDunePackage {
   pname = "gluten-async";
   inherit (gluten) src version;
 
-  propagatedBuildInputs = [ faraday-async gluten ];
+  propagatedBuildInputs = [
+    faraday-async
+    gluten
+  ];
 }

--- a/ocaml/gluten/default.nix
+++ b/ocaml/gluten/default.nix
@@ -1,12 +1,20 @@
-{ fetchFromGitHub, buildDunePackage, bigstringaf, faraday }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  bigstringaf,
+  faraday,
+}:
 
 buildDunePackage {
   pname = "gluten";
   version = "0.5.1";
 
   src = builtins.fetchurl {
-    url = https://github.com/anmonteiro/gluten/releases/download/0.5.1/gluten-0.5.1.tbz;
+    url = "https://github.com/anmonteiro/gluten/releases/download/0.5.1/gluten-0.5.1.tbz";
     sha256 = "15lx1zmkjzawi78qsssjf179p9f5302ygd3i97ay9gyia0q1p5sm";
   };
-  propagatedBuildInputs = [ bigstringaf faraday ];
+  propagatedBuildInputs = [
+    bigstringaf
+    faraday
+  ];
 }

--- a/ocaml/gluten/eio.nix
+++ b/ocaml/gluten/eio.nix
@@ -1,8 +1,19 @@
-{ buildDunePackage, gluten, eio, eio_main, eio-ssl }:
+{
+  buildDunePackage,
+  gluten,
+  eio,
+  eio_main,
+  eio-ssl,
+}:
 
 buildDunePackage {
   pname = "gluten-eio";
   inherit (gluten) src version;
 
-  propagatedBuildInputs = [ gluten eio eio_main eio-ssl ];
+  propagatedBuildInputs = [
+    gluten
+    eio
+    eio_main
+    eio-ssl
+  ];
 }

--- a/ocaml/gluten/lwt-unix.nix
+++ b/ocaml/gluten/lwt-unix.nix
@@ -1,4 +1,10 @@
-{ buildDunePackage, gluten, faraday-lwt-unix, gluten-lwt, lwt_ssl }:
+{
+  buildDunePackage,
+  gluten,
+  faraday-lwt-unix,
+  gluten-lwt,
+  lwt_ssl,
+}:
 
 buildDunePackage {
   pname = "gluten-lwt-unix";

--- a/ocaml/gluten/lwt.nix
+++ b/ocaml/gluten/lwt.nix
@@ -1,7 +1,14 @@
-{ buildDunePackage, gluten, lwt }:
+{
+  buildDunePackage,
+  gluten,
+  lwt,
+}:
 
 buildDunePackage {
   pname = "gluten-lwt";
-  propagatedBuildInputs = [ gluten lwt ];
+  propagatedBuildInputs = [
+    gluten
+    lwt
+  ];
   inherit (gluten) src version;
 }

--- a/ocaml/gluten/mirage.nix
+++ b/ocaml/gluten/mirage.nix
@@ -1,10 +1,11 @@
-{ buildDunePackage
-, faraday-lwt
-, gluten
-, gluten-lwt
-, conduit-mirage
-, mirage-flow
-, cstruct
+{
+  buildDunePackage,
+  faraday-lwt,
+  gluten,
+  gluten-lwt,
+  conduit-mirage,
+  mirage-flow,
+  cstruct,
 }:
 
 buildDunePackage {

--- a/ocaml/graphql/async.nix
+++ b/ocaml/graphql/async.nix
@@ -1,8 +1,16 @@
-{ buildDunePackage, graphql, async, alcotest }:
+{
+  buildDunePackage,
+  graphql,
+  async,
+  alcotest,
+}:
 
 buildDunePackage {
   pname = "graphql-async";
   inherit (graphql) src version;
   checkInputs = [ alcotest ];
-  propagatedBuildInputs = [ graphql async ];
+  propagatedBuildInputs = [
+    graphql
+    async
+  ];
 }

--- a/ocaml/graphql/default.nix
+++ b/ocaml/graphql/default.nix
@@ -1,8 +1,20 @@
-{ buildDunePackage, graphql_parser, yojson, rresult, seq, alcotest }:
+{
+  buildDunePackage,
+  graphql_parser,
+  yojson,
+  rresult,
+  seq,
+  alcotest,
+}:
 
 buildDunePackage {
   pname = "graphql";
   inherit (graphql_parser) src version;
   checkInputs = [ alcotest ];
-  propagatedBuildInputs = [ graphql_parser yojson rresult seq ];
+  propagatedBuildInputs = [
+    graphql_parser
+    yojson
+    rresult
+    seq
+  ];
 }

--- a/ocaml/graphql/lwt.nix
+++ b/ocaml/graphql/lwt.nix
@@ -1,8 +1,16 @@
-{ buildDunePackage, graphql, lwt, alcotest }:
+{
+  buildDunePackage,
+  graphql,
+  lwt,
+  alcotest,
+}:
 
 buildDunePackage {
   pname = "graphql-lwt";
   inherit (graphql) src version;
   checkInputs = [ alcotest ];
-  propagatedBuildInputs = [ graphql lwt ];
+  propagatedBuildInputs = [
+    graphql
+    lwt
+  ];
 }

--- a/ocaml/graphql/parser.nix
+++ b/ocaml/graphql/parser.nix
@@ -1,4 +1,11 @@
-{ fetchFromGitHub, buildDunePackage, alcotest, menhir, fmt, re }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  alcotest,
+  menhir,
+  fmt,
+  re,
+}:
 
 buildDunePackage {
   pname = "graphql_parser";
@@ -12,5 +19,9 @@ buildDunePackage {
 
   nativeBuildInputs = [ menhir ];
   checkInputs = [ alcotest ];
-  propagatedBuildInputs = [ menhir fmt re ];
+  propagatedBuildInputs = [
+    menhir
+    fmt
+    re
+  ];
 }

--- a/ocaml/graphql_ppx/default.nix
+++ b/ocaml/graphql_ppx/default.nix
@@ -1,4 +1,11 @@
-{ fetchFromGitHub, buildDunePackage, cppo, yojson, ppxlib, reason }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  cppo,
+  yojson,
+  ppxlib,
+  reason,
+}:
 
 buildDunePackage {
   pname = "graphql_ppx";
@@ -12,7 +19,11 @@ buildDunePackage {
   };
 
   nativeBuildInputs = [ cppo ];
-  propagatedBuildInputs = [ yojson ppxlib reason ];
+  propagatedBuildInputs = [
+    yojson
+    ppxlib
+    reason
+  ];
 
   postInstall = ''
     mkdir -p $out/lib-runtime

--- a/ocaml/h2/async.nix
+++ b/ocaml/h2/async.nix
@@ -1,9 +1,22 @@
-{ buildDunePackage, h2, async, gluten-async, faraday-async, async_ssl }:
+{
+  buildDunePackage,
+  h2,
+  async,
+  gluten-async,
+  faraday-async,
+  async_ssl,
+}:
 
 buildDunePackage {
   inherit (h2) src version;
   pname = "h2-async";
   doCheck = false;
 
-  propagatedBuildInputs = [ h2 async gluten-async faraday-async async_ssl ];
+  propagatedBuildInputs = [
+    h2
+    async
+    gluten-async
+    faraday-async
+    async_ssl
+  ];
 }

--- a/ocaml/h2/default.nix
+++ b/ocaml/h2/default.nix
@@ -1,8 +1,23 @@
-{ buildDunePackage, angstrom, faraday, base64, psq, hpack, httpaf }:
+{
+  buildDunePackage,
+  angstrom,
+  faraday,
+  base64,
+  psq,
+  hpack,
+  httpaf,
+}:
 
 buildDunePackage {
   inherit (hpack) src;
   version = "0.8.0";
   pname = "h2";
-  propagatedBuildInputs = [ angstrom faraday base64 psq hpack httpaf ];
+  propagatedBuildInputs = [
+    angstrom
+    faraday
+    base64
+    psq
+    hpack
+    httpaf
+  ];
 }

--- a/ocaml/h2/eio.nix
+++ b/ocaml/h2/eio.nix
@@ -1,7 +1,8 @@
-{ buildDunePackage
-, h2
-, gluten-eio
-, eio_main
+{
+  buildDunePackage,
+  h2,
+  gluten-eio,
+  eio_main,
 }:
 
 buildDunePackage {

--- a/ocaml/h2/hpack.nix
+++ b/ocaml/h2/hpack.nix
@@ -1,12 +1,20 @@
-{ fetchFromGitHub, buildDunePackage, angstrom, faraday }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  angstrom,
+  faraday,
+}:
 
 buildDunePackage {
   pname = "hpack";
   version = "0.10.0-dev";
 
   src = builtins.fetchurl {
-    url = https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz;
+    url = "https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz";
     sha256 = "1ijkijpk5ss9d2dn2myrqp1k2qc67ycvvix834v3islh7l8hpr1n";
   };
-  propagatedBuildInputs = [ angstrom faraday ];
+  propagatedBuildInputs = [
+    angstrom
+    faraday
+  ];
 }

--- a/ocaml/h2/lwt-unix.nix
+++ b/ocaml/h2/lwt-unix.nix
@@ -1,7 +1,19 @@
-{ buildDunePackage, gluten-lwt-unix, h2, h2-lwt, faraday-lwt-unix, lwt_ssl }:
+{
+  buildDunePackage,
+  gluten-lwt-unix,
+  h2,
+  h2-lwt,
+  faraday-lwt-unix,
+  lwt_ssl,
+}:
 
 buildDunePackage {
   inherit (h2) version src;
   pname = "h2-lwt-unix";
-  propagatedBuildInputs = [ gluten-lwt-unix h2-lwt faraday-lwt-unix lwt_ssl ];
+  propagatedBuildInputs = [
+    gluten-lwt-unix
+    h2-lwt
+    faraday-lwt-unix
+    lwt_ssl
+  ];
 }

--- a/ocaml/h2/lwt.nix
+++ b/ocaml/h2/lwt.nix
@@ -1,7 +1,16 @@
-{ buildDunePackage, gluten-lwt, h2, lwt }:
+{
+  buildDunePackage,
+  gluten-lwt,
+  h2,
+  lwt,
+}:
 
 buildDunePackage {
   inherit (h2) version src;
   pname = "h2-lwt";
-  propagatedBuildInputs = [ gluten-lwt h2 lwt ];
+  propagatedBuildInputs = [
+    gluten-lwt
+    h2
+    lwt
+  ];
 }

--- a/ocaml/h2/mirage.nix
+++ b/ocaml/h2/mirage.nix
@@ -1,8 +1,18 @@
-{ buildDunePackage, conduit-mirage, h2, h2-lwt, gluten-mirage }:
+{
+  buildDunePackage,
+  conduit-mirage,
+  h2,
+  h2-lwt,
+  gluten-mirage,
+}:
 
 buildDunePackage {
   inherit (h2) version src;
   pname = "h2-mirage";
   doCheck = false;
-  propagatedBuildInputs = [ conduit-mirage h2-lwt gluten-mirage ];
+  propagatedBuildInputs = [
+    conduit-mirage
+    h2-lwt
+    gluten-mirage
+  ];
 }

--- a/ocaml/httpun-ws/async.nix
+++ b/ocaml/httpun-ws/async.nix
@@ -1,10 +1,11 @@
-{ buildDunePackage
-, httpun-ws
-, async
-, gluten-async
-, faraday-async
-, async_ssl
-, digestif
+{
+  buildDunePackage,
+  httpun-ws,
+  async,
+  gluten-async,
+  faraday-async,
+  async_ssl,
+  digestif,
 }:
 
 buildDunePackage {

--- a/ocaml/httpun-ws/default.nix
+++ b/ocaml/httpun-ws/default.nix
@@ -1,12 +1,26 @@
-{ fetchFromGitHub, buildDunePackage, angstrom, faraday, gluten, httpaf, base64 }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  angstrom,
+  faraday,
+  gluten,
+  httpaf,
+  base64,
+}:
 
 buildDunePackage {
   pname = "httpun-ws";
   version = "n/a";
   src = builtins.fetchurl {
-    url = https://github.com/anmonteiro/httpun-ws/releases/download/0.1.0/httpun-ws-0.1.0.tbz;
+    url = "https://github.com/anmonteiro/httpun-ws/releases/download/0.1.0/httpun-ws-0.1.0.tbz";
     sha256 = "1p0z8sbzsm42ifl3awc923zz24f559lz5w3vn200wr0f0imcl6cx";
   };
 
-  propagatedBuildInputs = [ angstrom faraday gluten httpaf base64 ];
+  propagatedBuildInputs = [
+    angstrom
+    faraday
+    gluten
+    httpaf
+    base64
+  ];
 }

--- a/ocaml/httpun-ws/eio.nix
+++ b/ocaml/httpun-ws/eio.nix
@@ -1,7 +1,18 @@
-{ buildDunePackage, httpun-ws, gluten-eio, eio, digestif }:
+{
+  buildDunePackage,
+  httpun-ws,
+  gluten-eio,
+  eio,
+  digestif,
+}:
 
 buildDunePackage {
   pname = "httpun-ws-eio";
   inherit (httpun-ws) src version;
-  propagatedBuildInputs = [ httpun-ws gluten-eio eio digestif ];
+  propagatedBuildInputs = [
+    httpun-ws
+    gluten-eio
+    eio
+    digestif
+  ];
 }

--- a/ocaml/httpun-ws/lwt-unix.nix
+++ b/ocaml/httpun-ws/lwt-unix.nix
@@ -1,8 +1,9 @@
-{ buildDunePackage
-, httpun-ws
-, httpun-ws-lwt
-, faraday-lwt-unix
-, gluten-lwt-unix
+{
+  buildDunePackage,
+  httpun-ws,
+  httpun-ws-lwt,
+  faraday-lwt-unix,
+  gluten-lwt-unix,
 }:
 
 buildDunePackage {

--- a/ocaml/httpun-ws/lwt.nix
+++ b/ocaml/httpun-ws/lwt.nix
@@ -1,7 +1,18 @@
-{ buildDunePackage, httpun-ws, gluten-lwt, lwt, digestif }:
+{
+  buildDunePackage,
+  httpun-ws,
+  gluten-lwt,
+  lwt,
+  digestif,
+}:
 
 buildDunePackage {
   pname = "httpun-ws-lwt";
   inherit (httpun-ws) src version;
-  propagatedBuildInputs = [ httpun-ws gluten-lwt lwt digestif ];
+  propagatedBuildInputs = [
+    httpun-ws
+    gluten-lwt
+    lwt
+    digestif
+  ];
 }

--- a/ocaml/httpun-ws/mirage.nix
+++ b/ocaml/httpun-ws/mirage.nix
@@ -1,13 +1,18 @@
-{ buildDunePackage
-, conduit-mirage
-, httpun-ws
-, httpun-ws-lwt
-, gluten-mirage
+{
+  buildDunePackage,
+  conduit-mirage,
+  httpun-ws,
+  httpun-ws-lwt,
+  gluten-mirage,
 }:
 
 buildDunePackage {
   pname = "httpun-ws-mirage";
   inherit (httpun-ws) src version;
 
-  propagatedBuildInputs = [ conduit-mirage httpun-ws-lwt gluten-mirage ];
+  propagatedBuildInputs = [
+    conduit-mirage
+    httpun-ws-lwt
+    gluten-mirage
+  ];
 }

--- a/ocaml/httpun/async.nix
+++ b/ocaml/httpun/async.nix
@@ -1,9 +1,10 @@
-{ buildDunePackage
-, httpun
-, async
-, gluten-async
-, faraday-async
-, async_ssl
+{
+  buildDunePackage,
+  httpun,
+  async,
+  gluten-async,
+  faraday-async,
+  async_ssl,
 }:
 
 buildDunePackage {

--- a/ocaml/httpun/default.nix
+++ b/ocaml/httpun/default.nix
@@ -1,7 +1,17 @@
-{ fetchFromGitHub, buildDunePackage, httpun-types, angstrom, faraday }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  httpun-types,
+  angstrom,
+  faraday,
+}:
 
 buildDunePackage {
   inherit (httpun-types) version src;
   pname = "httpun";
-  propagatedBuildInputs = [ angstrom faraday httpun-types ];
+  propagatedBuildInputs = [
+    angstrom
+    faraday
+    httpun-types
+  ];
 }

--- a/ocaml/httpun/eio.nix
+++ b/ocaml/httpun/eio.nix
@@ -1,7 +1,8 @@
-{ buildDunePackage
-, httpun
-, gluten-eio
-, eio_main
+{
+  buildDunePackage,
+  httpun,
+  gluten-eio,
+  eio_main,
 }:
 
 buildDunePackage {

--- a/ocaml/httpun/lwt-unix.nix
+++ b/ocaml/httpun/lwt-unix.nix
@@ -1,9 +1,10 @@
-{ buildDunePackage
-, httpun
-, httpun-lwt
-, gluten-lwt-unix
-, faraday-lwt-unix
-, lwt_ssl
+{
+  buildDunePackage,
+  httpun,
+  httpun-lwt,
+  gluten-lwt-unix,
+  faraday-lwt-unix,
+  lwt_ssl,
 }:
 
 buildDunePackage {

--- a/ocaml/httpun/lwt.nix
+++ b/ocaml/httpun/lwt.nix
@@ -1,7 +1,16 @@
-{ buildDunePackage, httpun, gluten-lwt, lwt }:
+{
+  buildDunePackage,
+  httpun,
+  gluten-lwt,
+  lwt,
+}:
 
 buildDunePackage {
   pname = "httpun-lwt";
   inherit (httpun) version src;
-  propagatedBuildInputs = [ httpun gluten-lwt lwt ];
+  propagatedBuildInputs = [
+    httpun
+    gluten-lwt
+    lwt
+  ];
 }

--- a/ocaml/httpun/mirage.nix
+++ b/ocaml/httpun/mirage.nix
@@ -1,8 +1,18 @@
-{ buildDunePackage, conduit-mirage, httpun, httpun-lwt, gluten-mirage }:
+{
+  buildDunePackage,
+  conduit-mirage,
+  httpun,
+  httpun-lwt,
+  gluten-mirage,
+}:
 
 buildDunePackage {
   inherit (httpun) version src;
   pname = "httpun-mirage";
   doCheck = false;
-  propagatedBuildInputs = [ conduit-mirage httpun-lwt gluten-mirage ];
+  propagatedBuildInputs = [
+    conduit-mirage
+    httpun-lwt
+    gluten-mirage
+  ];
 }

--- a/ocaml/httpun/types.nix
+++ b/ocaml/httpun/types.nix
@@ -1,4 +1,8 @@
-{ fetchFromGitHub, buildDunePackage, faraday }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  faraday,
+}:
 
 buildDunePackage {
   version = "0.1.0-dev";
@@ -6,7 +10,7 @@ buildDunePackage {
   propagatedBuildInputs = [ faraday ];
 
   src = builtins.fetchurl {
-    url = https://github.com/anmonteiro/httpun/releases/download/0.1.0/httpun-0.1.0.tbz;
+    url = "https://github.com/anmonteiro/httpun/releases/download/0.1.0/httpun-0.1.0.tbz";
     sha256 = "1lclla34qc03yss3vfbw83nmxg3r9ccik6013vn8vkz189glc1sh";
   };
 }

--- a/ocaml/hyper/default.nix
+++ b/ocaml/hyper/default.nix
@@ -1,9 +1,10 @@
-{ fetchFromGitHub
-, buildDunePackage
-, dream-httpaf
-, dream-pure
-, mirage-crypto-rng-lwt
-, uri
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  dream-httpaf,
+  dream-pure,
+  mirage-crypto-rng-lwt,
+  uri,
 }:
 
 buildDunePackage rec {

--- a/ocaml/janestreet-0.16.nix
+++ b/ocaml/janestreet-0.16.nix
@@ -1,17 +1,18 @@
-{ self
-, bash
-, fetchpatch
-, fetchFromGitHub
-, fzf
-, lib
-, linuxHeaders
-, nixpkgs
-, pam
-, kerberos
-, net-snmp
-, openssl
-, postgresql
-, zstd
+{
+  self,
+  bash,
+  fetchpatch,
+  fetchFromGitHub,
+  fzf,
+  lib,
+  linuxHeaders,
+  nixpkgs,
+  pam,
+  kerberos,
+  net-snmp,
+  openssl,
+  postgresql,
+  zstd,
 }:
 
 with self;
@@ -23,7 +24,10 @@ with self;
     minimalOCamlVersion = "4.08";
     hash = "sha256-hAZzc2ypbGE/8mxxk4GZqr17JlIYv71gZJMQ4plsK38=";
     meta.description = "A small library describing abstract algebra concepts";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   accessor = janePackage {
@@ -31,7 +35,11 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-yClfUXqwVoipF4WqbqC6VBVYc6t8MZYVoHGjchH7XQA=";
     meta.description = "A library that makes it nicer to work with nested functional data structures";
-    propagatedBuildInputs = [ base higher_kinded ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      higher_kinded
+      ppx_jane
+    ];
   };
 
   accessor_async = janePackage {
@@ -39,7 +47,13 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-kGT7aFNOgU8/2ez9L/lefb2LN7I87+WthZHnb+dY9PE=";
     meta.description = "Accessors for Async types, for use with the Accessor library";
-    propagatedBuildInputs = [ accessor_core async_kernel core ppx_accessor ppx_jane ];
+    propagatedBuildInputs = [
+      accessor_core
+      async_kernel
+      core
+      ppx_accessor
+      ppx_jane
+    ];
   };
 
   accessor_base = janePackage {
@@ -55,14 +69,21 @@ with self;
     pname = "accessor_core";
     hash = "sha256-f4s/I+xDi/aca1WgaE+P3CD4e80jenS0WHg4T1Stcbg=";
     meta.description = "Accessors for Core types, for use with the Accessor library";
-    propagatedBuildInputs = [ accessor_base core_kernel ];
+    propagatedBuildInputs = [
+      accessor_base
+      core_kernel
+    ];
   };
 
   async = janePackage {
     pname = "async";
     hash = "sha256-TpsC9sn8noiNI0aYbMalUUv3xlC2LMERsv6Gr928Vzc=";
     meta.description = "Monadic concurrency library";
-    propagatedBuildInputs = [ async_rpc_kernel async_unix textutils ];
+    propagatedBuildInputs = [
+      async_rpc_kernel
+      async_unix
+      textutils
+    ];
     doCheck = false; # we don't have netkit_sockets
   };
 
@@ -70,7 +91,13 @@ with self;
     pname = "async_durable";
     hash = "sha256-PImYpM9xNFUWeWRld4jFwWBRowUP1iXzdxkK/fP/rHE=";
     meta.description = "Durable connections for use with async";
-    propagatedBuildInputs = [ async_kernel async_rpc_kernel core core_kernel ppx_jane ];
+    propagatedBuildInputs = [
+      async_kernel
+      async_rpc_kernel
+      core
+      core_kernel
+      ppx_jane
+    ];
   };
 
   async_extra = janePackage {
@@ -91,7 +118,10 @@ with self;
     pname = "async_inotify";
     hash = "sha256-seFbs06w3T+B49sw3nOjpXpoJbJ+IJ3qN5LnufrsE48=";
     meta.description = "Async wrapper for inotify";
-    propagatedBuildInputs = [ async_find inotify ];
+    propagatedBuildInputs = [
+      async_find
+      inotify
+    ];
   };
 
   async_interactive = janePackage {
@@ -106,7 +136,11 @@ with self;
     hash = "sha256-JyF1busOv9JWxp55oaxBozIQyCKlmAY3csBA4/98qy0=";
     meta.description = "A small library that provide Async support for JavaScript platforms";
     buildInputs = [ js_of_ocaml-ppx ];
-    propagatedBuildInputs = [ async_rpc_kernel js_of_ocaml uri-sexp ];
+    propagatedBuildInputs = [
+      async_rpc_kernel
+      js_of_ocaml
+      uri-sexp
+    ];
   };
 
   async_kernel = janePackage {
@@ -120,14 +154,21 @@ with self;
     pname = "async_rpc_kernel";
     hash = "sha256-OccFMfhTRSQwx1LJcN8OkDpA62KabsyWn2hox84jqow=";
     meta.description = "Platform-independent core of Async RPC library";
-    propagatedBuildInputs = [ async_kernel protocol_version_header ];
+    propagatedBuildInputs = [
+      async_kernel
+      protocol_version_header
+    ];
   };
 
   async_rpc_websocket = janePackage {
     pname = "async_rpc_websocket";
     hash = "sha256-S3xIw/mew9YhtenWfp8ZD82WtOQSzJHtreT1+kRivus=";
     meta.description = "Library to serve and dispatch Async RPCs over websockets";
-    propagatedBuildInputs = [ async_rpc_kernel async_websocket cohttp_async_websocket ];
+    propagatedBuildInputs = [
+      async_rpc_kernel
+      async_websocket
+      cohttp_async_websocket
+    ];
   };
 
   async_sendfile = janePackage {
@@ -141,7 +182,10 @@ with self;
     pname = "async_shell";
     hash = "sha256-DjIbadCjPymnkDsnonmxKumCWf5P9XO3ZaAwOaYRnbk=";
     meta.description = "Shell helpers for Async";
-    propagatedBuildInputs = [ async shell ];
+    propagatedBuildInputs = [
+      async
+      shell
+    ];
   };
 
   async_smtp = janePackage {
@@ -149,7 +193,17 @@ with self;
     hash = "sha256-X0eegZMMU9EnC9Oi+6DjtwNmyzQYr3EKi1duNzEAfkk=";
     minimalOCamlVersion = "4.12";
     meta.description = "SMTP client and server";
-    propagatedBuildInputs = [ async_extra async_inotify async_sendfile async_shell async_ssl email_message resource_cache re2_stable sexp_macro ];
+    propagatedBuildInputs = [
+      async_extra
+      async_inotify
+      async_sendfile
+      async_shell
+      async_ssl
+      email_message
+      resource_cache
+      re2_stable
+      sexp_macro
+    ];
   };
 
   async_ssl = janePackage {
@@ -158,35 +212,56 @@ with self;
     hash = "sha256-83YKxvVb/JwBnQG4R/R1Ztik9T/hO4cbiNTfFnErpG4=";
     meta.description = "Async wrappers for SSL";
     buildInputs = [ dune-configurator ];
-    propagatedBuildInputs = [ async ctypes ctypes-foreign openssl ];
+    propagatedBuildInputs = [
+      async
+      ctypes
+      ctypes-foreign
+      openssl
+    ];
   };
 
   async_udp = janePackage {
     pname = "async_udp";
     hash = "sha256-vO0Y8bs24OO8t8WloeBxNaHeAoQSp0qMQJG6pP66OGw=";
     meta.description = "Monadic concurrency library";
-    propagatedBuildInputs = [ async core_unix ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      core_unix
+      ppx_jane
+    ];
   };
 
   async_unix = janePackage {
     pname = "async_unix";
     hash = "sha256-dT+yJC73sxS4NPR/GC/FyVLbWtYpM9DqKykVk8PEEWU=";
     meta.description = "Monadic concurrency library";
-    propagatedBuildInputs = [ async_kernel core_unix ];
+    propagatedBuildInputs = [
+      async_kernel
+      core_unix
+    ];
   };
 
   async_websocket = janePackage {
     pname = "async_websocket";
     hash = "sha256-Qy+A8ee6u5Vr05FNeaH/6Sdp9bcq3cnaDYO9OU06VW0=";
     meta.description = "A library that implements the websocket protocol on top of Async";
-    propagatedBuildInputs = [ async cryptokit ];
+    propagatedBuildInputs = [
+      async
+      cryptokit
+    ];
   };
 
   babel = janePackage {
     pname = "babel";
     hash = "sha256-nnMliU0d6vtHTYEy9uMi8nMaHvAsEXKN6uNByqZ28+c=";
     meta.description = "A library for defining Rpcs that can evolve over time without breaking backward compatibility.";
-    propagatedBuildInputs = [ async_rpc_kernel core ppx_jane streamable tilde_f ];
+    propagatedBuildInputs = [
+      async_rpc_kernel
+      core
+      ppx_jane
+      streamable
+      tilde_f
+    ];
     checkInputs = [ alcotest ];
   };
 
@@ -205,7 +280,10 @@ with self;
     hash = "sha256-gQbzdr05DEowzd0k9JBTF0gGMwlaVwTVJuoKZ0u9voU=";
     minimalOCamlVersion = "4.14";
     meta.description = "String type based on [Bigarray], for use in I/O and C-bindings";
-    propagatedBuildInputs = [ int_repr ppx_jane ];
+    propagatedBuildInputs = [
+      int_repr
+      ppx_jane
+    ];
   };
 
   base_quickcheck = janePackage {
@@ -213,7 +291,13 @@ with self;
     hash = "sha256-9Flg8vAoT6f+3lw9wETQhsaA1fSsQiqKeEhzo0qtDu4=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Randomized testing framework, designed for compatibility with Base";
-    propagatedBuildInputs = [ ppx_base ppx_fields_conv ppx_let ppx_sexp_value splittable_random ];
+    propagatedBuildInputs = [
+      ppx_base
+      ppx_fields_conv
+      ppx_let
+      ppx_sexp_value
+      splittable_random
+    ];
   };
 
   base_trie = janePackage {
@@ -221,7 +305,12 @@ with self;
     hash = "sha256-KV/k3B0h/4rE+MY6f4qDnlaObMmewUS+NAN2M7sb+yw=";
     minimalOCamlVersion = "4.14";
     meta.description = "Trie data structure library";
-    propagatedBuildInputs = [ base core expect_test_helpers_core ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      core
+      expect_test_helpers_core
+      ppx_jane
+    ];
   };
 
   bidirectional_map = janePackage {
@@ -234,14 +323,24 @@ with self;
   bigdecimal = janePackage {
     pname = "bigdecimal";
     hash = "sha256-6rbZE5UWCm69mqoJpWI2fqRD6OJicQSsowdYKy96wAo=";
-    propagatedBuildInputs = [ bignum core expect_test_helpers_core ppx_jane zarith ];
+    propagatedBuildInputs = [
+      bignum
+      core
+      expect_test_helpers_core
+      ppx_jane
+      zarith
+    ];
     meta.description = "Arbitrary-precision decimal based on Zarith";
   };
 
   bignum = janePackage {
     pname = "bignum";
     hash = "sha256-PmvqGImF1Nrr6swx5q3+9mCfSbieC3RvWuz8oCTkSgg=";
-    propagatedBuildInputs = [ core_kernel zarith zarith_stubs_js ];
+    propagatedBuildInputs = [
+      core_kernel
+      zarith
+      zarith_stubs_js
+    ];
     meta.description = "Core-flavoured wrapper around zarith's arbitrary-precision rationals";
   };
 
@@ -265,7 +364,11 @@ with self;
     hash = "sha256-YJ+qkVG5PLBmioa1gP7y6jwn82smyyYDIwHwhDqNeWM=";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ ppx_pattern_bind ];
-    nativeBuildInputs = [ js_of_ocaml-compiler ocaml-embed-file ppx_css ];
+    nativeBuildInputs = [
+      js_of_ocaml-compiler
+      ocaml-embed-file
+      ppx_css
+    ];
     propagatedBuildInputs = [
       async
       async_durable
@@ -306,7 +409,12 @@ with self;
     pname = "cohttp_async_websocket";
     hash = "sha256-OBtyKMyvfz0KNG4SWmvoTMVPnVTpO12N38q+kEbegJE=";
     meta.description = "Websocket library for use with cohttp and async";
-    propagatedBuildInputs = [ async_websocket cohttp-async ppx_jane uri-sexp ];
+    propagatedBuildInputs = [
+      async_websocket
+      cohttp-async
+      ppx_jane
+      uri-sexp
+    ];
     postPatch = ''
       substituteInPlace "src/cohttp_async_websocket.ml" \
         --replace-fail Cohttp_async.Io Cohttp_async.Io.IO \
@@ -326,14 +434,21 @@ with self;
     pname = "command_rpc";
     hash = "sha256-5AuJnJFT42UVl4vejU1oTyr67emrvvDCemQGnj8beTA=";
     meta.description = "Utilities for Versioned RPC communication with a child process over stdin and stdout";
-    propagatedBuildInputs = [ core async ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      async
+      ppx_jane
+    ];
   };
 
   content_security_policy = janePackage {
     pname = "content_security_policy";
     hash = "sha256-q/J+ZzeC6txyuRQzR8Hmu7cYJCQbxaMlVEmK8fj0hus=";
     meta.description = "A library for building content-security policies";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
   };
 
   core = janePackage {
@@ -342,7 +457,13 @@ with self;
     version = "0.16.2";
     hash = "sha256-cyOU++XJJkU2YMHfn8saFOxLoQSFhF7kARJi/9unbFQ=";
     buildInputs = [ jst-config ];
-    propagatedBuildInputs = [ base base_bigstring base_quickcheck ppx_jane time_now ];
+    propagatedBuildInputs = [
+      base
+      base_bigstring
+      base_quickcheck
+      ppx_jane
+      time_now
+    ];
     doCheck = false; # circular dependency with core_kernel
   };
 
@@ -357,7 +478,10 @@ with self;
     pname = "core_extended";
     hash = "sha256-hcjmFDdVKCHK8u6D4Qn2a/HYTEZOvkXHcB6BTpbjF/s=";
     meta.description = "Extra components that are not as closely vetted or as stable as Core";
-    propagatedBuildInputs = [ core_unix record_builder ];
+    propagatedBuildInputs = [
+      core_unix
+      record_builder
+    ];
   };
 
   core_kernel = janePackage {
@@ -365,7 +489,12 @@ with self;
     hash = "sha256-YB3WMNLePrOKu+mmVedNo0pWN9x5fIaBxJsby56TFJU=";
     meta.description = "System-independent part of Core";
     buildInputs = [ jst-config ];
-    propagatedBuildInputs = [ base_bigstring core int_repr sexplib ];
+    propagatedBuildInputs = [
+      base_bigstring
+      core
+      int_repr
+      sexplib
+    ];
     doCheck = false; # we don't have quickcheck_deprecated
   };
 
@@ -373,7 +502,16 @@ with self;
     pname = "core_profiler";
     hash = "sha256-AltXJSJhIqrBR9IZlDIL9HK1CPQDyEi5/I5oSQ1yBEY=";
     meta.description = "Profiling library";
-    propagatedBuildInputs = [ core core_kernel core_unix ppx_jane re2 shell textutils textutils_kernel ];
+    propagatedBuildInputs = [
+      core
+      core_kernel
+      core_unix
+      ppx_jane
+      re2
+      shell
+      textutils
+      textutils_kernel
+    ];
   };
 
   core_unix = janePackage {
@@ -381,7 +519,14 @@ with self;
     hash = "sha256-mePpxjbUumMemHDKhRgACilchgS6QHZEV1ghYtT3flg=";
     meta.description = "Unix-specific portions of Core";
     buildInputs = [ jst-config ];
-    propagatedBuildInputs = [ core_kernel expect_test_helpers_core ocaml_intrinsics ppx_jane timezone spawn ];
+    propagatedBuildInputs = [
+      core_kernel
+      expect_test_helpers_core
+      ocaml_intrinsics
+      ppx_jane
+      timezone
+      spawn
+    ];
     postPatch = ''
       patchShebangs unix_pseudo_terminal/src/discover.sh
     '';
@@ -390,28 +535,43 @@ with self;
   csvfields = janePackage {
     pname = "csvfields";
     hash = "sha256-FEkjRmLeqNvauBlrY2xtLZfxVfnFWU8w8noEArPUieo=";
-    propagatedBuildInputs = [ core num ];
+    propagatedBuildInputs = [
+      core
+      num
+    ];
     meta.description = "Runtime support for ppx_xml_conv and ppx_csv_conv";
   };
 
   dedent = janePackage {
     pname = "dedent";
     hash = "sha256-fzytLr3tVr2vPmykUBzNFMxnyMcIeeo8S9BydsTKnQw=";
-    propagatedBuildInputs = [ base ppx_jane stdio ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+      stdio
+    ];
     meta.description = "A library for improving redability of multi-line string constants in code.";
   };
 
   delimited_parsing = janePackage {
     pname = "delimited_parsing";
     hash = "sha256-XyO3hzPz48i1cnMTJvZfarM6HC7qdHqdftp9SnCjPEU=";
-    propagatedBuildInputs = [ async core_extended ];
+    propagatedBuildInputs = [
+      async
+      core_extended
+    ];
     meta.description = "Parsing of character (e.g., comma) separated and fixed-width values";
   };
 
   diffable = janePackage {
     pname = "diffable";
     hash = "sha256-ascQUbxzvRR8XrroaupyFZ2YNQMvlXn4PemumYTwRF4=";
-    propagatedBuildInputs = [ core ppx_jane stored_reversed streamable ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      stored_reversed
+      streamable
+    ];
     meta.description = "An interface for diffs.";
   };
 
@@ -419,35 +579,56 @@ with self;
     pname = "ecaml";
     hash = "sha256-VS7eTTD85ci3mJIXd2pG1Y/ygT9dCIvfzU2HtOufW6U=";
     meta.description = "Library for writing Emacs plugin in OCaml";
-    propagatedBuildInputs = [ async expect_test_helpers_core ];
+    propagatedBuildInputs = [
+      async
+      expect_test_helpers_core
+    ];
   };
 
   email_message = janePackage {
     pname = "email_message";
     hash = "sha256-eso68owbAspjaVgj/wGFQ7VQYlAwyYV3oNitLQWiRPA=";
     meta.description = "E-mail message parser";
-    propagatedBuildInputs = [ angstrom async base64 cryptokit magic-mime re2 ];
+    propagatedBuildInputs = [
+      angstrom
+      async
+      base64
+      cryptokit
+      magic-mime
+      re2
+    ];
   };
 
   env_config = janePackage {
     pname = "env_config";
     hash = "sha256-CvvpKI7F40DVC7iByrzCqW1ilPiIhdDPYaJrDoUZVSs=";
     meta.description = "Helper library for retrieving configuration from an environment variable";
-    propagatedBuildInputs = [ async core core_unix ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      core
+      core_unix
+      ppx_jane
+    ];
   };
 
   expect_test_helpers_async = janePackage {
     pname = "expect_test_helpers_async";
     hash = "sha256-dEvOMb1aCEt05XtkKIC9jWoIQ/2zM0Gj+K/ZN3bFjeI=";
     meta.description = "Async helpers for writing expectation tests";
-    propagatedBuildInputs = [ async expect_test_helpers_core ];
+    propagatedBuildInputs = [
+      async
+      expect_test_helpers_core
+    ];
   };
 
   expect_test_helpers_core = janePackage {
     pname = "expect_test_helpers_core";
     hash = "sha256-8DsMwk9WhQQ7iMNYSFBglfbcgvE5dySt4J4qjzJ3dJk=";
     meta.description = "Helpers for writing expectation tests";
-    propagatedBuildInputs = [ core_kernel sexp_pretty ];
+    propagatedBuildInputs = [
+      core_kernel
+      sexp_pretty
+    ];
   };
 
   fieldslib = janePackage {
@@ -462,8 +643,7 @@ with self;
     pname = "file_path";
     minimalOCamlVersion = "4.11";
     hash = "sha256-EEpDZNgUgyeqivRhZgQWWlerl+7OOcvAbjjQ3e1NYOQ=";
-    meta.description =
-      "A library for typed manipulation of UNIX-style file paths";
+    meta.description = "A library for typed manipulation of UNIX-style file paths";
     propagatedBuildInputs = [
       async
       core
@@ -479,7 +659,10 @@ with self;
     pname = "fuzzy_match";
     hash = "sha256-M3yOqP0/OZFbqZZpgDdhJ/FZU3MhKwIXbWjwuMlxe2Q=";
     meta.description = "A library for fuzzy string matching";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
   };
 
   fzf = janePackage {
@@ -487,7 +670,11 @@ with self;
     minimalOCamlVersion = "4.08";
     hash = "sha256-IQ2wze34LlOutecDOrPhj3U7MFVJTSjQW+If3QyHoes=";
     meta.description = "A library for running the fzf command line tool";
-    propagatedBuildInputs = [ async core_kernel ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      core_kernel
+      ppx_jane
+    ];
     postPatch = ''
       substituteInPlace src/fzf.ml --replace-fail /usr/bin/fzf ${fzf}/bin/fzf
     '';
@@ -498,7 +685,10 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-jnsf5T1D1++AUdrato/NO3gTVXu14klXozHFIG9HH/o=";
     meta.description = "Hexadecimal encoding library";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
     checkInputs = [ ounit ];
   };
 
@@ -507,7 +697,13 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-PX6P0zEOi2LU8IYwH4xqY+pNpy9OowtjmGZB9ANopLw=";
     meta.description = "A library that wraps the Mercurial command line interface";
-    propagatedBuildInputs = [ async core core_kernel expect_test_helpers_core ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      core
+      core_kernel
+      expect_test_helpers_core
+      ppx_jane
+    ];
   };
 
   higher_kinded = janePackage {
@@ -515,7 +711,10 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-aCpYc7f4mrPsGp038YabEyw72cA6GbCKsok+5Hej5P0=";
     meta.description = "A library with an encoding of higher kinded types in OCaml";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   incr_dom = janePackage {
@@ -523,7 +722,12 @@ with self;
     hash = "sha256-fnD/YnaGK6MIy/fL6bDwcoGDJhHo2+1l8dCXxwN28kg=";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ js_of_ocaml-ppx ];
-    propagatedBuildInputs = [ async_js incr_map incr_select virtual_dom ];
+    propagatedBuildInputs = [
+      async_js
+      incr_map
+      incr_select
+      virtual_dom
+    ];
   };
 
   incr_dom_interactive = janePackage {
@@ -550,7 +754,14 @@ with self;
     hash = "sha256-6a2OPdu//8SoskFiG8Gi83lgV7ZChqeju4+WMfRTuz4=";
     meta.description = "A library for simplifying rendering of large amounts of data";
     buildInputs = [ js_of_ocaml-ppx ];
-    propagatedBuildInputs = [ incr_dom ppx_jane ppx_pattern_bind splay_tree virtual_dom js_of_ocaml ];
+    propagatedBuildInputs = [
+      incr_dom
+      ppx_jane
+      ppx_pattern_bind
+      splay_tree
+      virtual_dom
+      js_of_ocaml
+    ];
   };
 
   incr_dom_sexp_form = janePackage {
@@ -576,7 +787,13 @@ with self;
     hash = "sha256-D3ZD0C4YfZOfXw+3CtqL8DKcz+b06UL8AF7Rf9x+hps=";
     meta.description = "Helpers for incremental operations on map like data structures";
     buildInputs = [ ppx_pattern_bind ];
-    propagatedBuildInputs = [ abstract_algebra bignum diffable incremental streamable ];
+    propagatedBuildInputs = [
+      abstract_algebra
+      bignum
+      diffable
+      incremental
+      streamable
+    ];
   };
 
   incr_select = janePackage {
@@ -590,21 +807,30 @@ with self;
     pname = "incremental";
     hash = "sha256-PXGY0M2xeVWDLeS3SrqXy1dqsyeKgndGT6NpuiyNQQQ=";
     meta.description = "Library for incremental computations";
-    propagatedBuildInputs = [ core_kernel lru_cache ];
+    propagatedBuildInputs = [
+      core_kernel
+      lru_cache
+    ];
   };
 
   indentation_buffer = janePackage {
     pname = "indentation_buffer";
     hash = "sha256-5ayWs7yUnuxh5S3Dp0GbYTkGXttDMomfZak4MHePFbk=";
     meta.description = "A library for building strings with indentation";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
   };
 
   int_repr = janePackage {
     pname = "int_repr";
     hash = "sha256-lghu2U1JwZaR4dkd9PcJEW3pZSPoaFhUluIDwFAYFK0=";
     meta.description = "Integers of various widths";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   jane_rope = janePackage {
@@ -612,7 +838,10 @@ with self;
     hash = "sha256-MpjbwV+VS3qRuW8kxhjGzsITEdrPeWyr0V+LiKR6U8U=";
     minimalOCamlVersion = "4.14";
     meta.description = "String representation with cheap concatenation.";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   jane-street-headers = janePackage {
@@ -627,7 +856,11 @@ with self;
     hash = "sha256-lN8+8uhcVn3AoApWzqeCe/It1G6f0VgZzFcwFEckejk=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "A library for parsing CPU capabilities out of the `cpuid` instruction.";
-    propagatedBuildInputs = [ core core_kernel ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      core_kernel
+      ppx_jane
+    ];
   };
 
   janestreet_csv = janePackage {
@@ -656,21 +889,33 @@ with self;
     pname = "js_of_ocaml_patches";
     hash = "sha256-Uj+X/0XUP5Za8NKfHGo9OZnqzKCiuurYJyluD6b0wOQ=";
     meta.description = "Additions to js_of_ocaml's standard library that are required by Jane Street libraries.";
-    propagatedBuildInputs = [ js_of_ocaml js_of_ocaml-ppx ];
+    propagatedBuildInputs = [
+      js_of_ocaml
+      js_of_ocaml-ppx
+    ];
   };
 
   jsonaf = janePackage {
     pname = "jsonaf";
     hash = "sha256-Gn54NUg4YOyrXY5kXCZhHFz24CfUT9c55cJ2sOsNVw8=";
     meta.description = "A library for parsing, manipulating, and serializing data structured as JSON";
-    propagatedBuildInputs = [ base ppx_jane angstrom faraday ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+      angstrom
+      faraday
+    ];
   };
 
   jst-config = janePackage {
     pname = "jst-config";
     hash = "sha256-GviY+zYza7UNYOlAnfAz0aH4LH2B5xA+7iELLuZLgQQ=";
     meta.description = "Compile-time configuration for Jane Street libraries";
-    buildInputs = [ dune-configurator ppx_assert stdio ];
+    buildInputs = [
+      dune-configurator
+      ppx_assert
+      stdio
+    ];
     patches = [
       # remove on next release
       (fetchpatch {
@@ -705,7 +950,14 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-A1vNNS8B5R8iyBZiZCskqScDa8D66bVS4nKQQ2K8JZk=";
     meta.description = "Align words in an intelligent way";
-    propagatedBuildInputs = [ core core_unix patience_diff ppx_jane re2 ocaml_pcre ];
+    propagatedBuildInputs = [
+      core
+      core_unix
+      patience_diff
+      ppx_jane
+      re2
+      ocaml_pcre
+    ];
   };
 
   lru_cache = janePackage {
@@ -713,14 +965,22 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-FqOBC4kBL9IuFIL4JrVU7iF1AUu+1R/CchR52eyEsa8=";
     meta.description = "An LRU Cache implementation.";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
   };
 
   man_in_the_middle_debugger = janePackage {
     pname = "man_in_the_middle_debugger";
     minimalOCamlVersion = "4.14";
     hash = "sha256-b2A/ITf9gx3thSdEY2n7jxKrMOVDpzx4JkSMB3aTyE4=";
-    propagatedBuildInputs = [ async core ppx_jane angstrom-async ];
+    propagatedBuildInputs = [
+      async
+      core
+      ppx_jane
+      angstrom-async
+    ];
     meta.description = "Man-in-the-middle debugging library";
   };
 
@@ -729,7 +989,7 @@ with self;
     version = "0.2.3";
     meta.description = "Streaming client for Memprof";
     hash = "sha256-dWkTrN8ZgNUz7BW7Aut8mfx8o4n8f6UZaDv/7rbbwNs=";
-    doCheck = ! lib.versionOlder "5.0" ocaml.version;
+    doCheck = !lib.versionOlder "5.0" ocaml.version;
   };
 
   memtrace_viewer = janePackage {
@@ -737,7 +997,10 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-MDpmLCm2buRx/TINcrtzRYHSptuebgIP0JwKurNtWBw=";
     buildInputs = [ js_of_ocaml-ppx ];
-    nativeBuildInputs = [ js_of_ocaml ocaml-embed-file ];
+    nativeBuildInputs = [
+      js_of_ocaml
+      ocaml-embed-file
+    ];
     propagatedBuildInputs = [
       async_js
       async_kernel
@@ -785,14 +1048,24 @@ with self;
     pname = "netsnmp";
     hash = "sha256-Zjm1fZgERh1TWL7GWgss4ek5oXD+/5P/si2Tw2547Vg=";
     meta.description = "An interface to the Net-SNMP client library";
-    propagatedBuildInputs = [ async core ppx_jane net-snmp openssl ];
+    propagatedBuildInputs = [
+      async
+      core
+      ppx_jane
+      net-snmp
+      openssl
+    ];
   };
 
   notty_async = janePackage {
     pname = "notty_async";
     minimalOCamlVersion = "4.14";
     hash = "sha256-/nfpgCJOUjLi+eKBRMMZAPem/lO59h+s2lnAgSp6wFU=";
-    propagatedBuildInputs = [ async ppx_jane notty ];
+    propagatedBuildInputs = [
+      async
+      ppx_jane
+      notty
+    ];
     meta.description = "An Async driver for Notty";
   };
 
@@ -807,21 +1080,31 @@ with self;
     '';
   };
 
-  ocaml-compiler-libs = janePackage ({
-    pname = "ocaml-compiler-libs";
-    minimalOCamlVersion = "4.04.1";
-    hash = "00if2f7j9d8igdkj4rck3p74y17j6b233l91mq02drzrxj199qjv";
-    meta.description = "OCaml compiler libraries repackaged";
-  } // (if lib.versionAtLeast ocaml.version "5.2" then {
-    version = "0.17.0";
-    hash = "sha256-QaC6BWrpFblra6X1+TrlK+J3vZxLvLJZ2b0427DiQzM=";
-  }
-  else { }));
+  ocaml-compiler-libs = janePackage (
+    {
+      pname = "ocaml-compiler-libs";
+      minimalOCamlVersion = "4.04.1";
+      hash = "00if2f7j9d8igdkj4rck3p74y17j6b233l91mq02drzrxj199qjv";
+      meta.description = "OCaml compiler libraries repackaged";
+    }
+    // (
+      if lib.versionAtLeast ocaml.version "5.2" then
+        {
+          version = "0.17.0";
+          hash = "sha256-QaC6BWrpFblra6X1+TrlK+J3vZxLvLJZ2b0427DiQzM=";
+        }
+      else
+        { }
+    )
+  );
 
   ocaml-embed-file = janePackage {
     pname = "ocaml-embed-file";
     hash = "sha256-rs+68VATumUgZQ9QrG+By5yNc8cy7avL0BDeqwix0co=";
-    propagatedBuildInputs = [ async ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      ppx_jane
+    ];
     meta.description = "Files contents as module constants";
   };
 
@@ -849,7 +1132,10 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-37RfbT4N0rhrrOXwneLaBCH8DeBV+M75AlwwPH0kRb0=";
     meta.description = "USDT probes for OCaml: command line tool";
-    propagatedBuildInputs = [ owee linuxHeaders ];
+    propagatedBuildInputs = [
+      owee
+      linuxHeaders
+    ];
     doCheck = false;
   };
 
@@ -858,7 +1144,12 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-qh9mX03Fk9Jb8yox7mZ/CGbWecszK15oaygKbJVDqa0=";
     meta.description = "A friendly applicative interface for Jsonaf.";
-    propagatedBuildInputs = [ core core_extended jsonaf ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      core_extended
+      jsonaf
+      ppx_jane
+    ];
   };
 
   ordinal_abbreviation = janePackage {
@@ -866,7 +1157,10 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-bGlzFcM6Yw8fcuovrv11WNtAB4mVYv4BjuMlkhsHomQ=";
     meta.description = "A minimal library for generating ordinal names of integers.";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   pam = janePackage {
@@ -877,7 +1171,11 @@ with self;
       description = "OCaml bindings for the Linux-PAM library";
       platforms = lib.platforms.linux;
     };
-    propagatedBuildInputs = [ pam core ppx_jane ];
+    propagatedBuildInputs = [
+      pam
+      core
+      ppx_jane
+    ];
   };
 
   parsexp = janePackage {
@@ -885,7 +1183,10 @@ with self;
     hash = "sha256-oc2ASDtUyRBB68tjAoblryAcXF+u3XP1mkQPO5hNbKo=";
     minimalOCamlVersion = "4.14";
     meta.description = "S-expression parsing library";
-    propagatedBuildInputs = [ base sexplib0 ];
+    propagatedBuildInputs = [
+      base
+      sexplib0
+    ];
   };
 
   parsexp_io = janePackage {
@@ -893,7 +1194,12 @@ with self;
     hash = "sha256-KunCNh9WZojlss7nXfC9ZqOVYszv+W3ZHF+O4xY+ALc=";
     minimalOCamlVersion = "4.14";
     meta.description = "S-expression parsing library";
-    propagatedBuildInputs = [ base parsexp ppx_js_style stdio ];
+    propagatedBuildInputs = [
+      base
+      parsexp
+      ppx_js_style
+      stdio
+    ];
   };
 
   patdiff = janePackage {
@@ -904,7 +1210,11 @@ with self;
     # Used by patdiff-git-wrapper.  Providing it here also causes the shebang
     # line to be automatically patched.
     buildInputs = [ bash ];
-    propagatedBuildInputs = [ core_unix patience_diff ocaml_pcre ];
+    propagatedBuildInputs = [
+      core_unix
+      patience_diff
+      ocaml_pcre
+    ];
     meta = {
       description = "File Diff using the Patience Diff algorithm";
     };
@@ -922,14 +1232,24 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-l7SMFI+U2rde2OSUNOXPb9NBsvjPrBcxStNooxMgVB8=";
     meta.description = "An RPC which tracks state on the client and server so it only needs to send diffs across the wire.";
-    propagatedBuildInputs = [ async_kernel async_rpc_kernel core core_kernel diffable ppx_jane ];
+    propagatedBuildInputs = [
+      async_kernel
+      async_rpc_kernel
+      core
+      core_kernel
+      diffable
+      ppx_jane
+    ];
   };
 
   posixat = janePackage {
     pname = "posixat";
     hash = "sha256-Nhp5jiK/TTwQXY5Bm4TTeH+xDTdXtvkSq5CS/Sr1UgA=";
     minimalOCamlVersion = "4.07";
-    propagatedBuildInputs = [ ppx_optcomp ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_optcomp
+      ppx_sexp_conv
+    ];
     meta.description = "Binding to the posix *at functions";
   };
 
@@ -938,7 +1258,14 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-RAm4h/JYENIGobLNNsKY1dRFPGlh9Vzez9EdycoLnVQ=";
     meta.description = "OCaml/async implementation of the postgres protocol (i.e., does not use C-bindings to libpq)";
-    propagatedBuildInputs = [ async async_ssl core core_kernel ppx_jane postgresql ];
+    propagatedBuildInputs = [
+      async
+      async_ssl
+      core
+      core_kernel
+      ppx_jane
+      postgresql
+    ];
   };
 
   ppx_accessor = janePackage {
@@ -955,7 +1282,12 @@ with self;
     hash = "sha256-LrpKE0BlFC3QseSXf5WhI71blshUzhH8yo2nXjAtiB8=";
     minimalOCamlVersion = "4.14";
     meta.description = "Assert-like extension nodes that raise useful errors on failure";
-    propagatedBuildInputs = [ ppx_cold ppx_compare ppx_here ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_cold
+      ppx_compare
+      ppx_here
+      ppx_sexp_conv
+    ];
   };
 
   ppx_base = janePackage {
@@ -963,7 +1295,12 @@ with self;
     hash = "sha256-Ak+7+33qEGYwZWbES032SdkFOsae0+tWtR/DV+xrB10=";
     minimalOCamlVersion = "4.14";
     meta.description = "Base set of ppx rewriters";
-    propagatedBuildInputs = [ ppx_cold ppx_enumerate ppx_hash ppx_globalize ];
+    propagatedBuildInputs = [
+      ppx_cold
+      ppx_enumerate
+      ppx_hash
+      ppx_globalize
+    ];
   };
 
   ppx_bench = janePackage {
@@ -979,7 +1316,10 @@ with self;
     hash = "sha256-ktfa4umCnLd9oY2WWX/5R7vPB/g7DJX8x3nF9fYLNCQ=";
     minimalOCamlVersion = "4.14";
     meta.description = "Generation of bin_prot readers and writers from types";
-    propagatedBuildInputs = [ bin_prot ppx_here ];
+    propagatedBuildInputs = [
+      bin_prot
+      ppx_here
+    ];
     doCheck = false; # circular dependency with ppx_jane
   };
 
@@ -988,7 +1328,10 @@ with self;
     hash = "sha256-boP07qHPbzf4ntLdV18oyID09ZUOfkIn9ZdQ0DvtrUA=";
     minimalOCamlVersion = "4.14";
     meta.description = "Expands [@cold] into [@inline never][@specialise never][@local never]";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_compare = janePackage {
@@ -996,7 +1339,10 @@ with self;
     hash = "sha256-4bZdhyfnzTjH4E303O6GO2jW968ftuXwoE4/x854JOo=";
     minimalOCamlVersion = "4.14";
     meta.description = "Generation of comparison functions from types";
-    propagatedBuildInputs = [ ppxlib base ];
+    propagatedBuildInputs = [
+      ppxlib
+      base
+    ];
   };
 
   ppx_conv_func = janePackage {
@@ -1004,7 +1350,10 @@ with self;
     hash = "sha256-HPHSZHdR9ll+7EbWc36shTdRPFYB0lkApidk+XL3clI=";
     minimalOCamlVersion = "4.14";
     meta.description = "Part of the Jane Street's PPX rewriters collection.";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_csv_conv = janePackage {
@@ -1012,7 +1361,12 @@ with self;
     hash = "sha256-RdPcDPLzoSf45Zeon3f4HcEvlwB6Q6sAINX3LHmjmj8=";
     minimalOCamlVersion = "4.14";
     meta.description = "Generate functions to read/write records in csv format";
-    propagatedBuildInputs = [ base csvfields ppx_conv_func ppx_fields_conv ];
+    propagatedBuildInputs = [
+      base
+      csvfields
+      ppx_conv_func
+      ppx_fields_conv
+    ];
   };
 
   ppx_custom_printf = janePackage {
@@ -1044,14 +1398,24 @@ with self;
     pname = "ppx_demo";
     hash = "sha256-t/jz94YpwmorhWlcuflIZe0l85cESE62L9I7NMASVWM=";
     meta.description = "PPX that exposes the source code string of an expression/module structure.";
-    propagatedBuildInputs = [ core dedent ppx_jane ppxlib ];
+    propagatedBuildInputs = [
+      core
+      dedent
+      ppx_jane
+      ppxlib
+    ];
   };
 
   ppx_derive_at_runtime = janePackage {
     pname = "ppx_derive_at_runtime";
     hash = "sha256-UESWOkyWTHJlsE6KZkty9P+iHI3oY1rLve3raRAqMbk=";
     meta.description = "Define a new ppx deriver by naming a runtime module.";
-    propagatedBuildInputs = [ base expect_test_helpers_core ppx_jane ppxlib ];
+    propagatedBuildInputs = [
+      base
+      expect_test_helpers_core
+      ppx_jane
+      ppxlib
+    ];
   };
 
   ppx_disable_unused_warnings = janePackage {
@@ -1059,7 +1423,10 @@ with self;
     hash = "sha256-jVNXmAy/Ti7MZmbdBjFuDwbmIILJB57flmmB6MoyCtY=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Expands [@disable_unused_warnings] into [@warning \"-20-26-32-33-34-35-36-37-38-39-60-66-67\"]";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_enumerate = janePackage {
@@ -1067,7 +1434,10 @@ with self;
     hash = "sha256-v5JPu+qEXoZ1+mu/yTZW2sfCzU0K60/sInG/Ox1D35s=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Generate a list containing all values of a finite type";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_expect = janePackage {
@@ -1075,7 +1445,14 @@ with self;
     hash = "sha256-H5ybRHufycdyCxKu370+QZAMUPQsHVD+6nD93tzvLn8=";
     minimalOCamlVersion = "4.14";
     meta.description = "Cram like framework for OCaml";
-    propagatedBuildInputs = [ base ppx_here ppx_inline_test stdio re ppx_compare ];
+    propagatedBuildInputs = [
+      base
+      ppx_here
+      ppx_inline_test
+      stdio
+      re
+      ppx_compare
+    ];
     doCheck = false; # test build rules broken
   };
 
@@ -1084,7 +1461,10 @@ with self;
     hash = "sha256-kl0JZocMWo2KNciCWkT4nIbJZbh56ijZmlZWbxV8Qj0=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Generation of accessor and iteration functions for ocaml records";
-    propagatedBuildInputs = [ fieldslib ppxlib ];
+    propagatedBuildInputs = [
+      fieldslib
+      ppxlib
+    ];
   };
 
   ppx_fixed_literal = janePackage {
@@ -1092,7 +1472,10 @@ with self;
     hash = "sha256-vS2KcCO0fVCmiIBkUBgK6qnqdjREj57QCujHERcJTyo=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Simpler notation for fixed point literals";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_globalize = janePackage {
@@ -1100,7 +1483,10 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-SG7710YPwWmhRVl7wN3ZQz3ZMTw3cpoywVSeVQAI3Zc=";
     meta.description = "A ppx rewriter that generates functions to copy local values to the global heap";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_hash = janePackage {
@@ -1108,7 +1494,10 @@ with self;
     hash = "sha256-ZmdW+q7fak8iG42jRQgZ6chmjHHwrDSy9wg7pq/6zwk=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that generates hash functions from type expressions and definitions";
-    propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_compare
+      ppx_sexp_conv
+    ];
   };
 
   ppx_here = janePackage {
@@ -1116,7 +1505,10 @@ with self;
     hash = "sha256-ULEom0pTusxf2k2hduv+5NVp7pW5doA/e3QGQNJfGoM=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Expands [%here] into its location";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
     doCheck = false; # test build rules broken
   };
 
@@ -1134,7 +1526,10 @@ with self;
     hash = "sha256-01q5GX53p0QQf8sifYuR0by/+d0hsaOx4YQFhp6l2es=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Syntax extension for writing in-line tests in ocaml code";
-    propagatedBuildInputs = [ ppxlib time_now ];
+    propagatedBuildInputs = [
+      ppxlib
+      time_now
+    ];
     doCheck = false; # test build rules broken
   };
 
@@ -1167,9 +1562,13 @@ with self;
     pname = "ppx_jsonaf_conv";
     hash = "sha256-GWDhSLtr2+VG3XFIbHgWUcLJFniC7/z90ndiE919CBo=";
     minimalOCamlVersion = "4.14";
-    meta.description =
-      "[@@deriving] plugin to generate Jsonaf conversion functions";
-    propagatedBuildInputs = [ base jsonaf ppx_jane ppxlib ];
+    meta.description = "[@@deriving] plugin to generate Jsonaf conversion functions";
+    propagatedBuildInputs = [
+      base
+      jsonaf
+      ppx_jane
+      ppxlib
+    ];
   };
 
   ppx_js_style = janePackage {
@@ -1177,7 +1576,11 @@ with self;
     hash = "sha256-q5CLyeu+5qjegLrJkQVMnId3HMvZ8j3c0PqEa2vTBtU=";
     minimalOCamlVersion = "4.14";
     meta.description = "Code style checker for Jane Street Packages";
-    propagatedBuildInputs = [ octavius base ppxlib ];
+    propagatedBuildInputs = [
+      octavius
+      base
+      ppxlib
+    ];
   };
 
   ppx_let = janePackage {
@@ -1185,7 +1588,10 @@ with self;
     hash = "sha256-/kEkYXFZ5OyTM4i/WWViaxKvigpoKKoiWtUWuEMkgBE=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Monadic let-bindings";
-    propagatedBuildInputs = [ ppxlib ppx_here ];
+    propagatedBuildInputs = [
+      ppxlib
+      ppx_here
+    ];
   };
 
   ppx_log = janePackage {
@@ -1193,7 +1599,13 @@ with self;
     hash = "sha256-/HwoxBWKuVqTDYe4u0cYNGqg2Lj0h49U2VrFa4cpE2g=";
     minimalOCamlVersion = "4.08.0";
     meta.description = "Ppx_sexp_message-like extension nodes for lazily rendering log messages";
-    propagatedBuildInputs = [ base ppx_here ppx_sexp_conv ppx_sexp_message sexplib ];
+    propagatedBuildInputs = [
+      base
+      ppx_here
+      ppx_sexp_conv
+      ppx_sexp_message
+      sexplib
+    ];
   };
 
   ppx_module_timer = janePackage {
@@ -1201,7 +1613,10 @@ with self;
     hash = "sha256-AfG+ZnacrR6p7MOvtktVKVLrMBpNMkX9b2+eqNZNRF4=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Ppx rewriter that records top-level module startup times";
-    propagatedBuildInputs = [ stdio time_now ];
+    propagatedBuildInputs = [
+      stdio
+      time_now
+    ];
   };
 
   ppx_optcomp = janePackage {
@@ -1209,7 +1624,10 @@ with self;
     hash = "sha256-TONxBQq/b0kc89f3+jItHd9SnerNx8xa2AjO7HOW+xQ=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Optional compilation for OCaml";
-    propagatedBuildInputs = [ stdio ppxlib ];
+    propagatedBuildInputs = [
+      stdio
+      ppxlib
+    ];
   };
 
   ppx_optional = janePackage {
@@ -1217,7 +1635,10 @@ with self;
     hash = "sha256-1GpKEEH1Ul+W0k4/8Mra/qYlyFpeMfZ3xrmB3X7uve0=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Pattern matching on flat options";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_pattern_bind = janePackage {
@@ -1240,7 +1661,11 @@ with self;
     pname = "ppx_python";
     hash = "sha256-lpc6F+Scc5ECdOXPWowKSWRnFSzKbmE8oHs7zCjq3j8=";
     meta.description = "A [@@deriving] plugin to generate Python conversion functions ";
-    propagatedBuildInputs = [ ppx_base ppxlib pyml ];
+    propagatedBuildInputs = [
+      ppx_base
+      ppxlib
+      pyml
+    ];
   };
 
   ppx_sexp_conv = janePackage {
@@ -1248,7 +1673,11 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-eCQfYAxZZmfNTbPrFW0sqrj63kIdIQ1MAlImCaMop68=";
     meta.description = "[@@deriving] plugin to generate S-expression conversion functions";
-    propagatedBuildInputs = [ ppxlib sexplib0 base ];
+    propagatedBuildInputs = [
+      ppxlib
+      sexplib0
+      base
+    ];
   };
 
   ppx_sexp_message = janePackage {
@@ -1256,7 +1685,10 @@ with self;
     hash = "sha256-4g3Fjrjqhw+XNkCyxrXkgZDEa3e+ytPsEtQA2xSv+jA=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter for easy construction of s-expressions";
-    propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_here
+      ppx_sexp_conv
+    ];
   };
 
   ppx_sexp_value = janePackage {
@@ -1264,7 +1696,10 @@ with self;
     hash = "sha256-LsP+deeFYxB38xXw7LLB3gOMGZiUOFRYklGVY7DMmvE=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that simplifies building s-expressions from ocaml values";
-    propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_here
+      ppx_sexp_conv
+    ];
   };
 
   ppx_stable = janePackage {
@@ -1272,7 +1707,10 @@ with self;
     hash = "sha256-DFCBJY+Q8LjXSF9vHwPpUJLNyMoAXdDwQZrvhl+9g0U=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Stable types conversions generator";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_stable_witness = janePackage {
@@ -1285,7 +1723,10 @@ with self;
       never change. This allows programs running at different versions of the
       code to safely communicate.
     '';
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_string = janePackage {
@@ -1293,7 +1734,11 @@ with self;
     minimalOCamlVersion = "4.04.2";
     hash = "sha256-GQlgiaES8wc6Y7rTgmPrf9UfMfu125VoNGEbdc7kFsk=";
     meta.description = "Ppx extension for string interpolation";
-    propagatedBuildInputs = [ ppx_base ppxlib stdio ];
+    propagatedBuildInputs = [
+      ppx_base
+      ppxlib
+      stdio
+    ];
   };
 
   ppx_tydi = janePackage {
@@ -1301,14 +1746,21 @@ with self;
     hash = "sha256-neu2Z7TgQdBzf8UtYDRhnGp3Iggfd90Fr+gQuwVTMOo=";
     minimalOCamlVersion = "4.14";
     meta.description = "Let expressions, inferring pattern type from expression.";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_typed_fields = janePackage {
     pname = "ppx_typed_fields";
     hash = "sha256-l4lCQ4n5FLPS82sb3FgW+HF2OEY/kY10sNfr+aQF8x8=";
     meta.description = "GADT-based field accessors and utilities";
-    propagatedBuildInputs = [ core ppx_jane ppxlib ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      ppxlib
+    ];
   };
 
   ppx_typerep_conv = janePackage {
@@ -1316,7 +1768,10 @@ with self;
     minimalOCamlVersion = "4.04.2";
     hash = "sha256-DxjgwZee0jOea7qyPfEhRrdcKWQb2jtjrowiJszS+Fs=";
     meta.description = "Generation of runtime types from type declarations";
-    propagatedBuildInputs = [ ppxlib typerep ];
+    propagatedBuildInputs = [
+      ppxlib
+      typerep
+    ];
   };
 
   ppx_variants_conv = janePackage {
@@ -1324,7 +1779,10 @@ with self;
     minimalOCamlVersion = "4.04.2";
     hash = "sha256-Q/CCcMrD+XN5YRMzKvXuiQHfcwXwI773s8x150/eMzs=";
     meta.description = "Generation of accessor and iteration functions for ocaml variant types";
-    propagatedBuildInputs = [ variantslib ppxlib ];
+    propagatedBuildInputs = [
+      variantslib
+      ppxlib
+    ];
   };
 
   ppx_xml_conv = janePackage {
@@ -1332,7 +1790,12 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-0yz1cSmgyJ7Ph1jiQjxTQ1fRwN7AQmhLmInbF4NIUew=";
     meta.description = "Generate XML conversion functions from records";
-    propagatedBuildInputs = [ base csvfields ppx_conv_func ppx_fields_conv ];
+    propagatedBuildInputs = [
+      base
+      csvfields
+      ppx_conv_func
+      ppx_fields_conv
+    ];
   };
 
   ppx_yojson_conv_lib = janePackage {
@@ -1348,14 +1811,23 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-8KpAwG0DCw9v4RtDcb3Y/BYX+ggqsRlSWAQ0NIFaIhk=";
     meta.description = "A PPX syntax extension that generates code for converting OCaml types to and from Yojson";
-    propagatedBuildInputs = [ base ppx_js_style ppx_yojson_conv_lib ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppx_js_style
+      ppx_yojson_conv_lib
+      ppxlib
+    ];
   };
 
   profunctor = janePackage {
     pname = "profunctor";
     hash = "sha256-CFHMtCuBnrlr+B2cdJm2Tamt0A/e+f3SnjEavvE31xQ=";
     meta.description = "A library providing a signature for simple profunctors and traversal of a record";
-    propagatedBuildInputs = [ base ppx_jane record_builder ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+      record_builder
+    ];
   };
 
   protocol_version_header = janePackage {
@@ -1386,14 +1858,22 @@ with self;
     pname = "re_parser";
     hash = "sha256-4ITQk7y6gEVKgpw920y0GiK+oKmPdBVLKODQs6wE8sM=";
     meta.description = "Typed parsing using regular expressions.";
-    propagatedBuildInputs = [ base regex_parser_intf re ];
+    propagatedBuildInputs = [
+      base
+      regex_parser_intf
+      re
+    ];
   };
 
   re2 = janePackage {
     pname = "re2";
     hash = "sha256-ZRJ7ooXtatEEh0sPL8M9OZ+6s7xNdTuw0Ot6txiG16I=";
     meta.description = "OCaml bindings for RE2, Google's regular expression library";
-    propagatedBuildInputs = [ core_kernel jane_rope regex_parser_intf ];
+    propagatedBuildInputs = [
+      core_kernel
+      jane_rope
+      regex_parser_intf
+    ];
     prePatch = ''
       substituteInPlace src/re2_c/dune --replace-fail 'CXX=g++' 'CXX=c++'
     '';
@@ -1404,21 +1884,33 @@ with self;
     version = "0.14.0";
     hash = "0kjc0ff6b3509s3b9n4q8ilb06d5fngdh3z58cm95vg7zkcas9w3";
     meta.description = "Re2_stable adds an incomplete but stable serialization of Re2";
-    propagatedBuildInputs = [ core re2 ];
+    propagatedBuildInputs = [
+      core
+      re2
+    ];
   };
 
   record_builder = janePackage {
     pname = "record_builder";
     hash = "sha256-46zGgN9RlDjoSbi8RimuQVrMhy65Gpic0YPZpHOeoo0=";
     meta.description = "A library which provides traversal of records with an applicative";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   redis-async = janePackage {
     pname = "redis-async";
     hash = "sha256-5msIS2m8nkaprR8NEBfKFWZBWaDJiUtjHbfPelg9/os=";
     meta.description = "Redis client for Async applications";
-    propagatedBuildInputs = [ async bignum core core_kernel ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      bignum
+      core
+      core_kernel
+      ppx_jane
+    ];
   };
 
   regex_parser_intf = janePackage {
@@ -1439,7 +1931,16 @@ with self;
     pname = "rpc_parallel";
     hash = "sha256-YlTyfCpy9qiowXz8zqgrMj2krgUhz7SPcDJpyDbsOu4=";
     meta.description = "Type-safe parallel library built on top of Async_rpc";
-    propagatedBuildInputs = [ async core core_kernel core_unix krb ppx_jane sexplib qtest ];
+    propagatedBuildInputs = [
+      async
+      core
+      core_kernel
+      core_unix
+      krb
+      ppx_jane
+      sexplib
+      qtest
+    ];
     # depends on "qtest_deprecated" which doesn't exist publicly.
     doCheck = false;
   };
@@ -1448,14 +1949,22 @@ with self;
     pname = "semantic_version";
     hash = "sha256-KJanaDUW56ndvnTlnPeQgh0C7zsRqXJ328gcEiVDrmc=";
     meta.description = "Semantic versioning";
-    propagatedBuildInputs = [ core ppx_jane re ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      re
+    ];
   };
 
   sequencer_table = janePackage {
     pname = "sequencer_table";
     hash = "sha256-7YcJEmu9wHO1NcTKbarOigOzlXxnQXUuiQAhfeRVyFM=";
     meta.description = "A table of [Async.Sequencer]'s, indexed by key";
-    propagatedBuildInputs = [ async_kernel core ppx_jane ];
+    propagatedBuildInputs = [
+      async_kernel
+      core
+      ppx_jane
+    ];
   };
 
   sexp = janePackage {
@@ -1488,13 +1997,25 @@ with self;
     hash = "sha256-Y/abRingL4+3qvaKgW9jH46E9uq7jYE2+kgr8ERKqfI=";
     minimalOCamlVersion = "4.14";
     meta.description = "Sexp grammar helpers";
-    propagatedBuildInputs = [ core ppx_bin_prot ppx_compare ppx_hash ppx_let ppx_sexp_conv ppx_sexp_message zarith ];
+    propagatedBuildInputs = [
+      core
+      ppx_bin_prot
+      ppx_compare
+      ppx_hash
+      ppx_let
+      ppx_sexp_conv
+      ppx_sexp_message
+      zarith
+    ];
   };
 
   sexp_macro = janePackage {
     pname = "sexp_macro";
     hash = "sha256-x9WsFFrV7wUqgPUw8KkfyzOxLrS5h5++OSK8QljeQqg=";
-    propagatedBuildInputs = [ async sexplib ];
+    propagatedBuildInputs = [
+      async
+      sexplib
+    ];
     meta.description = "Sexp macros";
   };
 
@@ -1503,14 +2024,21 @@ with self;
     hash = "sha256-tcWdYZ717LkGowRSRoEcUNY7VCMX64uhCaY3bXhWxKM=";
     minimalOCamlVersion = "4.14";
     meta.description = "S-expression pretty-printer";
-    propagatedBuildInputs = [ ppx_base re sexplib ];
+    propagatedBuildInputs = [
+      ppx_base
+      re
+      sexplib
+    ];
   };
 
   sexp_select = janePackage {
     pname = "sexp_select";
     hash = "sha256-HEzZowojeK9yDOoTY/l01fYLUdolzQGlMO9u3phV8so=";
     minimalOCamlVersion = "4.14";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
     meta.description = "A library to use CSS-style selectors to traverse sexp trees";
   };
 
@@ -1518,7 +2046,11 @@ with self;
     pname = "sexp_string_quickcheck";
     hash = "sha256-LwtAYlmu89mIU4vVoIN632dIxLej8S9yj5tL0BQzJwk=";
     minimalOCamlVersion = "4.14";
-    propagatedBuildInputs = [ core parsexp ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      parsexp
+      ppx_jane
+    ];
     meta.description = "Quickcheck helpers for strings parsing to sexps";
   };
 
@@ -1535,7 +2067,10 @@ with self;
     hash = "sha256-LkGNnp717LMHeWe1Ka6qUZcpw8fKSsd5MusaLgFjm70=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Library for serializing OCaml values to and from S-expressions";
-    propagatedBuildInputs = [ num parsexp ];
+    propagatedBuildInputs = [
+      num
+      parsexp
+    ];
   };
 
   shell = janePackage {
@@ -1551,7 +2086,10 @@ with self;
     pname = "shexp";
     hash = "sha256-npIcrxMOcIgsecdUEx5XHYp0KVrXiMzMLi8jskAp4vo=";
     minimalOCamlVersion = "4.07";
-    propagatedBuildInputs = [ posixat spawn ];
+    propagatedBuildInputs = [
+      posixat
+      spawn
+    ];
     meta.description = "Process library and s-expression based shell";
   };
 
@@ -1575,7 +2113,12 @@ with self;
     pname = "splittable_random";
     hash = "sha256-wMmLuzhKmnS2iTYVTPUx5Rv2LhL/ygmWmb9t2pUjz+E=";
     meta.description = "PRNG that can be split into independent streams";
-    propagatedBuildInputs = [ base ppx_assert ppx_bench ppx_sexp_message ];
+    propagatedBuildInputs = [
+      base
+      ppx_assert
+      ppx_bench
+      ppx_sexp_message
+    ];
   };
 
   streamable = janePackage {
@@ -1584,7 +2127,15 @@ with self;
     hash = "sha256-3djrUW2tPKaEmoOIpdjN6ok7U9i07yreqbi1kP+6pnY=";
     minimalOCamlVersion = "4.14";
     meta.description = "A collection of types suitable for incremental serialization.";
-    propagatedBuildInputs = [ async_kernel async_rpc_kernel base core core_kernel ppx_jane ppxlib ];
+    propagatedBuildInputs = [
+      async_kernel
+      async_rpc_kernel
+      base
+      core
+      core_kernel
+      ppx_jane
+      ppxlib
+    ];
   };
 
   string_dict = janePackage {
@@ -1592,7 +2143,11 @@ with self;
     hash = "sha256-UB4jhD1DRIHNdUFRqkLyfm+TrWgmJpbedFb+vMtAKdo=";
     minimalOCamlVersion = "4.14";
     meta.description = "Efficient static string dictionaries";
-    propagatedBuildInputs = [ base ppx_compare ppx_hash ];
+    propagatedBuildInputs = [
+      base
+      ppx_compare
+      ppx_hash
+    ];
   };
 
   stdio = janePackage {
@@ -1606,7 +2161,10 @@ with self;
   stored_reversed = janePackage {
     pname = "stored_reversed";
     hash = "sha256-ef11f0qifEvxKChM49Hnfk6J6hL+b0tMlm0iDLd5Y0Q=";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
     meta.description = "A library for representing a list temporarily stored in reverse order.";
   };
 
@@ -1614,14 +2172,21 @@ with self;
     pname = "textutils";
     hash = "sha256-2qy99MUMpkuNCvCYlk36k4kN6cPjrEILbwEUv4DyNYw=";
     meta.description = "Text output utilities";
-    propagatedBuildInputs = [ core_unix textutils_kernel ];
+    propagatedBuildInputs = [
+      core_unix
+      textutils_kernel
+    ];
   };
 
   textutils_kernel = janePackage {
     pname = "textutils_kernel";
     hash = "sha256-DiXemANj5ONmvMzp+tly3AJud5u9i7HdaHmn8aVQS48=";
     meta.description = "Text output utilities";
-    propagatedBuildInputs = [ core ppx_jane uutf ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      uutf
+    ];
   };
 
   tilde_f = janePackage {
@@ -1629,7 +2194,10 @@ with self;
     hash = "sha256-qLjM9liJfMIh2fqRPBdnmtUf4xhzk2MY8dFNdON3Aew=";
     minimalOCamlVersion = "4.14";
     meta.description = "Provides a let-syntax for continuation-passing style.";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   time_now = janePackage {
@@ -1637,8 +2205,15 @@ with self;
     hash = "sha256-DjSrx/HgwCYS0Xzm2gFvWUVLD7a1KuFVIyVrJjBi8Tc=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Reports the current time";
-    buildInputs = [ jst-config ppx_optcomp ];
-    propagatedBuildInputs = [ jane-street-headers base ppx_base ];
+    buildInputs = [
+      jst-config
+      ppx_optcomp
+    ];
+    propagatedBuildInputs = [
+      jane-street-headers
+      base
+      ppx_base
+    ];
   };
 
   timezone = janePackage {
@@ -1652,7 +2227,13 @@ with self;
     pname = "toplevel_backend";
     hash = "sha256-EjcTd4oHpGRiYf3vD2RVk+q7KKX7As+zKcNuNLi/3RE=";
     meta.description = "Shared backend for setting up toplevels";
-    propagatedBuildInputs = [ core ppx_here ppx_jane ppx_optcomp findlib ];
+    propagatedBuildInputs = [
+      core
+      ppx_here
+      ppx_jane
+      ppx_optcomp
+      findlib
+    ];
   };
 
   toplevel_expect_test = janePackage {
@@ -1675,7 +2256,10 @@ with self;
     pname = "topological_sort";
     hash = "sha256-um5++60mR++iHAruKqoQfd4EbQ1kb3L+cPOWhs9sIHI=";
     meta.description = "Topological sort algorithm";
-    propagatedBuildInputs = [ ppx_jane stdio ];
+    propagatedBuildInputs = [
+      ppx_jane
+      stdio
+    ];
   };
 
   tracing = janePackage {
@@ -1683,7 +2267,13 @@ with self;
     hash = "sha256-RN0uFPb0FEhNV/+fi+sHwpCULo1aCu5knxi7kF0H5dc=";
     minimalOCamlVersion = "4.14";
     meta.description = "Tracing library";
-    propagatedBuildInputs = [ async core core_kernel core_unix ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      core
+      core_kernel
+      core_unix
+      ppx_jane
+    ];
   };
 
   typerep = janePackage {
@@ -1699,7 +2289,10 @@ with self;
     hash = "sha256-UvFL/M9OsD+SOs9MYMKiKzZilLJHzriop6SPA4bOhZQ=";
     minimalOCamlVersion = "4.14";
     meta.description = "An identifier for a user";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
   };
 
   variantslib = janePackage {
@@ -1761,7 +2354,11 @@ with self;
     hash = "sha256-QcYqlOpCAr0owmO6sLDJhki8lUnNvtkaxldKb5I5AF0=";
     meta.description = "OCaml bindings to Zstandard";
     buildInputs = [ ppx_jane ];
-    propagatedBuildInputs = [ core_kernel ctypes zstd ];
+    propagatedBuildInputs = [
+      core_kernel
+      ctypes
+      zstd
+    ];
   };
 
 }

--- a/ocaml/janestreet-0.17.nix
+++ b/ocaml/janestreet-0.17.nix
@@ -1,17 +1,18 @@
-{ self
-, bash
-, fetchpatch
-, fetchFromGitHub
-, fzf
-, lib
-, linuxHeaders
-, nixpkgs
-, pam
-, kerberos
-, net-snmp
-, openssl
-, postgresql
-, zstd
+{
+  self,
+  bash,
+  fetchpatch,
+  fetchFromGitHub,
+  fzf,
+  lib,
+  linuxHeaders,
+  nixpkgs,
+  pam,
+  kerberos,
+  net-snmp,
+  openssl,
+  postgresql,
+  zstd,
 }:
 
 with self;
@@ -22,21 +23,34 @@ with self;
     pname = "abstract_algebra";
     hash = "sha256-W2rSSbppNkulCgGeTiovzP5zInPWIVfflDxWkGpEOFA=";
     meta.description = "A small library describing abstract algebra concepts";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   accessor = janePackage {
     pname = "accessor";
     hash = "sha256-1inoFwDDhnfhW+W3aAkcFNUkf5Umy8BDGDEbMty+Fts=";
     meta.description = "A library that makes it nicer to work with nested functional data structures";
-    propagatedBuildInputs = [ base higher_kinded ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      higher_kinded
+      ppx_jane
+    ];
   };
 
   accessor_async = janePackage {
     pname = "accessor_async";
     hash = "sha256-EYyxZur+yshYaX1EJbWc/bCaAa9PDKiuK87fIeqhspo=";
     meta.description = "Accessors for Async types, for use with the Accessor library";
-    propagatedBuildInputs = [ accessor_core async_kernel core ppx_accessor ppx_jane ];
+    propagatedBuildInputs = [
+      accessor_core
+      async_kernel
+      core
+      ppx_accessor
+      ppx_jane
+    ];
   };
 
   accessor_base = janePackage {
@@ -50,14 +64,22 @@ with self;
     pname = "accessor_core";
     hash = "sha256-ku83ZfLtVI8FvQhrKcnJmhmoNlYcVMKx1tor5N8Nq7M=";
     meta.description = "Accessors for Core types, for use with the Accessor library";
-    propagatedBuildInputs = [ accessor_base core_kernel ];
+    propagatedBuildInputs = [
+      accessor_base
+      core_kernel
+    ];
   };
 
   async = janePackage {
     pname = "async";
     hash = "sha256-CwRPH5tFZHJqptdmNwdZvKvSJ1Qr21gV1jaxsa/vFBU=";
     meta.description = "Monadic concurrency library";
-    propagatedBuildInputs = [ async_rpc_kernel async_log async_unix textutils ];
+    propagatedBuildInputs = [
+      async_rpc_kernel
+      async_log
+      async_unix
+      textutils
+    ];
     doCheck = false; # we don't have netkit_sockets
   };
 
@@ -92,7 +114,10 @@ with self;
     pname = "async_inotify";
     hash = "sha256-608G8OKQxqrQdYc1Cfrd8g8WLX6QwSeMUz8ORuSbmA8=";
     meta.description = "Async wrapper for inotify";
-    propagatedBuildInputs = [ async_find inotify ];
+    propagatedBuildInputs = [
+      async_find
+      inotify
+    ];
   };
 
   async_interactive = janePackage {
@@ -107,7 +132,11 @@ with self;
     hash = "sha256-4t7dJ04lTQ0b6clf8AvtyC8ip43vIcEBXgHJLiRbuGM=";
     meta.description = "A small library that provide Async support for JavaScript platforms";
     buildInputs = [ js_of_ocaml-ppx ];
-    propagatedBuildInputs = [ async_rpc_kernel js_of_ocaml uri-sexp ];
+    propagatedBuildInputs = [
+      async_rpc_kernel
+      js_of_ocaml
+      uri-sexp
+    ];
   };
 
   async_kernel = janePackage {
@@ -134,14 +163,21 @@ with self;
     pname = "async_rpc_kernel";
     hash = "sha256-zSqmRgybvWhS9XiNIqgxUjQU8xc9aXM69ZaBq4+r+HA=";
     meta.description = "Platform-independent core of Async RPC library";
-    propagatedBuildInputs = [ async_kernel protocol_version_header ];
+    propagatedBuildInputs = [
+      async_kernel
+      protocol_version_header
+    ];
   };
 
   async_rpc_websocket = janePackage {
     pname = "async_rpc_websocket";
     hash = "sha256-pbgG872Av6rX/CH2sOKgTVR42XpP0xhzdR/Bqoq7bSU=";
     meta.description = "Library to serve and dispatch Async RPCs over websockets";
-    propagatedBuildInputs = [ async_rpc_kernel async_websocket cohttp_async_websocket ];
+    propagatedBuildInputs = [
+      async_rpc_kernel
+      async_websocket
+      cohttp_async_websocket
+    ];
   };
 
   async_sendfile = janePackage {
@@ -155,14 +191,27 @@ with self;
     pname = "async_shell";
     hash = "sha256-/wqfuKiQQufs/KhNtBn8C9AzX7GbP8s8cyWGynJ0m1M=";
     meta.description = "Shell helpers for Async";
-    propagatedBuildInputs = [ async shell ];
+    propagatedBuildInputs = [
+      async
+      shell
+    ];
   };
 
   async_smtp = janePackage {
     pname = "async_smtp";
     hash = "sha256-RWtbg6Vpp71ock8Duya5j9Y89OUY4wRXh0pDOxM1NT4=";
     meta.description = "SMTP client and server";
-    propagatedBuildInputs = [ async_extra async_inotify async_sendfile async_shell async_ssl email_message resource_cache re2_stable sexp_macro ];
+    propagatedBuildInputs = [
+      async_extra
+      async_inotify
+      async_sendfile
+      async_shell
+      async_ssl
+      email_message
+      resource_cache
+      re2_stable
+      sexp_macro
+    ];
   };
 
   async_ssl = janePackage {
@@ -170,35 +219,57 @@ with self;
     hash = "sha256-7obEoeckwydi2wHBkBmX0LynY1QVCb3sQ/U945eteJo=";
     meta.description = "Async wrappers for SSL";
     buildInputs = [ dune-configurator ];
-    propagatedBuildInputs = [ async ctypes ctypes-foreign openssl ];
+    propagatedBuildInputs = [
+      async
+      ctypes
+      ctypes-foreign
+      openssl
+    ];
   };
 
   async_udp = janePackage {
     pname = "async_udp";
     hash = "sha256-ekAqIE/SsPep5ExLTMp4c7muBdWO6U1cITbb70hGmbc=";
     meta.description = "Monadic concurrency library";
-    propagatedBuildInputs = [ async core_unix ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      core_unix
+      ppx_jane
+    ];
   };
 
   async_unix = janePackage {
     pname = "async_unix";
     hash = "sha256-fA1e5AnNe/tMTMZ60jtGUofRi4rh+MmVx81kfhfaBaQ=";
     meta.description = "Monadic concurrency library";
-    propagatedBuildInputs = [ async_kernel cstruct core_unix ];
+    propagatedBuildInputs = [
+      async_kernel
+      cstruct
+      core_unix
+    ];
   };
 
   async_websocket = janePackage {
     pname = "async_websocket";
     hash = "sha256-22N+QO9hpkKHv3n9WkvtmJouxb/nuauv1UXdVV0zOGA=";
     meta.description = "A library that implements the websocket protocol on top of Async";
-    propagatedBuildInputs = [ async cryptokit ];
+    propagatedBuildInputs = [
+      async
+      cryptokit
+    ];
   };
 
   babel = janePackage {
     pname = "babel";
     hash = "sha256-mRSlLXtaGj8DcdDZGUZbi16qQxtfb+fXkwxz6AXxN3o=";
     meta.description = "A library for defining Rpcs that can evolve over time without breaking backward compatibility.";
-    propagatedBuildInputs = [ async_rpc_kernel core ppx_jane streamable tilde_f ];
+    propagatedBuildInputs = [
+      async_rpc_kernel
+      core
+      ppx_jane
+      streamable
+      tilde_f
+    ];
     checkInputs = [ alcotest ];
   };
 
@@ -208,7 +279,10 @@ with self;
     hash = "sha256-CPIKv7x8dXQ5BguGsLQt/Tqf42gBnh3NrSP0H7D4Aiw=";
     meta.description = "Full standard library replacement for OCaml";
     buildInputs = [ dune-configurator ];
-    propagatedBuildInputs = [ ocaml_intrinsics_kernel sexplib0 ];
+    propagatedBuildInputs = [
+      ocaml_intrinsics_kernel
+      sexplib0
+    ];
     checkInputs = [ alcotest ];
   };
 
@@ -216,7 +290,10 @@ with self;
     pname = "base_bigstring";
     hash = "sha256-tGDtkVOU10GzNsJ4wZtbqyIMjY5lHM4+rA3+w34TYOE=";
     meta.description = "String type based on [Bigarray], for use in I/O and C-bindings";
-    propagatedBuildInputs = [ int_repr ppx_jane ];
+    propagatedBuildInputs = [
+      int_repr
+      ppx_jane
+    ];
   };
 
   base_quickcheck = janePackage {
@@ -224,7 +301,13 @@ with self;
     hash = "sha256-jDxO+/9Qnntt6ZNX1xvaWvoJ0JpnPqeq8X8nsYpeqsY=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Randomized testing framework, designed for compatibility with Base";
-    propagatedBuildInputs = [ ppx_base ppx_fields_conv ppx_let ppx_sexp_value splittable_random ];
+    propagatedBuildInputs = [
+      ppx_base
+      ppx_fields_conv
+      ppx_let
+      ppx_sexp_value
+      splittable_random
+    ];
   };
 
   base_trie = janePackage {
@@ -232,7 +315,12 @@ with self;
     hash = "sha256-KuVDLJiEIjbvLCNI51iFLlsMli+hspWMyhrMk5pSL58=";
     minimalOCamlVersion = "4.14";
     meta.description = "Trie data structure library";
-    propagatedBuildInputs = [ base core expect_test_helpers_core ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      core
+      expect_test_helpers_core
+      ppx_jane
+    ];
   };
 
   bidirectional_map = janePackage {
@@ -245,14 +333,24 @@ with self;
   bigdecimal = janePackage {
     pname = "bigdecimal";
     hash = "sha256-DMZJ9x3m9WUmNNvT3LYZZBAnzFy7RywpEG5lT2wWOCQ=";
-    propagatedBuildInputs = [ bignum core expect_test_helpers_core ppx_jane zarith ];
+    propagatedBuildInputs = [
+      bignum
+      core
+      expect_test_helpers_core
+      ppx_jane
+      zarith
+    ];
     meta.description = "Arbitrary-precision decimal based on Zarith";
   };
 
   bignum = janePackage {
     pname = "bignum";
     hash = "sha256-QhVEZ97n/YUBBXYCshDa5UnZpv0BKK6xRN1kXabY3Es=";
-    propagatedBuildInputs = [ core_kernel zarith zarith_stubs_js ];
+    propagatedBuildInputs = [
+      core_kernel
+      zarith
+      zarith_stubs_js
+    ];
     meta.description = "Core-flavoured wrapper around zarith's arbitrary-precision rationals";
   };
 
@@ -279,7 +377,11 @@ with self;
     hash = "sha256-rr87o/w/a6NtCrDIIYmk2a5IZ1WJM/qJUeDqTLN1Gr4=";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ ppx_pattern_bind ];
-    nativeBuildInputs = [ js_of_ocaml-compiler ocaml-embed-file ppx_css ];
+    nativeBuildInputs = [
+      js_of_ocaml-compiler
+      ocaml-embed-file
+      ppx_css
+    ];
     propagatedBuildInputs = [
       async
       async_durable
@@ -328,14 +430,23 @@ with self;
     pname = "codicons";
     hash = "sha256-S4VrMObA5+SNeL/XsWU6SoSD/0TVvuqHjthUaQCDoRU=";
     meta.description = "Icons from VS code";
-    propagatedBuildInputs = [ core ppx_jane virtual_dom ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      virtual_dom
+    ];
   };
 
   cohttp_async_websocket = janePackage {
     pname = "cohttp_async_websocket";
     hash = "sha256-0InGCF34LWQes9S4OgbR6w+6cylThYuj1Dj0aQyTnuY=";
     meta.description = "Websocket library for use with cohttp and async";
-    propagatedBuildInputs = [ async_websocket cohttp-async ppx_jane uri-sexp ];
+    propagatedBuildInputs = [
+      async_websocket
+      cohttp-async
+      ppx_jane
+      uri-sexp
+    ];
     postPatch = ''
       substituteInPlace "src/cohttp_async_websocket.ml" \
         --replace-fail Cohttp_async.Io Cohttp_async.Io.IO \
@@ -355,7 +466,11 @@ with self;
     pname = "command_rpc";
     hash = "sha256-0qEI5inalvrjjFc7Hr+wPhK50dyiTUwcDQVWvTcHJ/8=";
     meta.description = "Utilities for Versioned RPC communication with a child process over stdin and stdout";
-    propagatedBuildInputs = [ core async ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      async
+      ppx_jane
+    ];
     doCheck = false;
   };
 
@@ -363,7 +478,12 @@ with self;
     pname = "content_security_policy";
     hash = "sha256-AQN2JJA+5B0PERNNOA9FXX6rIeej40bwJtQmHP6GKw4=";
     meta.description = "A library for building content-security policies";
-    propagatedBuildInputs = [ core ppx_jane base64 cryptokit ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      base64
+      cryptokit
+    ];
   };
 
   core = janePackage {
@@ -386,14 +506,21 @@ with self;
     pname = "core_bench";
     hash = "sha256-oXE3FuCCIbX2M0r4Ds2BMUU6g1bqe9E87lDo2CcMtMU=";
     meta.description = "Benchmarking library";
-    propagatedBuildInputs = [ textutils core_extended delimited_parsing ];
+    propagatedBuildInputs = [
+      textutils
+      core_extended
+      delimited_parsing
+    ];
   };
 
   core_extended = janePackage {
     pname = "core_extended";
     hash = "sha256-Xl6czD1gdnvHkXDz+qa7TWZq6dm8wlDqywxEIi2R6bI=";
     meta.description = "Extra components that are not as closely vetted or as stable as Core";
-    propagatedBuildInputs = [ core_unix record_builder ];
+    propagatedBuildInputs = [
+      core_unix
+      record_builder
+    ];
   };
 
   core_kernel = janePackage {
@@ -401,7 +528,13 @@ with self;
     hash = "sha256-l7U0edUCNHTroYMBHiEMDx5sl7opEmmmeo2Z06tCMts=";
     meta.description = "System-independent part of Core";
     buildInputs = [ jst-config ];
-    propagatedBuildInputs = [ base_bigstring core int_repr sexplib uopt ];
+    propagatedBuildInputs = [
+      base_bigstring
+      core
+      int_repr
+      sexplib
+      uopt
+    ];
     doCheck = false; # we don't have quickcheck_deprecated
   };
 
@@ -409,7 +542,16 @@ with self;
     pname = "core_profiler";
     hash = "sha256-UStqVfWHYr78SzMuOgJKMlz5PZBW5LZt1OwpSicEOF0=";
     meta.description = "Profiling library";
-    propagatedBuildInputs = [ core core_kernel core_unix ppx_jane re2 shell textutils textutils_kernel ];
+    propagatedBuildInputs = [
+      core
+      core_kernel
+      core_unix
+      ppx_jane
+      re2
+      shell
+      textutils
+      textutils_kernel
+    ];
   };
 
   core_unix = janePackage {
@@ -435,28 +577,43 @@ with self;
   csvfields = janePackage {
     pname = "csvfields";
     hash = "sha256-hCH2NGQIRTU5U3TUOYHao6Kz5PhnLbySmzic4ytppEc=";
-    propagatedBuildInputs = [ core num ];
+    propagatedBuildInputs = [
+      core
+      num
+    ];
     meta.description = "Runtime support for ppx_xml_conv and ppx_csv_conv";
   };
 
   dedent = janePackage {
     pname = "dedent";
     hash = "sha256-Scir/gaIhmNowXZ0tv57M/Iv1GXQIkyDks1sU1DAoIQ=";
-    propagatedBuildInputs = [ base ppx_jane stdio ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+      stdio
+    ];
     meta.description = "A library for improving redability of multi-line string constants in code.";
   };
 
   delimited_parsing = janePackage {
     pname = "delimited_parsing";
     hash = "sha256-bgt99kQvaU7FPK1+K1UOAUbSaaaCB1DV23Cuo3A68M0=";
-    propagatedBuildInputs = [ async core_extended ];
+    propagatedBuildInputs = [
+      async
+      core_extended
+    ];
     meta.description = "Parsing of character (e.g., comma) separated and fixed-width values";
   };
 
   diffable = janePackage {
     pname = "legacy_diffable";
     hash = "sha256-wUSG04bHCnwqXpWKgkceAORs1inxexiPKZIR9fEVmCo=";
-    propagatedBuildInputs = [ core ppx_jane stored_reversed streamable ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      stored_reversed
+      streamable
+    ];
     meta.description = "An interface for diffs.";
   };
 
@@ -475,28 +632,46 @@ with self;
     pname = "email_message";
     hash = "sha256-1OJ6bQb/rdyfAgMyuKT/ylpa8qBldZV5kEm0B45Ej1w=";
     meta.description = "E-mail message parser";
-    propagatedBuildInputs = [ angstrom async base64 cryptokit magic-mime re2 ];
+    propagatedBuildInputs = [
+      angstrom
+      async
+      base64
+      cryptokit
+      magic-mime
+      re2
+    ];
   };
 
   env_config = janePackage {
     pname = "env_config";
     hash = "sha256-vG309p7xqanTnrnHBwvuCO3YD4tVbTNa7F1F9sZDZE0=";
     meta.description = "Helper library for retrieving configuration from an environment variable";
-    propagatedBuildInputs = [ async core core_unix ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      core
+      core_unix
+      ppx_jane
+    ];
   };
 
   expect_test_helpers_async = janePackage {
     pname = "expect_test_helpers_async";
     hash = "sha256-oInNgNISqOrmQUXVxzjDy+mS06yPEeFPGIvaKnCETjk=";
     meta.description = "Async helpers for writing expectation tests";
-    propagatedBuildInputs = [ async expect_test_helpers_core ];
+    propagatedBuildInputs = [
+      async
+      expect_test_helpers_core
+    ];
   };
 
   expect_test_helpers_core = janePackage {
     pname = "expect_test_helpers_core";
     hash = "sha256-vnlDZ8k3JFCdN6WGiaG9OEEdQJnw0/eMogFCfTXIu2Y=";
     meta.description = "Helpers for writing expectation tests";
-    propagatedBuildInputs = [ core_kernel sexp_pretty ];
+    propagatedBuildInputs = [
+      core_kernel
+      sexp_pretty
+    ];
   };
 
   fieldslib = janePackage {
@@ -511,8 +686,7 @@ with self;
     pname = "file_path";
     minimalOCamlVersion = "4.11";
     hash = "sha256-XSLfYasn6qMZmDzAUGssOM9EX09n2W9/imTgNoSBEyk=";
-    meta.description =
-      "A library for typed manipulation of UNIX-style file paths";
+    meta.description = "A library for typed manipulation of UNIX-style file paths";
     propagatedBuildInputs = [
       async
       core
@@ -528,7 +702,10 @@ with self;
     pname = "fuzzy_match";
     hash = "sha256-XB1U4mY0LcdsKYRnmV0SR4ODTIZynZetBk5X5SdHs44=";
     meta.description = "A library for fuzzy string matching";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
   };
 
   fzf = janePackage {
@@ -536,7 +713,12 @@ with self;
     minimalOCamlVersion = "4.08";
     hash = "sha256-yHdvC3cB5sVXsZQbtNzUZkaaqOe/7y8pDHgLwugAlQg=";
     meta.description = "A library for running the fzf command line tool";
-    propagatedBuildInputs = [ async core_kernel ppx_jane fzf ];
+    propagatedBuildInputs = [
+      async
+      core_kernel
+      ppx_jane
+      fzf
+    ];
   };
 
   gel = janePackage {
@@ -546,7 +728,10 @@ with self;
       A library to mark non-record fields global. GEL stands for Global Even
       if inside a Local.
     '';
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   hex_encode = janePackage {
@@ -554,7 +739,10 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-5DqaCJllphdEreOpzAjT61qb3M6aN9b2xhiUjHVLrvE=";
     meta.description = "Hexadecimal encoding library";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
     checkInputs = [ ounit ];
   };
 
@@ -563,14 +751,23 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-DbKp1U7gRd4+3cbEYZbX2jKU578XCHYQDn/x8PA7zaM=";
     meta.description = "A library that wraps the Mercurial command line interface";
-    propagatedBuildInputs = [ async core core_kernel expect_test_helpers_core ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      core
+      core_kernel
+      expect_test_helpers_core
+      ppx_jane
+    ];
   };
 
   higher_kinded = janePackage {
     pname = "higher_kinded";
     hash = "sha256-6aZxgGzltRs2aS4MYJh23Gpoqcko6xJxU11T6KixXno=";
     meta.description = "A library with an encoding of higher kinded types in OCaml";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   incr_dom = janePackage {
@@ -578,7 +775,12 @@ with self;
     hash = "sha256-dkF7+aq5Idw1ltDgGEjGYspdmOXjXqv8AA27b4M7U8A=";
     meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
     buildInputs = [ js_of_ocaml-ppx ];
-    propagatedBuildInputs = [ async_js incr_map incr_select virtual_dom ];
+    propagatedBuildInputs = [
+      async_js
+      incr_map
+      incr_select
+      virtual_dom
+    ];
   };
 
   incr_dom_interactive = janePackage {
@@ -605,7 +807,14 @@ with self;
     hash = "sha256-bGTcUXRwy5tmdwhOwbLNYl3fDye7b5+z3hyTWGsUc3Y=";
     meta.description = "A library for simplifying rendering of large amounts of data";
     buildInputs = [ js_of_ocaml-ppx ];
-    propagatedBuildInputs = [ incr_dom ppx_jane ppx_pattern_bind splay_tree virtual_dom js_of_ocaml ];
+    propagatedBuildInputs = [
+      incr_dom
+      ppx_jane
+      ppx_pattern_bind
+      splay_tree
+      virtual_dom
+      js_of_ocaml
+    ];
   };
 
   incr_dom_sexp_form = janePackage {
@@ -631,7 +840,13 @@ with self;
     hash = "sha256-qNahlxe3Pe1EEcFz1bAKUw3vBaNjgDlahQeuj/+VqbI=";
     meta.description = "Helpers for incremental operations on map like data structures";
     buildInputs = [ ppx_pattern_bind ];
-    propagatedBuildInputs = [ abstract_algebra bignum diffable incremental streamable ];
+    propagatedBuildInputs = [
+      abstract_algebra
+      bignum
+      diffable
+      incremental
+      streamable
+    ];
   };
 
   incr_select = janePackage {
@@ -645,21 +860,30 @@ with self;
     pname = "incremental";
     hash = "sha256-siBN36Vv0Bktyxh+8tL6XkUGLqSYMxqvd0UWuTRgAnI=";
     meta.description = "Library for incremental computations";
-    propagatedBuildInputs = [ core_kernel lru_cache ];
+    propagatedBuildInputs = [
+      core_kernel
+      lru_cache
+    ];
   };
 
   indentation_buffer = janePackage {
     pname = "indentation_buffer";
     hash = "sha256-/IUZyRkcxUsddzGGIoaLpXbpCxJ1satK79GkzPxSPSc=";
     meta.description = "A library for building strings with indentation";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
   };
 
   int_repr = janePackage {
     pname = "int_repr";
     hash = "sha256-yeaAzw95zB1wow9Alg18CU+eemZVxjdLiO/wVRitDwE=";
     meta.description = "Integers of various widths";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   jane_rope = janePackage {
@@ -667,7 +891,10 @@ with self;
     hash = "sha256-Lo4+ZUX9R2EGrz4BN+LqdJgVXB3hQqNifgwsjFC1Hfs=";
     minimalOCamlVersion = "4.14";
     meta.description = "String representation with cheap concatenation.";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   jane-street-headers = janePackage {
@@ -682,7 +909,11 @@ with self;
     hash = "sha256-3ZwEZQSkJJyFW5/+C9x8nW6+GrfVwccNFPlcs7qNcjQ=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "A library for parsing CPU capabilities out of the `cpuid` instruction.";
-    propagatedBuildInputs = [ core core_kernel ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      core_kernel
+      ppx_jane
+    ];
   };
 
   janestreet_csv = janePackage {
@@ -711,7 +942,10 @@ with self;
     pname = "js_of_ocaml_patches";
     hash = "sha256-N61IEZLGfCU3ZX+sw35DAUqUh3u8RaCFcNlXxU1dvL8=";
     meta.description = "Additions to js_of_ocaml's standard library that are required by Jane Street libraries.";
-    propagatedBuildInputs = [ js_of_ocaml js_of_ocaml-ppx ];
+    propagatedBuildInputs = [
+      js_of_ocaml
+      js_of_ocaml-ppx
+    ];
     # Compat with jsoo 3.8.2
     postPatch = ''
       substituteInPlace js_of_ocaml_patches.ml js_of_ocaml_patches.mli \
@@ -723,14 +957,23 @@ with self;
     pname = "jsonaf";
     hash = "sha256-MMIDHc40cmPpO0n8yREIGMyFndw3NfvGUhy6vHnn40w=";
     meta.description = "A library for parsing, manipulating, and serializing data structured as JSON";
-    propagatedBuildInputs = [ base ppx_jane angstrom faraday ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+      angstrom
+      faraday
+    ];
   };
 
   jst-config = janePackage {
     pname = "jst-config";
     hash = "sha256-xwQ+q2Hsduu2vWMWFcjoj3H8Es00N7Mv9LwIZG4hw7c=";
     meta.description = "Compile-time configuration for Jane Street libraries";
-    buildInputs = [ dune-configurator ppx_assert stdio ];
+    buildInputs = [
+      dune-configurator
+      ppx_assert
+      stdio
+    ];
   };
 
   krb = null;
@@ -739,21 +982,36 @@ with self;
     pname = "line-up-words";
     hash = "sha256-LXXS4tlJFjdkWxcTrHGi+PiVq2QCG49OgmOnLWuyrTY=";
     meta.description = "Align words in an intelligent way";
-    propagatedBuildInputs = [ core core_unix patience_diff ppx_jane re2 ocaml_pcre ];
+    propagatedBuildInputs = [
+      core
+      core_unix
+      patience_diff
+      ppx_jane
+      re2
+      ocaml_pcre
+    ];
   };
 
   lru_cache = janePackage {
     pname = "janestreet_lru_cache";
     hash = "sha256-/UMSccN9yGAXF7/g6ueSnsfPSnF1fm0zJIRFsThZvH8=";
     meta.description = "An LRU Cache implementation.";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
   };
 
   man_in_the_middle_debugger = janePackage {
     pname = "man_in_the_middle_debugger";
     minimalOCamlVersion = "4.14";
     hash = "sha256-ImEzn/EssgW63vdGhLMp4NB/FW0SsCMQ32ZNAs7bDg4=";
-    propagatedBuildInputs = [ async core ppx_jane angstrom-async ];
+    propagatedBuildInputs = [
+      async
+      core
+      ppx_jane
+      angstrom-async
+    ];
     meta.description = "Man-in-the-middle debugging library";
   };
 
@@ -762,14 +1020,17 @@ with self;
     version = "0.2.3";
     meta.description = "Streaming client for Memprof";
     hash = "sha256-dWkTrN8ZgNUz7BW7Aut8mfx8o4n8f6UZaDv/7rbbwNs=";
-    doCheck = ! lib.versionOlder "5.0" ocaml.version;
+    doCheck = !lib.versionOlder "5.0" ocaml.version;
   };
 
   memtrace_viewer = janePackage {
     pname = "memtrace_viewer";
     hash = "sha256-vtqhN+ro9UUqmgt8mxNq3caAvtjBr2YVFFvrYF22JoE=";
     buildInputs = [ js_of_ocaml-ppx ];
-    nativeBuildInputs = [ js_of_ocaml ocaml-embed-file ];
+    nativeBuildInputs = [
+      js_of_ocaml
+      ocaml-embed-file
+    ];
     propagatedBuildInputs = [
       async_js
       async_kernel
@@ -823,14 +1084,24 @@ with self;
     pname = "netsnmp";
     hash = "sha256-Pi36I/ULt980G005nMegLg9vhyLH9c/3v6YmT0dXsyk=";
     meta.description = "An interface to the Net-SNMP client library";
-    propagatedBuildInputs = [ async core ppx_jane net-snmp openssl ];
+    propagatedBuildInputs = [
+      async
+      core
+      ppx_jane
+      net-snmp
+      openssl
+    ];
   };
 
   notty_async = janePackage {
     pname = "notty_async";
     minimalOCamlVersion = "4.14";
     hash = "sha256-zD9V2vtgCJfjj4DAQLReGIno2SLeryukCPgScyoQFP0=";
-    propagatedBuildInputs = [ async ppx_jane notty ];
+    propagatedBuildInputs = [
+      async
+      ppx_jane
+      notty
+    ];
     meta.description = "An Async driver for Notty";
   };
 
@@ -844,23 +1115,34 @@ with self;
     '';
   };
 
-  ocaml-compiler-libs = janePackage ({
-    pname = "ocaml-compiler-libs";
-    version = "0.16.0";
-    hash = lib.fakeHash;
-    meta.description = "OCaml compiler libraries repackaged";
-  } // (if lib.versionAtLeast ocaml.version "5.2" then {
-    version = "0.17.0";
-    hash = "sha256-QaC6BWrpFblra6X1+TrlK+J3vZxLvLJZ2b0427DiQzM=";
-  } else {
-    version = "0.12.4";
-    hash = "00if2f7j9d8igdkj4rck3p74y17j6b233l91mq02drzrxj199qjv";
-  }));
+  ocaml-compiler-libs = janePackage (
+    {
+      pname = "ocaml-compiler-libs";
+      version = "0.16.0";
+      hash = lib.fakeHash;
+      meta.description = "OCaml compiler libraries repackaged";
+    }
+    // (
+      if lib.versionAtLeast ocaml.version "5.2" then
+        {
+          version = "0.17.0";
+          hash = "sha256-QaC6BWrpFblra6X1+TrlK+J3vZxLvLJZ2b0427DiQzM=";
+        }
+      else
+        {
+          version = "0.12.4";
+          hash = "00if2f7j9d8igdkj4rck3p74y17j6b233l91mq02drzrxj199qjv";
+        }
+    )
+  );
 
   ocaml-embed-file = janePackage {
     pname = "ocaml-embed-file";
     hash = "sha256-7fyZ5DNcRHud0rd4dLUv9Vyf3lMwMVxgkl9jVUn1/lw=";
-    propagatedBuildInputs = [ async ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      ppx_jane
+    ];
     meta.description = "Files contents as module constants";
   };
 
@@ -868,7 +1150,10 @@ with self;
     pname = "ocaml_intrinsics";
     hash = "sha256-Ndt6ZPJamBYzr1YA941BLwvRgkkbD8AEQR/JjjR38xI=";
     meta.description = "Intrinsics";
-    buildInputs = [ dune-configurator ocaml_intrinsics_kernel ];
+    buildInputs = [
+      dune-configurator
+      ocaml_intrinsics_kernel
+    ];
   };
 
   ocaml_intrinsics_kernel = janePackage {
@@ -900,7 +1185,10 @@ with self;
     pname = "ocaml-probes";
     hash = "sha256-jml2OxJJUYXshCx+1AiDO7kFhctcw7vB86bpPDWFJJY=";
     meta.description = "USDT probes for OCaml: command line tool";
-    propagatedBuildInputs = [ owee linuxHeaders ];
+    propagatedBuildInputs = [
+      owee
+      linuxHeaders
+    ];
     doCheck = false;
   };
 
@@ -909,14 +1197,22 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-pZCiwXRwZK6ohsGz/WLacgo48ekdT35uD4VESvGxH8A=";
     meta.description = "A friendly applicative interface for Jsonaf.";
-    propagatedBuildInputs = [ core core_extended jsonaf ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      core_extended
+      jsonaf
+      ppx_jane
+    ];
   };
 
   ordinal_abbreviation = janePackage {
     pname = "ordinal_abbreviation";
     hash = "sha256-kmTGnGbhdiUoXXw2DEAeZJL2sudEf8BRRt2RHCdL7HU=";
     meta.description = "A minimal library for generating ordinal names of integers.";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   pam = janePackage {
@@ -926,7 +1222,11 @@ with self;
       description = "OCaml bindings for the Linux-PAM library";
       platforms = lib.platforms.linux;
     };
-    propagatedBuildInputs = [ pam core ppx_jane ];
+    propagatedBuildInputs = [
+      pam
+      core
+      ppx_jane
+    ];
   };
 
   parsexp = janePackage {
@@ -934,7 +1234,10 @@ with self;
     hash = "sha256-iKrZ6XDLM6eRl7obaniDKK6X8R7Kxry6HD7OQBwh3NU=";
     minimalOCamlVersion = "4.14";
     meta.description = "S-expression parsing library";
-    propagatedBuildInputs = [ base sexplib0 ];
+    propagatedBuildInputs = [
+      base
+      sexplib0
+    ];
   };
 
   parsexp_io = janePackage {
@@ -942,7 +1245,12 @@ with self;
     hash = "sha256-r1HXO3VJ167QUgz4UIQuB5sY6p10FLE3Jrp9NmoDKoE=";
     minimalOCamlVersion = "4.14";
     meta.description = "S-expression parsing library";
-    propagatedBuildInputs = [ base parsexp ppx_js_style stdio ];
+    propagatedBuildInputs = [
+      base
+      parsexp
+      ppx_js_style
+      stdio
+    ];
   };
 
   patdiff = janePackage {
@@ -951,7 +1259,11 @@ with self;
     # Used by patdiff-git-wrapper.  Providing it here also causes the shebang
     # line to be automatically patched.
     buildInputs = [ bash ];
-    propagatedBuildInputs = [ core_unix patience_diff ocaml_pcre ];
+    propagatedBuildInputs = [
+      core_unix
+      patience_diff
+      ocaml_pcre
+    ];
     doCheck = false;
     meta = {
       description = "File Diff using the Patience Diff algorithm";
@@ -985,7 +1297,10 @@ with self;
     pname = "posixat";
     hash = "sha256-G+5q8x1jfG3wEwNzX2tkcC2Pm4E5/ZYxQyBwCUNXIrw=";
     minimalOCamlVersion = "4.07";
-    propagatedBuildInputs = [ ppx_optcomp ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_optcomp
+      ppx_sexp_conv
+    ];
     meta.description = "Binding to the posix *at functions";
   };
 
@@ -994,7 +1309,14 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-IZ5k9L5k9RWdneyS/ADiHuvo0KeibR8P0ygLTIGsGLc=";
     meta.description = "OCaml/async implementation of the postgres protocol (i.e., does not use C-bindings to libpq)";
-    propagatedBuildInputs = [ async async_ssl core core_kernel ppx_jane postgresql ];
+    propagatedBuildInputs = [
+      async
+      async_ssl
+      core
+      core_kernel
+      ppx_jane
+      postgresql
+    ];
   };
 
   ppx_accessor = janePackage {
@@ -1009,7 +1331,12 @@ with self;
     hash = "sha256-o9ywdFH6+qoJ3eWb29/gGlkWkHDMuBx626mNxrT1D8A=";
     minimalOCamlVersion = "4.14";
     meta.description = "Assert-like extension nodes that raise useful errors on failure";
-    propagatedBuildInputs = [ ppx_cold ppx_compare ppx_here ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_cold
+      ppx_compare
+      ppx_here
+      ppx_sexp_conv
+    ];
   };
 
   ppx_base = janePackage {
@@ -1038,7 +1365,10 @@ with self;
     hash = "sha256-nQps/+Csx3+6H6KBzIm/dLCGWJ9fcRD7JxB4P2lky0o=";
     minimalOCamlVersion = "4.14";
     meta.description = "Generation of bin_prot readers and writers from types";
-    propagatedBuildInputs = [ bin_prot ppx_here ];
+    propagatedBuildInputs = [
+      bin_prot
+      ppx_here
+    ];
     doCheck = false; # circular dependency with ppx_jane
   };
 
@@ -1047,7 +1377,10 @@ with self;
     hash = "sha256-fFZqlcbUS7D+GjnxSjGYckkQtx6ZcPNtOIsr6Rt6D9A=";
     minimalOCamlVersion = "4.14";
     meta.description = "Expands [@cold] into [@inline never][@specialise never][@local never]";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_compare = janePackage {
@@ -1055,7 +1388,11 @@ with self;
     hash = "sha256-uAXB9cba0IBl+cA2CAuGVVxuos4HXH5jlB6Qjxx44Y0=";
     minimalOCamlVersion = "4.14";
     meta.description = "Generation of comparison functions from types";
-    propagatedBuildInputs = [ ppxlib ppxlib_jane base ];
+    propagatedBuildInputs = [
+      ppxlib
+      ppxlib_jane
+      base
+    ];
   };
 
   ppx_conv_func = janePackage {
@@ -1063,7 +1400,10 @@ with self;
     hash = "sha256-PJ8T0u8VkxefaxojwrmbMXDjqyfAIxKe92B8QqRY2JU=";
     minimalOCamlVersion = "4.14";
     meta.description = "Part of the Jane Street's PPX rewriters collection.";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_csv_conv = janePackage {
@@ -1071,7 +1411,12 @@ with self;
     hash = "sha256-NtqfagLIYiuyBjEAxilAhATx8acJwD7LykHBzfr+yAc=";
     minimalOCamlVersion = "4.14";
     meta.description = "Generate functions to read/write records in csv format";
-    propagatedBuildInputs = [ base csvfields ppx_conv_func ppx_fields_conv ];
+    propagatedBuildInputs = [
+      base
+      csvfields
+      ppx_conv_func
+      ppx_fields_conv
+    ];
   };
 
   ppx_custom_printf = janePackage {
@@ -1103,14 +1448,24 @@ with self;
     pname = "ppx_demo";
     hash = "sha256-blD96GhicOj3b6jYNniSpq6fBR+ul9Y2kn0ZmfbeVMo=";
     meta.description = "PPX that exposes the source code string of an expression/module structure.";
-    propagatedBuildInputs = [ core dedent ppx_jane ppxlib ];
+    propagatedBuildInputs = [
+      core
+      dedent
+      ppx_jane
+      ppxlib
+    ];
   };
 
   ppx_derive_at_runtime = janePackage {
     pname = "ppx_derive_at_runtime";
     hash = "sha256-Y/z4BKFRt3z1lUGdc7SznIv/ys//dZHoPSnsouj1GtI=";
     meta.description = "Define a new ppx deriver by naming a runtime module.";
-    propagatedBuildInputs = [ base expect_test_helpers_core ppx_jane ppxlib ];
+    propagatedBuildInputs = [
+      base
+      expect_test_helpers_core
+      ppx_jane
+      ppxlib
+    ];
   };
 
   ppx_disable_unused_warnings = janePackage {
@@ -1118,7 +1473,10 @@ with self;
     hash = "sha256-KHWIufXU+k6xCLf8l50Pp/1JZ2wFrKnKT/aQYpadlmU=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Expands [@disable_unused_warnings] into [@warning \"-20-26-32-33-34-35-36-37-38-39-60-66-67\"]";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_diff = janePackage {
@@ -1128,7 +1486,11 @@ with self;
       A PPX rewriter that generates the implementation of [Ldiffable.S].
       Generates diffs and update functions for OCaml types.
     '';
-    propagatedBuildInputs = [ ppxlib_jane ppx_jane gel ];
+    propagatedBuildInputs = [
+      ppxlib_jane
+      ppx_jane
+      gel
+    ];
   };
 
   ppx_embed_file = janePackage {
@@ -1138,7 +1500,12 @@ with self;
       A PPX that allows embedding files directly into executables/libraries
       as strings or bytes
     '';
-    propagatedBuildInputs = [ core ppx_jane ppxlib shell ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      ppxlib
+      shell
+    ];
   };
 
   ppx_enumerate = janePackage {
@@ -1146,7 +1513,11 @@ with self;
     hash = "sha256-YqBrxp2fe91k8L3aQVW6egoDPj8onGSRueQkE2Icdu4=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Generate a list containing all values of a finite type";
-    propagatedBuildInputs = [ base ppxlib ppxlib_jane ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+      ppxlib_jane
+    ];
   };
 
   ppx_expect = janePackage {
@@ -1154,7 +1525,14 @@ with self;
     hash = "sha256-m4Nr48ZET632I6vw5RjpNA0elW3lpN3aPmfA3RzsEn8=";
     minimalOCamlVersion = "4.14";
     meta.description = "Cram like framework for OCaml";
-    propagatedBuildInputs = [ base ppx_here ppx_inline_test stdio re ppx_compare ];
+    propagatedBuildInputs = [
+      base
+      ppx_here
+      ppx_inline_test
+      stdio
+      re
+      ppx_compare
+    ];
     doCheck = false; # test build rules broken
   };
 
@@ -1163,7 +1541,10 @@ with self;
     hash = "sha256-FA7hDgqJMJ2obsVwzwaGnNLPvjP0SkTec8Nh3znuNDQ=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Generation of accessor and iteration functions for ocaml records";
-    propagatedBuildInputs = [ fieldslib ppxlib ];
+    propagatedBuildInputs = [
+      fieldslib
+      ppxlib
+    ];
   };
 
   ppx_fixed_literal = janePackage {
@@ -1171,7 +1552,10 @@ with self;
     hash = "sha256-Xq+btvZQ/+6bcHoH9DcrrhD5CkwpFeedn7YEFHeLzsU=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Simpler notation for fixed point literals";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_globalize = janePackage {
@@ -1179,7 +1563,11 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-LKV5zfaf6AXn3NzOhN2ka8NtjItPTIsfmoJVBw5bYi8=";
     meta.description = "A ppx rewriter that generates functions to copy local values to the global heap";
-    propagatedBuildInputs = [ base ppxlib ppxlib_jane ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+      ppxlib_jane
+    ];
   };
 
   ppx_hash = janePackage {
@@ -1187,7 +1575,10 @@ with self;
     hash = "sha256-GADCLoF2GjZkvAiezn0xyReCs1avrUgjJGSS/pMNq38=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that generates hash functions from type expressions and definitions";
-    propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_compare
+      ppx_sexp_conv
+    ];
   };
 
   ppx_here = janePackage {
@@ -1195,7 +1586,10 @@ with self;
     hash = "sha256-ybwOcv82uDRPTlfaQgaBJHVq6xBxIRUj07CXP131JsM=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Expands [%here] into its location";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
     doCheck = false; # test build rules broken
   };
 
@@ -1212,7 +1606,10 @@ with self;
     hash = "sha256-pNdrmAlT3MUbuPUcMmCRcUIXv4fZ/o/IofJmnUKf8Cs=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Syntax extension for writing in-line tests in ocaml code";
-    propagatedBuildInputs = [ ppxlib time_now ];
+    propagatedBuildInputs = [
+      ppxlib
+      time_now
+    ];
     doCheck = false; # test build rules broken
   };
 
@@ -1246,9 +1643,13 @@ with self;
     pname = "ppx_jsonaf_conv";
     hash = "sha256-v7CYOJ1g4LkqIv5De5tQjjkBWXqKHbvqfSr0X5jBUuM=";
     minimalOCamlVersion = "4.14";
-    meta.description =
-      "[@@deriving] plugin to generate Jsonaf conversion functions";
-    propagatedBuildInputs = [ base jsonaf ppx_jane ppxlib ];
+    meta.description = "[@@deriving] plugin to generate Jsonaf conversion functions";
+    propagatedBuildInputs = [
+      base
+      jsonaf
+      ppx_jane
+      ppxlib
+    ];
   };
 
   ppx_js_style = janePackage {
@@ -1256,7 +1657,11 @@ with self;
     hash = "sha256-7jRzxe4bLyZ2vnHeqWiLlCUvOlNUAk0dwCfBFhrykUU=";
     minimalOCamlVersion = "4.14";
     meta.description = "Code style checker for Jane Street Packages";
-    propagatedBuildInputs = [ octavius base ppxlib ];
+    propagatedBuildInputs = [
+      octavius
+      base
+      ppxlib
+    ];
   };
 
   ppx_let = janePackage {
@@ -1264,7 +1669,10 @@ with self;
     hash = "sha256-JkNQgbPHVDH659m4Xy9ipcZ/iqGtj5q1qQn1P+O7TUY=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Monadic let-bindings";
-    propagatedBuildInputs = [ ppxlib ppx_here ];
+    propagatedBuildInputs = [
+      ppxlib
+      ppx_here
+    ];
   };
 
   ppx_log = janePackage {
@@ -1295,7 +1703,10 @@ with self;
     hash = "sha256-OWo1Ij9JAxsk9HlTlaz9Qw2+4YCvXDmIvytAOgFCLPI=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Ppx rewriter that records top-level module startup times";
-    propagatedBuildInputs = [ stdio time_now ];
+    propagatedBuildInputs = [
+      stdio
+      time_now
+    ];
   };
 
   ppx_optcomp = janePackage {
@@ -1303,7 +1714,10 @@ with self;
     hash = "sha256-H9oTzhJx9IGRkcwY2YEvcvNgeJ8ETNO95qKcjTXJBwk=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Optional compilation for OCaml";
-    propagatedBuildInputs = [ stdio ppxlib ];
+    propagatedBuildInputs = [
+      stdio
+      ppxlib
+    ];
   };
 
   ppx_optional = janePackage {
@@ -1311,7 +1725,11 @@ with self;
     hash = "sha256-SHw2zh6lG1N9zWF2b3VWeYzRHUx4jUxyOYgHd2/N9wE=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Pattern matching on flat options";
-    propagatedBuildInputs = [ base ppxlib ppxlib_jane ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+      ppxlib_jane
+    ];
   };
 
   ppx_pattern_bind = janePackage {
@@ -1334,7 +1752,11 @@ with self;
     pname = "ppx_python";
     hash = "sha256-WqTYH5Zz/vRak/CL1ha8oUbQ8+XRuUu9610uj8II74o=";
     meta.description = "A [@@deriving] plugin to generate Python conversion functions ";
-    propagatedBuildInputs = [ ppx_base ppxlib pyml ];
+    propagatedBuildInputs = [
+      ppx_base
+      ppxlib
+      pyml
+    ];
     doCheck = false;
   };
 
@@ -1363,7 +1785,12 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-hUi0I50SODK1MpL86xy8eM8yn8f4q1Hv4LP9zFnnr70=";
     meta.description = "[@@deriving] plugin to generate S-expression conversion functions";
-    propagatedBuildInputs = [ ppxlib sexplib0 base ppxlib_jane ];
+    propagatedBuildInputs = [
+      ppxlib
+      sexplib0
+      base
+      ppxlib_jane
+    ];
   };
 
   ppx_sexp_message = janePackage {
@@ -1371,7 +1798,10 @@ with self;
     hash = "sha256-SNgTvsTUgFzjqHpyIYk4YuA4c5MbA9e77YUEsDaKTeA=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter for easy construction of s-expressions";
-    propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_here
+      ppx_sexp_conv
+    ];
   };
 
   ppx_sexp_value = janePackage {
@@ -1379,7 +1809,10 @@ with self;
     hash = "sha256-f96DLNFI+s3TKsOj01i6xUoM9L+qRgAXbbepNis397I=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "A ppx rewriter that simplifies building s-expressions from ocaml values";
-    propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
+    propagatedBuildInputs = [
+      ppx_here
+      ppx_sexp_conv
+    ];
   };
 
   ppx_stable = janePackage {
@@ -1387,7 +1820,10 @@ with self;
     hash = "sha256-N5oPjjQcLgiO9liX8Z0vg0IbQXaGZ4BqOgwvuIKSKaA=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Stable types conversions generator";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_stable_witness = janePackage {
@@ -1400,7 +1836,10 @@ with self;
       never change. This allows programs running at different versions of the
       code to safely communicate.
     '';
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_string = janePackage {
@@ -1408,14 +1847,24 @@ with self;
     minimalOCamlVersion = "4.04.2";
     hash = "sha256-taAvJas9DvR5CIiFf38IMdNqLJ0QJmnIdcNJAaVILgA=";
     meta.description = "Ppx extension for string interpolation";
-    propagatedBuildInputs = [ ppx_base ppxlib stdio ];
+    propagatedBuildInputs = [
+      ppx_base
+      ppxlib
+      stdio
+    ];
   };
 
   ppx_string_conv = janePackage {
     pname = "ppx_string_conv";
     hash = "sha256-r+XubSXjxVyCsra99D6keJ/lmXeK5SZbI6h/IFghvPQ=";
     meta.description = "Ppx extension for generating of_string & to_string";
-    propagatedBuildInputs = [ base ppxlib ppx_let ppx_string capitalization ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+      ppx_let
+      ppx_string
+      capitalization
+    ];
   };
 
   ppx_tydi = janePackage {
@@ -1423,14 +1872,21 @@ with self;
     hash = "sha256-PM89fP6Rb6M99HgEzQ7LfpW1W5adw6J/E1LFQJtdd0U=";
     minimalOCamlVersion = "4.14";
     meta.description = "Let expressions, inferring pattern type from expression.";
-    propagatedBuildInputs = [ base ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppxlib
+    ];
   };
 
   ppx_typed_fields = janePackage {
     pname = "ppx_typed_fields";
     hash = "sha256-aTPEBBc1zniZkEmzubGkU064bwGnefBOjVDqTdPm2w8=";
     meta.description = "GADT-based field accessors and utilities";
-    propagatedBuildInputs = [ core ppx_jane ppxlib ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      ppxlib
+    ];
   };
 
   ppx_typerep_conv = janePackage {
@@ -1438,7 +1894,10 @@ with self;
     minimalOCamlVersion = "4.04.2";
     hash = "sha256-V9yOSy3cj5/bz9PvpO3J+aeFu1G+qGQ8AR3gSczUZbY=";
     meta.description = "Generation of runtime types from type declarations";
-    propagatedBuildInputs = [ ppxlib typerep ];
+    propagatedBuildInputs = [
+      ppxlib
+      typerep
+    ];
   };
 
   ppx_variants_conv = janePackage {
@@ -1446,7 +1905,10 @@ with self;
     minimalOCamlVersion = "4.04.2";
     hash = "sha256-Av2F699LzVCpwcdji6qG0jt5DVxCnIY4eBLaPK1JC10=";
     meta.description = "Generation of accessor and iteration functions for ocaml variant types";
-    propagatedBuildInputs = [ variantslib ppxlib ];
+    propagatedBuildInputs = [
+      variantslib
+      ppxlib
+    ];
   };
 
   ppx_xml_conv = janePackage {
@@ -1454,7 +1916,12 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-4U0ZlV8OYXwNUz3bbxf49qovGTI8vyn7L3YJy0AndrM=";
     meta.description = "Generate XML conversion functions from records";
-    propagatedBuildInputs = [ base csvfields ppx_conv_func ppx_fields_conv ];
+    propagatedBuildInputs = [
+      base
+      csvfields
+      ppx_conv_func
+      ppx_fields_conv
+    ];
   };
 
   ppx_yojson_conv_lib = janePackage {
@@ -1470,7 +1937,12 @@ with self;
     minimalOCamlVersion = "4.14";
     hash = "sha256-O7t6Bq23C4avBD1ef1DFL+QopZt3ZzHYAcdapF16cGY=";
     meta.description = "A PPX syntax extension that generates code for converting OCaml types to and from Yojson";
-    propagatedBuildInputs = [ base ppx_js_style ppx_yojson_conv_lib ppxlib ];
+    propagatedBuildInputs = [
+      base
+      ppx_js_style
+      ppx_yojson_conv_lib
+      ppxlib
+    ];
   };
 
   ppxlib_jane = janePackage {
@@ -1484,7 +1956,11 @@ with self;
     pname = "profunctor";
     hash = "sha256-WYPJLt3kYvIzh88XcPpw2xvSNjNX63/LvWwIDK+Xr0Q=";
     meta.description = "A library providing a signature for simple profunctors and traversal of a record";
-    propagatedBuildInputs = [ base ppx_jane record_builder ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+      record_builder
+    ];
   };
 
   protocol_version_header = janePackage {
@@ -1516,14 +1992,22 @@ with self;
     pname = "re_parser";
     hash = "sha256-kZx652Znr3rUA/P5KiYvTScvtp55fzjnoxwQOZlvKiY=";
     meta.description = "Typed parsing using regular expressions.";
-    propagatedBuildInputs = [ base regex_parser_intf re ];
+    propagatedBuildInputs = [
+      base
+      regex_parser_intf
+      re
+    ];
   };
 
   re2 = janePackage {
     pname = "re2";
     hash = "sha256-0VCSOzrVouMRVZJumcqv0F+HQFXlFfVEFIhYq7Tfhrg=";
     meta.description = "OCaml bindings for RE2, Google's regular expression library";
-    propagatedBuildInputs = [ core_kernel jane_rope regex_parser_intf ];
+    propagatedBuildInputs = [
+      core_kernel
+      jane_rope
+      regex_parser_intf
+    ];
     prePatch = ''
       substituteInPlace src/re2_c/dune --replace-fail 'CXX=g++' 'CXX=c++'
     '';
@@ -1534,21 +2018,33 @@ with self;
     version = "0.14.0";
     hash = "sha256-gyet2Pzn7ZIqQ+UP2J51pRmwaESY2LSGTqCMZZwDTE4=";
     meta.description = "Re2_stable adds an incomplete but stable serialization of Re2";
-    propagatedBuildInputs = [ core re2 ];
+    propagatedBuildInputs = [
+      core
+      re2
+    ];
   };
 
   record_builder = janePackage {
     pname = "record_builder";
     hash = "sha256-NQ0Wizxi/wD8BCwt8hxZWnEpLBTn3XkaG+96ooOKIFE=";
     meta.description = "A library which provides traversal of records with an applicative";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   redis-async = janePackage {
     pname = "redis-async";
     hash = "sha256-bwKPEnK2uJq5H65BDAL1Vk3qSr5kUwaCEiFsgaCdHw8=";
     meta.description = "Redis client for Async applications";
-    propagatedBuildInputs = [ async bignum core core_kernel ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      bignum
+      core
+      core_kernel
+      ppx_jane
+    ];
   };
 
   regex_parser_intf = janePackage {
@@ -1586,14 +2082,22 @@ with self;
     pname = "semantic_version";
     hash = "sha256-2Z2C+1bfI6W7Pw7SRYw8EkaVVwQkkm+knCrJIfsJhPE=";
     meta.description = "Semantic versioning";
-    propagatedBuildInputs = [ core ppx_jane re ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      re
+    ];
   };
 
   sequencer_table = janePackage {
     pname = "sequencer_table";
     hash = "sha256-VBt6ogz3sVfPLrRCf17AtOdj2IQgUiHRMibBBERICgI=";
     meta.description = "A table of [Async.Sequencer]'s, indexed by key";
-    propagatedBuildInputs = [ async_kernel core ppx_jane ];
+    propagatedBuildInputs = [
+      async_kernel
+      core
+      ppx_jane
+    ];
   };
 
   sexp = janePackage {
@@ -1640,7 +2144,10 @@ with self;
   sexp_macro = janePackage {
     pname = "sexp_macro";
     hash = "sha256-KXJ+6uR38ywkr8uT8n2bWk10W7vW2ntMgxgF4ZvzzWU=";
-    propagatedBuildInputs = [ async sexplib ];
+    propagatedBuildInputs = [
+      async
+      sexplib
+    ];
     meta.description = "Sexp macros";
   };
 
@@ -1648,14 +2155,22 @@ with self;
     pname = "sexp_pretty";
     hash = "sha256-DcgLlwp3AMC1QzFYPzi7aHA+VhnhbG6p/fLDTMx8ATc=";
     meta.description = "S-expression pretty-printer";
-    propagatedBuildInputs = [ ppx_base re sexplib ];
+    propagatedBuildInputs = [
+      ppx_base
+      re
+      sexplib
+    ];
   };
 
   sexp_select = janePackage {
     pname = "sexp_select";
     hash = "sha256-3AUFRtNe32TEB7lItcu7XlEv+3k+4QTitcTnT0kg28Y=";
     minimalOCamlVersion = "4.14";
-    propagatedBuildInputs = [ base ppx_jane core_kernel ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+      core_kernel
+    ];
     meta.description = "A library to use CSS-style selectors to traverse sexp trees";
   };
 
@@ -1663,7 +2178,11 @@ with self;
     pname = "sexp_string_quickcheck";
     hash = "sha256-yhSjkEwn4vmefnwC3bgE9PxItnAmXQj8+JkNdn9cm84=";
     minimalOCamlVersion = "4.14";
-    propagatedBuildInputs = [ core parsexp ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      parsexp
+      ppx_jane
+    ];
     meta.description = "Quickcheck helpers for strings parsing to sexps";
   };
 
@@ -1679,7 +2198,10 @@ with self;
     hash = "sha256-DxTMAQbskZ87pMVQnxYc3opGGCzmUKGCZfszr/Z9TGA=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Library for serializing OCaml values to and from S-expressions";
-    propagatedBuildInputs = [ num parsexp ];
+    propagatedBuildInputs = [
+      num
+      parsexp
+    ];
   };
 
   shell = janePackage {
@@ -1695,7 +2217,10 @@ with self;
     pname = "shexp";
     hash = "sha256-tf9HqZ01gMWxfcpe3Pl3rdPTPgIEdb59iwzwThznqAc=";
     minimalOCamlVersion = "4.07";
-    propagatedBuildInputs = [ posixat spawn ];
+    propagatedBuildInputs = [
+      posixat
+      spawn
+    ];
     meta.description = "Process library and s-expression based shell";
   };
 
@@ -1718,7 +2243,12 @@ with self;
     pname = "splittable_random";
     hash = "sha256-LlaCxL17GBZc33spn/JnunpaMQ47n+RXS8CShBlaRWA=";
     meta.description = "PRNG that can be split into independent streams";
-    propagatedBuildInputs = [ base ppx_assert ppx_bench ppx_sexp_message ];
+    propagatedBuildInputs = [
+      base
+      ppx_assert
+      ppx_bench
+      ppx_sexp_message
+    ];
   };
 
   streamable = janePackage {
@@ -1726,7 +2256,15 @@ with self;
     hash = "sha256-FtrAX4nsacCO5HTVxwLgwwT8R2sASJ05qu4gT2ZVSDg=";
     minimalOCamlVersion = "4.14";
     meta.description = "A collection of types suitable for incremental serialization.";
-    propagatedBuildInputs = [ async_kernel async_rpc_kernel base core core_kernel ppx_jane ppxlib ];
+    propagatedBuildInputs = [
+      async_kernel
+      async_rpc_kernel
+      base
+      core
+      core_kernel
+      ppx_jane
+      ppxlib
+    ];
   };
 
   string_dict = janePackage {
@@ -1734,7 +2272,11 @@ with self;
     hash = "sha256-E6ImZU5HeGH3I5o1O4Hl5nW9ZnoX7SVlp8gppkW2Zds=";
     minimalOCamlVersion = "4.14";
     meta.description = "Efficient static string dictionaries";
-    propagatedBuildInputs = [ base ppx_compare ppx_hash ];
+    propagatedBuildInputs = [
+      base
+      ppx_compare
+      ppx_hash
+    ];
   };
 
   stdio = janePackage {
@@ -1748,7 +2290,10 @@ with self;
   stored_reversed = janePackage {
     pname = "stored_reversed";
     hash = "sha256-FPyQxXaGAzFWW6GiiqKQgU+6/lAZhEQwhNnXsmqKkzg=";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
     meta.description = "A library for representing a list temporarily stored in reverse order.";
   };
 
@@ -1756,14 +2301,21 @@ with self;
     pname = "textutils";
     hash = "sha256-J58sqp9fkx3JyjnH6oJLCyEC0ZvnuDfqLVl+dt3tEgA=";
     meta.description = "Text output utilities";
-    propagatedBuildInputs = [ core_unix textutils_kernel ];
+    propagatedBuildInputs = [
+      core_unix
+      textutils_kernel
+    ];
   };
 
   textutils_kernel = janePackage {
     pname = "textutils_kernel";
     hash = "sha256-B5ExbKMRSw4RVJ908FVGob2soHFnJ6Ajsdn0q8lDhio=";
     meta.description = "Text output utilities";
-    propagatedBuildInputs = [ core ppx_jane uutf ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+      uutf
+    ];
   };
 
   tilde_f = janePackage {
@@ -1771,7 +2323,10 @@ with self;
     hash = "sha256-tuddvOmhk0fikB4dHNdXamBx6xfo4DCvivs44QXp5RQ=";
     minimalOCamlVersion = "4.14";
     meta.description = "Provides a let-syntax for continuation-passing style.";
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   time_now = janePackage {
@@ -1779,8 +2334,15 @@ with self;
     hash = "sha256-bTPWE9+x+zmdLdzLc1naDlRErPZ8m4WXDJL2iLErdqk=";
     minimalOCamlVersion = "4.04.2";
     meta.description = "Reports the current time";
-    buildInputs = [ jst-config ppx_optcomp ];
-    propagatedBuildInputs = [ jane-street-headers base ppx_base ];
+    buildInputs = [
+      jst-config
+      ppx_optcomp
+    ];
+    propagatedBuildInputs = [
+      jane-street-headers
+      base
+      ppx_base
+    ];
   };
 
   timezone = janePackage {
@@ -1794,7 +2356,13 @@ with self;
     pname = "toplevel_backend";
     hash = "sha256-rm/nZoKIKA6f37QqT1+qoztUAtvUE20BDCndakaQxRg=";
     meta.description = "Shared backend for setting up toplevels";
-    propagatedBuildInputs = [ core ppx_here ppx_jane ppx_optcomp findlib ];
+    propagatedBuildInputs = [
+      core
+      ppx_here
+      ppx_jane
+      ppx_optcomp
+      findlib
+    ];
   };
 
   toplevel_expect_test = janePackage {
@@ -1817,7 +2385,10 @@ with self;
     pname = "topological_sort";
     hash = "sha256-jLkJnh5lasrphI6BUKv7oVPrKyGqNm6VIGYthNs04iU=";
     meta.description = "Topological sort algorithm";
-    propagatedBuildInputs = [ ppx_jane stdio ];
+    propagatedBuildInputs = [
+      ppx_jane
+      stdio
+    ];
   };
 
   tracing = janePackage {
@@ -1825,7 +2396,13 @@ with self;
     hash = "sha256-gzATwxUC6bLbCbspZHbcDpzQf2GrGA7tlhdJB9mTD0g=";
     minimalOCamlVersion = "4.14";
     meta.description = "Tracing library";
-    propagatedBuildInputs = [ async core core_kernel core_unix ppx_jane ];
+    propagatedBuildInputs = [
+      async
+      core
+      core_kernel
+      core_unix
+      ppx_jane
+    ];
   };
 
   typerep = janePackage {
@@ -1844,7 +2421,10 @@ with self;
       systems which avoid allocation. It has several downsides as compared to
       [option], and is not recommended for use in general-purpose software.
     '';
-    propagatedBuildInputs = [ base ppx_jane ];
+    propagatedBuildInputs = [
+      base
+      ppx_jane
+    ];
   };
 
   username_kernel = janePackage {
@@ -1852,7 +2432,10 @@ with self;
     hash = "sha256-1lxWSv7CbmucurNw8ws18N9DYqo4ik2KZBc5GtNmmeU=";
     minimalOCamlVersion = "4.14";
     meta.description = "An identifier for a user";
-    propagatedBuildInputs = [ core ppx_jane ];
+    propagatedBuildInputs = [
+      core
+      ppx_jane
+    ];
   };
 
   variantslib = janePackage {
@@ -1947,7 +2530,11 @@ with self;
     hash = "sha256-EUI7fnN8ZaM1l0RBsgSAMWO+VXA8VoCv/lO5kcj+j4E=";
     meta.description = "OCaml bindings to Zstandard";
     buildInputs = [ ppx_jane ];
-    propagatedBuildInputs = [ core_kernel ctypes zstd ];
+    propagatedBuildInputs = [
+      core_kernel
+      ctypes
+      zstd
+    ];
   };
 
 }

--- a/ocaml/jose/default.nix
+++ b/ocaml/jose/default.nix
@@ -1,15 +1,16 @@
-{ buildDunePackage
-, fetchFromGitHub
-, base64
-, mirage-crypto
-, mirage-crypto-pk
-, mirage-crypto-ec
-, x509
-, cstruct
-, astring
-, yojson
-, zarith
-, ptime
+{
+  buildDunePackage,
+  fetchFromGitHub,
+  base64,
+  mirage-crypto,
+  mirage-crypto-pk,
+  mirage-crypto-ec,
+  x509,
+  cstruct,
+  astring,
+  yojson,
+  zarith,
+  ptime,
 }:
 
 buildDunePackage rec {

--- a/ocaml/kcas/default.nix
+++ b/ocaml/kcas/default.nix
@@ -1,15 +1,16 @@
-{ backoff
-, buildDunePackage
-, domain-local-await
-, domain-local-timeout
-, multicore-magic
+{
+  backoff,
+  buildDunePackage,
+  domain-local-await,
+  domain-local-timeout,
+  multicore-magic,
 }:
 
 buildDunePackage {
   pname = "kcas";
   version = "0.7.9";
   src = builtins.fetchurl {
-    url = https://github.com/ocaml-multicore/kcas/releases/download/0.7.0/kcas-0.7.0.tbz;
+    url = "https://github.com/ocaml-multicore/kcas/releases/download/0.7.0/kcas-0.7.0.tbz";
     sha256 = "148zgbvkq67ial8rgmz5kzyi3y8m35dw62sqr4fx9vq1g6vfi3ws";
   };
   propagatedBuildInputs = [

--- a/ocaml/lambda-runtime/default.nix
+++ b/ocaml/lambda-runtime/default.nix
@@ -1,11 +1,12 @@
-{ buildDunePackage
-, fetchFromGitHub
-, yojson
-, ppx_deriving_yojson
-, piaf
-, uri
-, logs
-, lwt
+{
+  buildDunePackage,
+  fetchFromGitHub,
+  yojson,
+  ppx_deriving_yojson,
+  piaf,
+  uri,
+  logs,
+  lwt,
 }:
 
 buildDunePackage {

--- a/ocaml/lambda-runtime/vercel.nix
+++ b/ocaml/lambda-runtime/vercel.nix
@@ -1,10 +1,11 @@
-{ buildDunePackage
-, lambda-runtime
-, piaf
-, yojson
-, ppx_deriving_yojson
-, lwt
-, base64
+{
+  buildDunePackage,
+  lambda-runtime,
+  piaf,
+  yojson,
+  ppx_deriving_yojson,
+  lwt,
+  base64,
 
 }:
 

--- a/ocaml/logs-ppx/default.nix
+++ b/ocaml/logs-ppx/default.nix
@@ -1,4 +1,8 @@
-{ lib, buildDunePackage, ppxlib }:
+{
+  lib,
+  buildDunePackage,
+  ppxlib,
+}:
 
 buildDunePackage rec {
   pname = "logs-ppx";

--- a/ocaml/lwt/domain.nix
+++ b/ocaml/lwt/domain.nix
@@ -1,4 +1,10 @@
-{ lib, buildDunePackage, domainslib, fetchFromGitHub, lwt }:
+{
+  lib,
+  buildDunePackage,
+  domainslib,
+  fetchFromGitHub,
+  lwt,
+}:
 
 buildDunePackage {
   pname = "lwt_domain";
@@ -9,7 +15,10 @@ buildDunePackage {
     rev = "28319c184a648c9e79f60b8ba4f57c271f7e9606";
     hash = "sha256-rjjJX19/SuKUdvlE8BfV0iGdzmFLF+F8L4HzG4ja2HI=";
   };
-  propagatedBuildInputs = [ domainslib lwt ];
+  propagatedBuildInputs = [
+    domainslib
+    lwt
+  ];
 
   meta = {
     description = "Helpers for using Domainslib with Lwt";

--- a/ocaml/lwt/react.nix
+++ b/ocaml/lwt/react.nix
@@ -1,4 +1,10 @@
-{ lib, buildDunePackage, cppo, lwt, react }:
+{
+  lib,
+  buildDunePackage,
+  cppo,
+  lwt,
+  react,
+}:
 
 buildDunePackage {
   pname = "lwt_react";
@@ -7,7 +13,10 @@ buildDunePackage {
 
   buildInputs = [ cppo ];
 
-  propagatedBuildInputs = [ lwt react ];
+  propagatedBuildInputs = [
+    lwt
+    react
+  ];
 
   meta = {
     description = "Helpers for using React with Lwt";

--- a/ocaml/matrix/ctos.nix
+++ b/ocaml/matrix/ctos.nix
@@ -1,4 +1,13 @@
-{ lib, fetchFromGitHub, buildDunePackage, matrix-common, ezjsonm, fmt, logs, ppxlib }:
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  matrix-common,
+  ezjsonm,
+  fmt,
+  logs,
+  ppxlib,
+}:
 
 buildDunePackage {
   pname = "matrix-ctos";

--- a/ocaml/matrix/default.nix
+++ b/ocaml/matrix/default.nix
@@ -1,4 +1,13 @@
-{ lib, fetchFromGitHub, buildDunePackage, ezjsonm, fmt, logs, cmdliner, ppxlib }:
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  ezjsonm,
+  fmt,
+  logs,
+  cmdliner,
+  ppxlib,
+}:
 
 buildDunePackage {
   pname = "matrix-common";

--- a/ocaml/matrix/stos.nix
+++ b/ocaml/matrix/stos.nix
@@ -1,4 +1,15 @@
-{ lib, fetchFromGitHub, buildDunePackage, matrix-common, ezjsonm, fmt, logs, mirage-crypto-ec, x509, ppxlib }:
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  matrix-common,
+  ezjsonm,
+  fmt,
+  logs,
+  mirage-crypto-ec,
+  x509,
+  ppxlib,
+}:
 
 buildDunePackage {
   pname = "matrix-stos";

--- a/ocaml/melange-packages.nix
+++ b/ocaml/melange-packages.nix
@@ -7,19 +7,22 @@ with oself;
     pname = "melange-atdgen-codec-runtime";
     version = "n/a";
     src = builtins.fetchurl {
-      url = https://github.com/ahrefs/melange-atdgen-codec-runtime/releases/download/3.0.0/melange-atdgen-codec-runtime-3.0.0.tbz;
+      url = "https://github.com/ahrefs/melange-atdgen-codec-runtime/releases/download/3.0.0/melange-atdgen-codec-runtime-3.0.0.tbz";
       sha256 = "1fkw1ynqzmpf9h6jkqzcfv2i2cw4a16wmvbmc8hmgw0wymb99m2n";
     };
 
     nativeBuildInputs = [ melange ];
-    propagatedBuildInputs = [ melange melange-json ];
+    propagatedBuildInputs = [
+      melange
+      melange-json
+    ];
   };
 
   melange-fetch = buildDunePackage {
     pname = "melange-fetch";
     version = "n/a";
     src = builtins.fetchurl {
-      url = https://github.com/melange-community/melange-fetch/releases/download/0.1.0/melange-fetch-0.1.0.tbz;
+      url = "https://github.com/melange-community/melange-fetch/releases/download/0.1.0/melange-fetch-0.1.0.tbz";
       sha256 = "0y7z8jrwjgim2wgwg1ajjc1g365wgppgl3wza6b3955ahghjgyl8";
     };
     nativeBuildInputs = [ melange ];
@@ -35,26 +38,38 @@ with oself;
       rev = "fda583ba97148e09d5c3961d8278c189ce261b81";
       hash = "sha256-ejuXTLhMiRzyC6yJLd5xPzGUoj1fDP2/TaELlFKJJVM=";
     };
-    nativeBuildInputs = [ melange reason ];
-    propagatedBuildInputs = [ melange reason-react ];
+    nativeBuildInputs = [
+      melange
+      reason
+    ];
+    propagatedBuildInputs = [
+      melange
+      reason-react
+    ];
   };
 
   melange-testing-library = buildDunePackage {
     pname = "melange-testing-library";
     version = "n/a";
     src = builtins.fetchurl {
-      url = https://github.com/melange-community/melange-testing-library/releases/download/0.1.0/melange-testing-library-0.1.0.tbz;
+      url = "https://github.com/melange-community/melange-testing-library/releases/download/0.1.0/melange-testing-library-0.1.0.tbz";
       sha256 = "1mhir158zwpfigb75plgzz93i8jfnfjibdii2vh19vr3gcly7k23";
     };
-    nativeBuildInputs = [ melange reason ];
-    propagatedBuildInputs = [ melange reason-react ];
+    nativeBuildInputs = [
+      melange
+      reason
+    ];
+    propagatedBuildInputs = [
+      melange
+      reason-react
+    ];
   };
 
   melange-json = buildDunePackage {
     pname = "melange-json";
     version = "n/a";
     src = builtins.fetchurl {
-      url = https://github.com/melange-community/melange-json/releases/download/1.1.0/melange-json-1.1.0.tbz;
+      url = "https://github.com/melange-community/melange-json/releases/download/1.1.0/melange-json-1.1.0.tbz";
       sha256 = "12ih5drzrxjd70wfc0lz7q9pm6pm3j3wxnvwmqlvngvkkkh8dgnz";
     };
     nativeBuildInputs = [ melange ];
@@ -65,21 +80,27 @@ with oself;
     pname = "melange-jest";
     version = "n/a";
     src = builtins.fetchurl {
-      url = https://github.com/melange-community/melange-jest/releases/download/0.1.1/melange-jest-0.1.1.tbz;
+      url = "https://github.com/melange-community/melange-jest/releases/download/0.1.1/melange-jest-0.1.1.tbz";
       sha256 = "1vnn19bz5sqnvrpl6wma50q8a75diyb9ddl19061halga3a410y6";
     };
     nativeBuildInputs = [ melange ];
-    propagatedBuildInputs = [ melange reason-react ];
+    propagatedBuildInputs = [
+      melange
+      reason-react
+    ];
   };
 
   melange-numeral = buildDunePackage {
     pname = "melange-numeral";
     version = "0.0.1";
     src = builtins.fetchurl {
-      url = https://github.com/ahrefs/melange-numeral/releases/download/0.0.1/melange-numeral-0.0.1.tbz;
+      url = "https://github.com/ahrefs/melange-numeral/releases/download/0.0.1/melange-numeral-0.0.1.tbz";
       sha256 = "1a16j014ps835xqks7mgybqqq34rpvhnzbibrh1pypcqa7hhcdnd";
     };
-    nativeBuildInputs = [ melange reason ];
+    nativeBuildInputs = [
+      melange
+      reason
+    ];
     propagatedBuildInputs = [ melange ];
   };
 
@@ -87,11 +108,17 @@ with oself;
     pname = "melange-webapi";
     version = "n/a";
     src = builtins.fetchurl {
-      url = https://github.com/melange-community/melange-webapi/releases/download/0.21.0/melange-webapi-0.21.0.tbz;
+      url = "https://github.com/melange-community/melange-webapi/releases/download/0.21.0/melange-webapi-0.21.0.tbz";
       sha256 = "1h8j3fy6d0shxv9wjhgmm85ac7f69waz9ay3khw8impiv6h5w00k";
     };
-    nativeBuildInputs = [ melange reason ];
-    propagatedBuildInputs = [ melange melange-fetch ];
+    nativeBuildInputs = [
+      melange
+      reason
+    ];
+    propagatedBuildInputs = [
+      melange
+      melange-fetch
+    ];
   };
 
   melange-relay = buildDunePackage {
@@ -116,8 +143,14 @@ with oself;
     pname = "reason-react";
     version = "n/a";
     inherit (reason-react-ppx) src;
-    nativeBuildInputs = [ reason melange ];
-    propagatedBuildInputs = [ reason-react-ppx melange ];
+    nativeBuildInputs = [
+      reason
+      melange
+    ];
+    propagatedBuildInputs = [
+      reason-react-ppx
+      melange
+    ];
   };
 
   reason-react-ppx = buildDunePackage {

--- a/ocaml/melange/default.nix
+++ b/ocaml/melange/default.nix
@@ -1,21 +1,22 @@
-{ buildDunePackage
-, cppo
-, cmdliner
-, dune-build-info
-, fetchFromGitHub
-, jq
-, lib
-, makeWrapper
-, menhir
-, menhirLib
-, merlin
-, nodejs_latest
-, ocaml
-, ounit2
-, ppxlib
-, reason
-, tree
-, stdenv
+{
+  buildDunePackage,
+  cppo,
+  cmdliner,
+  dune-build-info,
+  fetchFromGitHub,
+  jq,
+  lib,
+  makeWrapper,
+  menhir,
+  menhirLib,
+  merlin,
+  nodejs_latest,
+  ocaml,
+  ounit2,
+  ppxlib,
+  reason,
+  tree,
+  stdenv,
 }:
 
 buildDunePackage {
@@ -25,29 +26,42 @@ buildDunePackage {
 
   src =
     if (lib.versionOlder "5.2" ocaml.version) then
-      builtins.fetchurl
-        {
-          url = https://github.com/melange-re/melange/releases/download/4.0.1-52/melange-4.0.1-52.tbz;
-          sha256 = "0dvmdxzkvr5qc064p9q8yciv5jkcw9njn1nxhzrpwb9dlj344jci";
-        }
+      builtins.fetchurl {
+        url = "https://github.com/melange-re/melange/releases/download/4.0.1-52/melange-4.0.1-52.tbz";
+        sha256 = "0dvmdxzkvr5qc064p9q8yciv5jkcw9njn1nxhzrpwb9dlj344jci";
+      }
     else if (lib.versionOlder "5.1" ocaml.version) then
-      builtins.fetchurl
-        {
-          url = https://github.com/melange-re/melange/releases/download/4.0.0-51/melange-4.0.0-51.tbz;
-          sha256 = "1mdxqqw3jyaf3ig1w9als2mghf9axbln6mm5k1x76pjrkp71i3gp";
-        }
+      builtins.fetchurl {
+        url = "https://github.com/melange-re/melange/releases/download/4.0.0-51/melange-4.0.0-51.tbz";
+        sha256 = "1mdxqqw3jyaf3ig1w9als2mghf9axbln6mm5k1x76pjrkp71i3gp";
+      }
     else
       builtins.fetchurl {
-        url = https://github.com/melange-re/melange/releases/download/4.0.0-414/melange-4.0.0-414.tbz;
+        url = "https://github.com/melange-re/melange/releases/download/4.0.0-414/melange-4.0.0-414.tbz";
         sha256 = "14rcq4qxwc33xlnpfxjqz9fs5l29jvzc04jvpzgvpj08fqww70iw";
       };
 
   doCheck = false;
 
-  nativeCheckInputs = [ nodejs_latest reason tree merlin jq ];
+  nativeCheckInputs = [
+    nodejs_latest
+    reason
+    tree
+    merlin
+    jq
+  ];
   checkInputs = [ ounit2 ];
-  nativeBuildInputs = [ cppo menhir makeWrapper ];
-  propagatedBuildInputs = [ cmdliner dune-build-info ppxlib menhirLib ];
+  nativeBuildInputs = [
+    cppo
+    menhir
+    makeWrapper
+  ];
+  propagatedBuildInputs = [
+    cmdliner
+    dune-build-info
+    ppxlib
+    menhirLib
+  ];
 
   postInstall = ''
     wrapProgram "$out/bin/melc" \

--- a/ocaml/merlin/default.nix
+++ b/ocaml/merlin/default.nix
@@ -1,19 +1,26 @@
-{ lib
-, substituteAll
-, ocaml
-, dune_3
-, buildDunePackage
-, dot-merlin-reader
-, yojson
-, csexp
-, result
-, merlin-lib
-, camlp-streams
+{
+  lib,
+  substituteAll,
+  ocaml,
+  dune_3,
+  buildDunePackage,
+  dot-merlin-reader,
+  yojson,
+  csexp,
+  result,
+  merlin-lib,
+  camlp-streams,
 }:
 
 buildDunePackage {
   pname = "merlin";
   inherit (dot-merlin-reader) src version;
 
-  buildInputs = [ dot-merlin-reader yojson csexp result camlp-streams ];
+  buildInputs = [
+    dot-merlin-reader
+    yojson
+    csexp
+    result
+    camlp-streams
+  ];
 }

--- a/ocaml/merlin/dot-merlin.nix
+++ b/ocaml/merlin/dot-merlin.nix
@@ -1,48 +1,47 @@
-{ lib
-, ocaml
-, findlib
-, buildDunePackage
-, yojson
-, csexp
-, result
-, merlin-lib
+{
+  lib,
+  ocaml,
+  findlib,
+  buildDunePackage,
+  yojson,
+  csexp,
+  result,
+  merlin-lib,
 }:
 
 buildDunePackage {
   pname = "dot-merlin-reader";
-  version =
-    if lib.versionAtLeast ocaml.version "4.14" then
-      merlin-lib.version else "n/a";
+  version = if lib.versionAtLeast ocaml.version "4.14" then merlin-lib.version else "n/a";
 
   src =
     if lib.versionAtLeast ocaml.version "4.14" then
       merlin-lib.src
-    else if (lib.versionOlder "4.13" ocaml.version)
-    then
-      builtins.fetchurl
-        {
-          url = https://github.com/ocaml/merlin/releases/download/v4.7-413/merlin-4.7-413.tbz;
-          sha256 = "09c3z6znj61p1mkzl9vjm7m00zgyw34jlhycqbp1490v5rcqcnb9";
-        }
-    else if (lib.versionOlder "4.12" ocaml.version)
-    then
-      builtins.fetchurl
-        {
-          url = https://github.com/ocaml/merlin/releases/download/v4.7-412/merlin-4.7-412.tbz;
-          sha256 = "0ijgc0a8hmmhpw4vcsklcfy9j018amqvj01g6w5sb50vn5mwhkfi";
-        }
-    else if (lib.versionOlder "4.11" ocaml.version)
-    then
-      builtins.fetchurl
-        {
-          url = https://github.com/ocaml/merlin/releases/download/v4.1-411/merlin-v4.1-411.tbz;
-          sha256 = "0zckb729mhp1329bcqp0mi1lxxipzbm4a5hqqzrf2g69k73nybly";
-        }
+    else if (lib.versionOlder "4.13" ocaml.version) then
+      builtins.fetchurl {
+        url = "https://github.com/ocaml/merlin/releases/download/v4.7-413/merlin-4.7-413.tbz";
+        sha256 = "09c3z6znj61p1mkzl9vjm7m00zgyw34jlhycqbp1490v5rcqcnb9";
+      }
+    else if (lib.versionOlder "4.12" ocaml.version) then
+      builtins.fetchurl {
+        url = "https://github.com/ocaml/merlin/releases/download/v4.7-412/merlin-4.7-412.tbz";
+        sha256 = "0ijgc0a8hmmhpw4vcsklcfy9j018amqvj01g6w5sb50vn5mwhkfi";
+      }
+    else if (lib.versionOlder "4.11" ocaml.version) then
+      builtins.fetchurl {
+        url = "https://github.com/ocaml/merlin/releases/download/v4.1-411/merlin-v4.1-411.tbz";
+        sha256 = "0zckb729mhp1329bcqp0mi1lxxipzbm4a5hqqzrf2g69k73nybly";
+      }
     else
       builtins.fetchurl {
-        url = https://github.com/ocaml/merlin/releases/download/v3.4.2/merlin-v3.4.2.tbz;
+        url = "https://github.com/ocaml/merlin/releases/download/v3.4.2/merlin-v3.4.2.tbz";
         sha256 = "109ai1ggnkrwbzsl1wdalikvs1zx940m6n65jllxj68in6bvidz1";
       };
 
-  propagatedBuildInputs = [ yojson csexp result merlin-lib findlib ];
+  propagatedBuildInputs = [
+    yojson
+    csexp
+    result
+    merlin-lib
+    findlib
+  ];
 }

--- a/ocaml/merlin/lib.nix
+++ b/ocaml/merlin/lib.nix
@@ -1,17 +1,17 @@
-{ fetchFromGitHub
-, lib
-, ocaml
-, buildDunePackage
-, yojson
-, csexp
-, result
+{
+  fetchFromGitHub,
+  lib,
+  ocaml,
+  buildDunePackage,
+  yojson,
+  csexp,
+  result,
 }:
 
 let
   merlinVersion = "4.12";
 
-  ocamlVersionShorthand = lib.concatStrings
-    (lib.take 2 (lib.splitVersion ocaml.version));
+  ocamlVersionShorthand = lib.concatStrings (lib.take 2 (lib.splitVersion ocaml.version));
 
   version = "${merlinVersion}-${ocamlVersionShorthand}";
 in
@@ -20,33 +20,30 @@ buildDunePackage {
   pname = "merlin-lib";
   version = version;
   src =
-    if (lib.versionOlder "5.2" ocaml.version)
-    then
-      builtins.fetchurl
-        {
-          url = https://github.com/ocaml/merlin/releases/download/v5.1-502/merlin-5.1-502.tbz;
-          sha256 = "05dfzhbyjygg8v7i9jgrxbii170mj13k81pam36gz74j4sy0in2g";
-        }
+    if (lib.versionOlder "5.2" ocaml.version) then
+      builtins.fetchurl {
+        url = "https://github.com/ocaml/merlin/releases/download/v5.1-502/merlin-5.1-502.tbz";
+        sha256 = "05dfzhbyjygg8v7i9jgrxbii170mj13k81pam36gz74j4sy0in2g";
+      }
+    else if (lib.versionOlder "5.1" ocaml.version) then
+      builtins.fetchurl {
+        url = "https://github.com/ocaml/merlin/releases/download/v4.16-501/merlin-4.16-501.tbz";
+        sha256 = "09hyq8v3hp4f7k0nm6gwpk9dn057l332qmz458lmqr20n04z6nys";
+      }
+    else if (lib.versionOlder "5.0" ocaml.version) then
+      builtins.fetchurl {
+        url = "https://github.com/ocaml/merlin/releases/download/v4.14-500/merlin-4.14-500.tbz";
+        sha256 = "03nps5mbh5lzf88d850903bz75g5sk33qc3zi7c0qlkmz0jg68zc";
+      }
     else
-      if (lib.versionOlder "5.1" ocaml.version) then
-        builtins.fetchurl
-          {
-            url = https://github.com/ocaml/merlin/releases/download/v4.16-501/merlin-4.16-501.tbz;
-            sha256 = "09hyq8v3hp4f7k0nm6gwpk9dn057l332qmz458lmqr20n04z6nys";
-          }
-      else
-        if (lib.versionOlder "5.0" ocaml.version)
-        then
-          builtins.fetchurl
-            {
-              url = https://github.com/ocaml/merlin/releases/download/v4.14-500/merlin-4.14-500.tbz;
-              sha256 = "03nps5mbh5lzf88d850903bz75g5sk33qc3zi7c0qlkmz0jg68zc";
-            }
-        else
-          builtins.fetchurl {
-            url = https://github.com/ocaml/merlin/releases/download/v4.16-414/merlin-4.16-414.tbz;
-            sha256 = "0bfgdwk77r11im5n6mvxkl9jp6kh65n3avrh3fg88mnzydsiksf5";
-          };
+      builtins.fetchurl {
+        url = "https://github.com/ocaml/merlin/releases/download/v4.16-414/merlin-4.16-414.tbz";
+        sha256 = "0bfgdwk77r11im5n6mvxkl9jp6kh65n3avrh3fg88mnzydsiksf5";
+      };
 
-  buildInputs = [ yojson csexp result ];
+  buildInputs = [
+    yojson
+    csexp
+    result
+  ];
 }

--- a/ocaml/mongo/bson.nix
+++ b/ocaml/mongo/bson.nix
@@ -1,4 +1,9 @@
-{ fetchFromGitHub, buildDunePackage, angstrom, faraday }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  angstrom,
+  faraday,
+}:
 
 buildDunePackage {
   pname = "bson";
@@ -10,5 +15,8 @@ buildDunePackage {
   };
   version = "0.0.1-dev";
 
-  propagatedBuildInputs = [ angstrom faraday ];
+  propagatedBuildInputs = [
+    angstrom
+    faraday
+  ];
 }

--- a/ocaml/mongo/lwt-unix.nix
+++ b/ocaml/mongo/lwt-unix.nix
@@ -1,8 +1,16 @@
-{ buildDunePackage, mongo, mongo-lwt, gluten-lwt-unix }:
+{
+  buildDunePackage,
+  mongo,
+  mongo-lwt,
+  gluten-lwt-unix,
+}:
 
 buildDunePackage {
   pname = "mongo-lwt-unix";
   inherit (mongo) src version;
 
-  propagatedBuildInputs = [ mongo-lwt gluten-lwt-unix ];
+  propagatedBuildInputs = [
+    mongo-lwt
+    gluten-lwt-unix
+  ];
 }

--- a/ocaml/mongo/lwt.nix
+++ b/ocaml/mongo/lwt.nix
@@ -1,8 +1,23 @@
-{ buildDunePackage, mongo, lwt, mirage-crypto, gluten-lwt, pbkdf, base64 }:
+{
+  buildDunePackage,
+  mongo,
+  lwt,
+  mirage-crypto,
+  gluten-lwt,
+  pbkdf,
+  base64,
+}:
 
 buildDunePackage {
   pname = "mongo-lwt";
   inherit (mongo) src version;
 
-  propagatedBuildInputs = [ mongo lwt mirage-crypto gluten-lwt pbkdf base64 ];
+  propagatedBuildInputs = [
+    mongo
+    lwt
+    mirage-crypto
+    gluten-lwt
+    pbkdf
+    base64
+  ];
 }

--- a/ocaml/mongo/ppx.nix
+++ b/ocaml/mongo/ppx.nix
@@ -1,8 +1,17 @@
-{ buildDunePackage, ppxlib, ppx_deriving, bson }:
+{
+  buildDunePackage,
+  ppxlib,
+  ppx_deriving,
+  bson,
+}:
 
 buildDunePackage {
   pname = "ppx_deriving_bson";
   inherit (bson) src version;
 
-  propagatedBuildInputs = [ ppxlib ppx_deriving bson ];
+  propagatedBuildInputs = [
+    ppxlib
+    ppx_deriving
+    bson
+  ];
 }

--- a/ocaml/multipart_form/default.nix
+++ b/ocaml/multipart_form/default.nix
@@ -1,29 +1,30 @@
-{ upstream ? false
-, lib
-, fetchFromGitHub
-, buildDunePackage
-, unstrctrd
-, lwt
-, ocaml
-, prettym
-, logs
-, ke
-, bigstringaf
-, astring
-, faraday
-, base64
-, pecu
-, rosetta
-, rresult
-, uutf
-, fmt
-, angstrom
-, alcotest
+{
+  upstream ? false,
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  unstrctrd,
+  lwt,
+  ocaml,
+  prettym,
+  logs,
+  ke,
+  bigstringaf,
+  astring,
+  faraday,
+  base64,
+  pecu,
+  rosetta,
+  rresult,
+  uutf,
+  fmt,
+  angstrom,
+  alcotest,
 }:
 
 let
   upstream_src = builtins.fetchurl {
-    url = https://github.com/dinosaure/multipart_form/releases/download/v0.6.0/multipart_form-0.6.0.tbz;
+    url = "https://github.com/dinosaure/multipart_form/releases/download/v0.6.0/multipart_form-0.6.0.tbz";
     sha256 = "05i10ql2zkf0v1rif3v08sas1rm1d1xghnndcx0svyng4g1jkqx0";
   };
   upstream_version = "0.4.1";
@@ -63,5 +64,8 @@ buildDunePackage {
 
   doCheck = !upstream;
 
-  checkInputs = [ alcotest rosetta ];
+  checkInputs = [
+    alcotest
+    rosetta
+  ];
 }

--- a/ocaml/multipart_form/lwt.nix
+++ b/ocaml/multipart_form/lwt.nix
@@ -1,16 +1,17 @@
-{ buildDunePackage
-, multipart_form
-, angstrom
-, bigarray-compat
-, bigstringaf
-, ke
-, lwt
-, alcotest
-, alcotest-lwt
-, rosetta
-, rresult
-, unstrctrd
-, logs
+{
+  buildDunePackage,
+  multipart_form,
+  angstrom,
+  bigarray-compat,
+  bigstringaf,
+  ke,
+  lwt,
+  alcotest,
+  alcotest-lwt,
+  rosetta,
+  rresult,
+  unstrctrd,
+  logs,
 }:
 
 buildDunePackage {

--- a/ocaml/ocaml-index/default.nix
+++ b/ocaml/ocaml-index/default.nix
@@ -1,13 +1,20 @@
-{ buildDunePackage, csexp, merlin-lib }:
+{
+  buildDunePackage,
+  csexp,
+  merlin-lib,
+}:
 
 buildDunePackage {
   pname = "ocaml-index";
   version = "1.0";
 
   src = builtins.fetchurl {
-    url = https://github.com/voodoos/ocaml-index/releases/download/v1.0/ocaml-index-1.0.tbz;
+    url = "https://github.com/voodoos/ocaml-index/releases/download/v1.0/ocaml-index-1.0.tbz";
     sha256 = "070yhxr5rnrk93hxzxy9qmk78x3ka684gbax5w0zfqfm22irrqq1";
   };
 
-  propagatedBuildInputs = [ merlin-lib csexp ];
+  propagatedBuildInputs = [
+    merlin-lib
+    csexp
+  ];
 }

--- a/ocaml/ocaml-migrate-types/default.nix
+++ b/ocaml/ocaml-migrate-types/default.nix
@@ -1,4 +1,9 @@
-{ fetchFromGitHub, buildDunePackage, ppx_optcomp, ocaml-migrate-parsetree-2 }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  ppx_optcomp,
+  ocaml-migrate-parsetree-2,
+}:
 
 buildDunePackage {
   pname = "ocaml-migrate-types";
@@ -9,5 +14,8 @@ buildDunePackage {
     rev = "58919cdf10b4e0de46234f19adef6390a215e3e2";
     sha256 = "sha256-X3Gfuelv1ElTLfkCSXlEijKM6KxiP8S0bS5kj76Cxjs=";
   };
-  propagatedBuildInputs = [ ppx_optcomp ocaml-migrate-parsetree-2 ];
+  propagatedBuildInputs = [
+    ppx_optcomp
+    ocaml-migrate-parsetree-2
+  ];
 }

--- a/ocaml/ocaml5.nix
+++ b/ocaml/ocaml5.nix
@@ -1,4 +1,10 @@
-{ darwin, fetchFromGitHub, nodejs_latest, oself, osuper }:
+{
+  darwin,
+  fetchFromGitHub,
+  nodejs_latest,
+  oself,
+  osuper,
+}:
 
 with oself;
 
@@ -9,7 +15,7 @@ with oself;
     pname = "backoff";
     version = "0.1.0";
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-multicore/backoff/releases/download/0.1.0/backoff-0.1.0.tbz;
+      url = "https://github.com/ocaml-multicore/backoff/releases/download/0.1.0/backoff-0.1.0.tbz";
       sha256 = "0013ikss0nq6yi8yjpkx67qnnpb3g6l8m386vqsd344y49war90i";
     };
   };
@@ -17,14 +23,22 @@ with oself;
   caqti-eio = buildDunePackage {
     inherit (caqti) version src;
     pname = "caqti-eio";
-    propagatedBuildInputs = [ eio eio_main caqti ];
+    propagatedBuildInputs = [
+      eio
+      eio_main
+      caqti
+    ];
   };
 
   cohttp-eio = buildDunePackage {
     pname = "cohttp-eio";
     inherit (http) src version;
     doCheck = false;
-    propagatedBuildInputs = [ cohttp eio_main ptime ];
+    propagatedBuildInputs = [
+      cohttp
+      eio_main
+      ptime
+    ];
   };
 
   eio-ssl = callPackage ./eio-ssl { };
@@ -32,7 +46,10 @@ with oself;
   graphql-eio = buildDunePackage {
     pname = "graphql-eio";
     inherit (graphql_parser) src version;
-    propagatedBuildInputs = [ eio_main graphql ];
+    propagatedBuildInputs = [
+      eio_main
+      graphql
+    ];
   };
 
   h2-eio = callPackage ./h2/eio.nix { };
@@ -43,7 +60,10 @@ with oself;
   kafka-eio = buildDunePackage {
     pname = "kafka-eio";
     inherit (kafka) hardeningDisable version src;
-    propagatedBuildInputs = [ eio kafka ];
+    propagatedBuildInputs = [
+      eio
+      kafka
+    ];
   };
 
   kcas = callPackage ./kcas { };
@@ -59,42 +79,57 @@ with oself;
   mirage-crypto-rng-eio = buildDunePackage {
     pname = "mirage-crypto-rng-eio";
     inherit (mirage-crypto) src version;
-    propagatedBuildInputs = [ eio mirage-crypto-rng ];
+    propagatedBuildInputs = [
+      eio
+      mirage-crypto-rng
+    ];
   };
 
   moonpool = buildDunePackage {
     pname = "moonpool";
     version = "0.6";
     src = builtins.fetchurl {
-      url = https://github.com/c-cube/moonpool/releases/download/v0.6/moonpool-0.6.tbz;
+      url = "https://github.com/c-cube/moonpool/releases/download/v0.6/moonpool-0.6.tbz";
       sha256 = "0cvnbv30nmpv7zpq9vfa3sz5wi1wxqm578mnga6blyx3h9f0kz9y";
     };
 
     propagatedBuildInputs = [ either ];
     doCheck = false;
     nativeCheckInputs = [ mdx ];
-    checkInputs = [ mdx qcheck-core trace trace-tef ];
+    checkInputs = [
+      mdx
+      qcheck-core
+      trace
+      trace-tef
+    ];
   };
 
   multicore-bench = buildDunePackage {
     pname = "multicore-bench";
     version = "0.1.2";
     src = builtins.fetchurl {
-      url =
-        https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.2/multicore-bench-0.1.2.tbz;
+      url = "https://github.com/ocaml-multicore/multicore-bench/releases/download/0.1.2/multicore-bench-0.1.2.tbz";
       sha256 = "1cj3wvawk4rxbgcy1cj3pj421jafg5xz18ff93wa1040cz01c975";
     };
-    propagatedBuildInputs = [ yojson mtime domain-local-await multicore-magic ];
+    propagatedBuildInputs = [
+      yojson
+      mtime
+      domain-local-await
+      multicore-magic
+    ];
     doCheck = true;
     nativeCheckInputs = [ mdx ];
-    checkInputs = [ backoff mdx ];
+    checkInputs = [
+      backoff
+      mdx
+    ];
   };
 
   multicore-magic = buildDunePackage {
     pname = "multicore-magic";
     version = "2.2.0";
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-multicore/multicore-magic/releases/download/2.2.0/multicore-magic-2.2.0.tbz;
+      url = "https://github.com/ocaml-multicore/multicore-magic/releases/download/2.2.0/multicore-magic-2.2.0.tbz";
       sha256 = "1a86lzqv8cv3jw64ijzlnm1qx2ynyy8ixrwyazdija1g58c6b2zk";
     };
   };
@@ -106,7 +141,7 @@ with oself;
     pname = "picos";
     version = "0.3.0";
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-multicore/picos/releases/download/0.3.0/picos-0.3.0.tbz;
+      url = "https://github.com/ocaml-multicore/picos/releases/download/0.3.0/picos-0.3.0.tbz";
       sha256 = "0rphlxacn9n3zpvy6v2s7v26ph6pzvgff11gz1j9gcp4pp008j2l";
     };
     propagatedBuildInputs = [
@@ -119,7 +154,11 @@ with oself;
     ];
 
     doCheck = true;
-    nativeCheckInputs = [ mdx nodejs_latest js_of_ocaml ];
+    nativeCheckInputs = [
+      mdx
+      nodejs_latest
+      js_of_ocaml
+    ];
     checkInputs = [
       multicore-bench
       alcotest
@@ -141,18 +180,22 @@ with oself;
     version = "0.5.0";
 
     src = builtins.fetchurl {
-      url = https://github.com/tarides/runtime_events_tools/releases/download/0.5.1/runtime_events_tools-0.5.1.tbz;
+      url = "https://github.com/tarides/runtime_events_tools/releases/download/0.5.1/runtime_events_tools-0.5.1.tbz";
       sha256 = "0r35cpbmj17ldpfkf4dzk4bs1knfy4hyjz6ax0ayrck25rm397dh";
     };
 
-    propagatedBuildInputs = [ tracing cmdliner hdr_histogram ];
+    propagatedBuildInputs = [
+      tracing
+      cmdliner
+      hdr_histogram
+    ];
   };
 
   thread-local-storage = buildDunePackage {
     pname = "thread-local-storage";
     version = "0.1";
     src = builtins.fetchurl {
-      url = https://github.com/c-cube/thread-local-storage/releases/download/v0.1/thread-local-storage-0.1.tbz;
+      url = "https://github.com/c-cube/thread-local-storage/releases/download/v0.1/thread-local-storage-0.1.tbz";
       sha256 = "1bk702faacqgwsx96yx9pgkikbxd1nk5xilix3mrg5l9v04gkbbj";
     };
   };
@@ -160,12 +203,18 @@ with oself;
   tls-eio = buildDunePackage {
     pname = "tls-eio";
     inherit (tls) version src;
-    propagatedBuildInputs = [ tls mirage-crypto-rng mirage-crypto-rng-eio x509 eio ];
+    propagatedBuildInputs = [
+      tls
+      mirage-crypto-rng
+      mirage-crypto-rng-eio
+      x509
+      eio
+    ];
   };
 
   wayland = osuper.wayland.overrideAttrs (o: {
     src = builtins.fetchurl {
-      url = https://github.com/talex5/ocaml-wayland/releases/download/v2.0/wayland-2.0.tbz;
+      url = "https://github.com/talex5/ocaml-wayland/releases/download/v2.0/wayland-2.0.tbz";
       sha256 = "0jw3x66yscl77w17pp31s4vhsba2xk6z2yvb30fvh0vd9p7ba8c8";
     };
     propagatedBuildInputs = [ eio ];

--- a/ocaml/oidc/client.nix
+++ b/ocaml/oidc/client.nix
@@ -1,10 +1,24 @@
-{ lib, buildDunePackage, oidc, jose, uri, yojson, logs }:
+{
+  lib,
+  buildDunePackage,
+  oidc,
+  jose,
+  uri,
+  yojson,
+  logs,
+}:
 
 buildDunePackage {
   pname = "oidc-client";
   inherit (oidc) src version;
 
-  propagatedBuildInputs = [ oidc jose uri yojson logs ];
+  propagatedBuildInputs = [
+    oidc
+    jose
+    uri
+    yojson
+    logs
+  ];
   postPatch = ''
     substituteInPlace oidc-client/dune --replace-fail "piaf" "piaf-lwt"
     substituteInPlace \

--- a/ocaml/oidc/default.nix
+++ b/ocaml/oidc/default.nix
@@ -1,5 +1,12 @@
-{ fetchFromGitHub, lib, buildDunePackage, jose, uri, yojson, logs }:
-
+{
+  fetchFromGitHub,
+  lib,
+  buildDunePackage,
+  jose,
+  uri,
+  yojson,
+  logs,
+}:
 
 buildDunePackage {
   pname = "oidc";
@@ -11,7 +18,12 @@ buildDunePackage {
     hash = "sha256-YyH4AWXbljMK0dt8e+ptk1SD66v6tGXyUaKCc5yeumo=";
   };
 
-  propagatedBuildInputs = [ jose uri yojson logs ];
+  propagatedBuildInputs = [
+    jose
+    uri
+    yojson
+    logs
+  ];
 
   meta = {
     description = "Base functions and types to work with OpenID Connect.";

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -1,4 +1,9 @@
-{ nixpkgs, overlays, super, updateOCamlPackages ? false }:
+{
+  nixpkgs,
+  overlays,
+  super,
+  updateOCamlPackages ? false,
+}:
 
 let
   inherit (super) lib callPackage ocaml-ng;
@@ -12,144 +17,174 @@ let
     "trunk"
     "jst"
   ];
-  newOCamlScope = { major_version, minor_version, patch_version, src, ... }@extraOpts:
-    ocaml-ng.mkOcamlPackages
-      ((callPackage
-        (import "${nixpkgs}/pkgs/development/compilers/ocaml/generic.nix" {
-          inherit major_version minor_version patch_version;
-        })
-        { }).overrideAttrs (_: { inherit src; } // extraOpts));
+  newOCamlScope =
+    {
+      major_version,
+      minor_version,
+      patch_version,
+      src,
+      ...
+    }@extraOpts:
+    ocaml-ng.mkOcamlPackages (
+      (callPackage (import "${nixpkgs}/pkgs/development/compilers/ocaml/generic.nix" {
+        inherit major_version minor_version patch_version;
+      }) { }).overrideAttrs
+        (_: { inherit src; } // extraOpts)
+    );
 
   custom-ocaml-ng =
-    ocaml-ng //
-    (if !(ocaml-ng ? "ocamlPackages_trunk") then {
-      ocamlPackages_4_12 = ocaml-ng.ocamlPackages_4_12.overrideScope (oself: osuper: {
-        ocaml = osuper.ocaml.overrideAttrs (_: {
-          src = super.fetchFromGitHub {
-            owner = "ocaml";
-            repo = "ocaml";
-            rev = "4.12.1";
-            hash = "sha256-xIBRHPG0cmhKr0mYp+wKl1a9Bo0PYX2Uc8VO7lCMVzM=";
+    ocaml-ng
+    // (
+      if !(ocaml-ng ? "ocamlPackages_trunk") then
+        {
+          ocamlPackages_4_12 = ocaml-ng.ocamlPackages_4_12.overrideScope (
+            oself: osuper: {
+              ocaml = osuper.ocaml.overrideAttrs (_: {
+                src = super.fetchFromGitHub {
+                  owner = "ocaml";
+                  repo = "ocaml";
+                  rev = "4.12.1";
+                  hash = "sha256-xIBRHPG0cmhKr0mYp+wKl1a9Bo0PYX2Uc8VO7lCMVzM=";
+                };
+              });
+            }
+          );
+          ocamlPackages_4_13 = ocaml-ng.ocamlPackages_4_13.overrideScope (
+            oself: osuper: {
+              ocaml = osuper.ocaml.overrideAttrs (_: {
+                src = super.fetchFromGitHub {
+                  owner = "ocaml";
+                  repo = "ocaml";
+                  rev = "4.13.1";
+                  hash = "sha256-Mq4mQ9ZgzSpw21b2s55fPsA7rKqXCESr+TAg6PfzU8Q=";
+                };
+              });
+            }
+          );
+          ocamlPackages_4_14 = ocaml-ng.ocamlPackages_4_14.overrideScope (
+            oself: osuper: {
+              ocaml = osuper.ocaml.overrideAttrs (_: {
+                src = super.fetchFromGitHub {
+                  owner = "ocaml";
+                  repo = "ocaml";
+                  rev = "4.14.2";
+                  hash = "sha256-xKcFQ8vkiOTw7CAMddF8Xf82GNpg879bUdyVC63XREg=";
+                };
+                hardeningDisable = [ "strictoverflow" ];
+              });
+            }
+          );
+          ocamlPackages_5_0 = ocaml-ng.ocamlPackages_5_0.overrideScope (
+            oself: osuper: {
+              ocaml = osuper.ocaml.overrideAttrs (_: {
+                src = super.fetchFromGitHub {
+                  owner = "ocaml";
+                  repo = "ocaml";
+                  rev = "5.0.0";
+                  hash = "sha256-pQrbncjIYrrreJS7LV+Z5J0AhAikD+94MHnZ3ChHF9w=";
+                };
+
+              });
+            }
+          );
+          ocamlPackages_5_1 = ocaml-ng.ocamlPackages_5_1.overrideScope (
+            oself: osuper: {
+              ocaml = osuper.ocaml.overrideAttrs (_: {
+                src = super.fetchFromGitHub {
+                  owner = "ocaml";
+                  repo = "ocaml";
+                  rev = "5.1.1";
+                  hash = "sha256-uSmTpDUVhj9niON65B9sc/8PBgurS3nIOx4dJjJiUqc=";
+                };
+              });
+            }
+          );
+
+          ocamlPackages_5_2 = ocaml-ng.ocamlPackages_5_2.overrideScope (
+            oself: osuper: {
+              ocaml = osuper.ocaml.overrideAttrs (_: {
+                src = super.fetchFromGitHub {
+                  owner = "ocaml";
+                  repo = "ocaml";
+                  rev = "5.2.0";
+                  hash = "sha256-cN5feAgjEX0ojyQaNWI5X4Q7HuccOmwLQsi9Khi8PB0=";
+                };
+              });
+            }
+          );
+
+          ocamlPackages_trunk = newOCamlScope {
+            major_version = "5";
+            minor_version = "3";
+            patch_version = "0+trunk";
+            hardeningDisable = [ "strictoverflow" ];
+            src = super.fetchFromGitHub {
+              owner = "ocaml";
+              repo = "ocaml";
+              rev = "ba6dbe91d4dee4edbdebed58cca30b0e40d8b7d5";
+              hash = "sha256-hRG7IGrwlW4voInsmgd8Nsd2tBS7yS60c58YnLsipO4=";
+            };
           };
-        });
-      });
-      ocamlPackages_4_13 = ocaml-ng.ocamlPackages_4_13.overrideScope (oself: osuper: {
-        ocaml = osuper.ocaml.overrideAttrs (_: {
-          src = super.fetchFromGitHub {
-            owner = "ocaml";
-            repo = "ocaml";
-            rev = "4.13.1";
-            hash = "sha256-Mq4mQ9ZgzSpw21b2s55fPsA7rKqXCESr+TAg6PfzU8Q=";
-          };
-        });
-      });
-      ocamlPackages_4_14 = ocaml-ng.ocamlPackages_4_14.overrideScope (oself: osuper: {
-        ocaml = osuper.ocaml.overrideAttrs (_: {
-          src = super.fetchFromGitHub {
-            owner = "ocaml";
-            repo = "ocaml";
-            rev = "4.14.2";
-            hash = "sha256-xKcFQ8vkiOTw7CAMddF8Xf82GNpg879bUdyVC63XREg=";
-          };
-          hardeningDisable = [ "strictoverflow" ];
-        });
-      });
-      ocamlPackages_5_0 = ocaml-ng.ocamlPackages_5_0.overrideScope (oself: osuper: {
-        ocaml = osuper.ocaml.overrideAttrs (_: {
-          src = super.fetchFromGitHub {
-            owner = "ocaml";
-            repo = "ocaml";
-            rev = "5.0.0";
-            hash = "sha256-pQrbncjIYrrreJS7LV+Z5J0AhAikD+94MHnZ3ChHF9w=";
-          };
 
-        });
-      });
-      ocamlPackages_5_1 = ocaml-ng.ocamlPackages_5_1.overrideScope (oself: osuper: {
-        ocaml = osuper.ocaml.overrideAttrs (_: {
-          src = super.fetchFromGitHub {
-            owner = "ocaml";
-            repo = "ocaml";
-            rev = "5.1.1";
-            hash = "sha256-uSmTpDUVhj9niON65B9sc/8PBgurS3nIOx4dJjJiUqc=";
-          };
-        });
-      });
+          ocamlPackages_jst = ocaml-ng.ocamlPackages_4_14.overrideScope (
+            oself: osuper: {
+              ocaml =
+                (callPackage (import "${nixpkgs}/pkgs/development/compilers/ocaml/generic.nix" {
+                  major_version = "4";
+                  minor_version = "14";
+                  patch_version = "1+jst";
+                }) { }).overrideAttrs
+                  (o: {
+                    src = super.fetchFromGitHub {
+                      owner = "ocaml-flambda";
+                      repo = "ocaml-jst";
+                      rev = "e3076d2e7321a8e8ff18e560ed7a55d6ff0ebf04";
+                      hash = "sha256-y5p73ZZtwkgUzvCHlE9nqA2OdlDbYWr8wnWRhYH82hE=";
+                    };
+                    hardeningDisable = [ "strictoverflow" ];
+                  });
 
-      ocamlPackages_5_2 = ocaml-ng.ocamlPackages_5_2.overrideScope (oself: osuper: {
-        ocaml = osuper.ocaml.overrideAttrs (_: {
-          src = super.fetchFromGitHub {
-            owner = "ocaml";
-            repo = "ocaml";
-            rev = "5.2.0";
-            hash = "sha256-cN5feAgjEX0ojyQaNWI5X4Q7HuccOmwLQsi9Khi8PB0=";
-          };
-        });
-      });
+              dune_3 = osuper.dune_3.overrideAttrs (_: {
+                postPatch = ''
+                  substituteInPlace boot/bootstrap.ml --replace-fail 'v >= (5, 0, 0)' "true"
+                  substituteInPlace boot/duneboot.ml --replace-fail 'ocaml_version >= (5, 0)' "true"
+                  substituteInPlace src/ocaml-config/ocaml_config.ml --replace-fail 'version >= (5, 0, 0)' "true"
+                  substituteInPlace src/ocaml/version.ml --replace-fail 'version >= (5, 0, 0)' "true"
+                '';
+              });
+            }
+          );
 
-      ocamlPackages_trunk = newOCamlScope {
-        major_version = "5";
-        minor_version = "3";
-        patch_version = "0+trunk";
-        hardeningDisable = [ "strictoverflow" ];
-        src = super.fetchFromGitHub {
-          owner = "ocaml";
-          repo = "ocaml";
-          rev = "ba6dbe91d4dee4edbdebed58cca30b0e40d8b7d5";
-          hash = "sha256-hRG7IGrwlW4voInsmgd8Nsd2tBS7yS60c58YnLsipO4=";
-        };
-      };
+        }
+      else
+        { }
+    );
 
-      ocamlPackages_jst = ocaml-ng.ocamlPackages_4_14.overrideScope (oself: osuper: {
-        ocaml = (callPackage
-          (import "${nixpkgs}/pkgs/development/compilers/ocaml/generic.nix" {
-            major_version = "4";
-            minor_version = "14";
-            patch_version = "1+jst";
-          })
-          { }).overrideAttrs (o: {
-          src = super.fetchFromGitHub {
-            owner = "ocaml-flambda";
-            repo = "ocaml-jst";
-            rev = "e3076d2e7321a8e8ff18e560ed7a55d6ff0ebf04";
-            hash = "sha256-y5p73ZZtwkgUzvCHlE9nqA2OdlDbYWr8wnWRhYH82hE=";
-          };
-          hardeningDisable = [ "strictoverflow" ];
-        });
+  overlaySinglePackageSet = pkgSet: builtins.foldl' (acc: x: acc.overrideScope x) pkgSet overlays;
 
-        dune_3 = osuper.dune_3.overrideAttrs (_: {
-          postPatch = ''
-            substituteInPlace boot/bootstrap.ml --replace-fail 'v >= (5, 0, 0)' "true"
-            substituteInPlace boot/duneboot.ml --replace-fail 'ocaml_version >= (5, 0)' "true"
-            substituteInPlace src/ocaml-config/ocaml_config.ml --replace-fail 'version >= (5, 0, 0)' "true"
-            substituteInPlace src/ocaml/version.ml --replace-fail 'version >= (5, 0, 0)' "true"
-          '';
-        });
-      });
-
-    } else { });
-
-  overlaySinglePackageSet = pkgSet:
-    builtins.foldl' (acc: x: acc.overrideScope x) pkgSet overlays;
-
-  overlayOCamlPackages = version:
-    lib.nameValuePair
-      "ocamlPackages_${version}"
-      (overlaySinglePackageSet custom-ocaml-ng."ocamlPackages_${version}");
+  overlayOCamlPackages =
+    version:
+    lib.nameValuePair "ocamlPackages_${version}" (
+      overlaySinglePackageSet custom-ocaml-ng."ocamlPackages_${version}"
+    );
 
   oPs = lib.listToAttrs (builtins.map overlayOCamlPackages ocamlVersions);
 
 in
 
 rec {
-  ocaml-ng = custom-ocaml-ng // oPs // {
-    ocamlPackages = overlaySinglePackageSet custom-ocaml-ng.ocamlPackages;
-    ocamlPackages_latest = oPs.ocamlPackages_5_2;
-  };
+  ocaml-ng =
+    custom-ocaml-ng
+    // oPs
+    // {
+      ocamlPackages = overlaySinglePackageSet custom-ocaml-ng.ocamlPackages;
+      ocamlPackages_latest = oPs.ocamlPackages_5_2;
+    };
   ocamlPackages =
     if updateOCamlPackages then
       overlaySinglePackageSet super.ocamlPackages
-    else ocaml-ng.ocamlPackages_5_2;
+    else
+      ocaml-ng.ocamlPackages_5_2;
   ocamlPackages_latest =
     if updateOCamlPackages then
       overlaySinglePackageSet super.ocamlPackage_latest

--- a/ocaml/pg_query/default.nix
+++ b/ocaml/pg_query/default.nix
@@ -1,10 +1,11 @@
-{ fetchFromGitHub
-, buildDunePackage
-, alcotest
-, cmdliner
-, ppx_deriving
-, ctypes
-, ctypes-foreign
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  alcotest,
+  cmdliner,
+  ppx_deriving,
+  ctypes,
+  ctypes-foreign,
 }:
 
 buildDunePackage {

--- a/ocaml/piaf/carl.nix
+++ b/ocaml/piaf/carl.nix
@@ -1,15 +1,16 @@
-{ lib
-, stdenv
-, overrideSDK
-, static ? false
-, piaf
-, ocaml
-, dune
-, findlib
-, cmdliner
-, camlzip
-, ezgzip
-, fmt
+{
+  lib,
+  stdenv,
+  overrideSDK,
+  static ? false,
+  piaf,
+  ocaml,
+  dune,
+  findlib,
+  cmdliner,
+  camlzip,
+  ezgzip,
+  fmt,
 }:
 
 let

--- a/ocaml/piaf/default.nix
+++ b/ocaml/piaf/default.nix
@@ -1,20 +1,21 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, buildDunePackage
-, eio
-, eio_main
-, eio-ssl
-, h2-eio
-, httpun-eio
-, ipaddr
-, magic-mime
-, multipart_form
-, uri
-, httpun-ws
-, alcotest
-, dune-site
-, ocaml
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  eio,
+  eio_main,
+  eio-ssl,
+  h2-eio,
+  httpun-eio,
+  ipaddr,
+  magic-mime,
+  multipart_form,
+  uri,
+  httpun-ws,
+  alcotest,
+  dune-site,
+  ocaml,
 }:
 
 buildDunePackage {

--- a/ocaml/ppx_jsx_embed/default.nix
+++ b/ocaml/ppx_jsx_embed/default.nix
@@ -1,4 +1,9 @@
-{ fetchFromGitHub, buildDunePackage, reason, ppxlib }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  reason,
+  ppxlib,
+}:
 
 buildDunePackage {
   pname = "ppx_jsx_embed";
@@ -10,5 +15,8 @@ buildDunePackage {
     hash = "sha256-7dPvSmpT+hU6+GlZoa/SpHVi7zRHwX/SZR7Jsk2aJ3A=";
   };
   doCheck = true;
-  propagatedBuildInputs = [ reason ppxlib ];
+  propagatedBuildInputs = [
+    reason
+    ppxlib
+  ];
 }

--- a/ocaml/ppx_rapper/async.nix
+++ b/ocaml/ppx_rapper/async.nix
@@ -1,8 +1,17 @@
-{ buildDunePackage, async, caqti-async, ppx_rapper }:
+{
+  buildDunePackage,
+  async,
+  caqti-async,
+  ppx_rapper,
+}:
 
 buildDunePackage {
   pname = "ppx_rapper_async";
   inherit (ppx_rapper) src version;
 
-  propagatedBuildInputs = [ async caqti-async ppx_rapper ];
+  propagatedBuildInputs = [
+    async
+    caqti-async
+    ppx_rapper
+  ];
 }

--- a/ocaml/ppx_rapper/default.nix
+++ b/ocaml/ppx_rapper/default.nix
@@ -1,4 +1,10 @@
-{ fetchFromGitHub, buildDunePackage, base, caqti, pg_query }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  base,
+  caqti,
+  pg_query,
+}:
 
 buildDunePackage rec {
   pname = "ppx_rapper";
@@ -11,5 +17,9 @@ buildDunePackage rec {
     hash = "sha256-HF7VVS2o5tdblkvd3Rwp8dohlwMJ/Dyo0fnd+D1+8vc=";
   };
 
-  propagatedBuildInputs = [ caqti pg_query base ];
+  propagatedBuildInputs = [
+    caqti
+    pg_query
+    base
+  ];
 }

--- a/ocaml/ppx_rapper/eio.nix
+++ b/ocaml/ppx_rapper/eio.nix
@@ -1,8 +1,17 @@
-{ buildDunePackage, ppx_rapper, eio, caqti-eio }:
+{
+  buildDunePackage,
+  ppx_rapper,
+  eio,
+  caqti-eio,
+}:
 
 buildDunePackage {
   pname = "ppx_rapper_eio";
   inherit (ppx_rapper) src version;
 
-  propagatedBuildInputs = [ ppx_rapper eio caqti-eio ];
+  propagatedBuildInputs = [
+    ppx_rapper
+    eio
+    caqti-eio
+  ];
 }

--- a/ocaml/ppx_rapper/lwt.nix
+++ b/ocaml/ppx_rapper/lwt.nix
@@ -1,8 +1,17 @@
-{ buildDunePackage, ppx_rapper, lwt, caqti-lwt }:
+{
+  buildDunePackage,
+  ppx_rapper,
+  lwt,
+  caqti-lwt,
+}:
 
 buildDunePackage {
   pname = "ppx_rapper_lwt";
   inherit (ppx_rapper) src version;
 
-  propagatedBuildInputs = [ ppx_rapper lwt caqti-lwt ];
+  propagatedBuildInputs = [
+    ppx_rapper
+    lwt
+    caqti-lwt
+  ];
 }

--- a/ocaml/prometheus/default.nix
+++ b/ocaml/prometheus/default.nix
@@ -5,7 +5,7 @@ buildDunePackage {
   version = "n/a";
 
   src = builtins.fetchurl {
-    url = https://github.com/ulrikstrid/prometheus/archive/5acd3509.tar.gz;
+    url = "https://github.com/ulrikstrid/prometheus/archive/5acd3509.tar.gz";
     sha256 = "01vxgjfydiwa5164c0l0waks3k3xj0mj2f6bxf7mjhcxj6bixhns";
   };
 }

--- a/ocaml/reason/default.nix
+++ b/ocaml/reason/default.nix
@@ -1,16 +1,17 @@
-{ lib
-, fetchFromGitHub
-, buildDunePackage
-, ocaml
-, cppo
-, menhir
-, menhirLib
-, menhirSdk
-, fix
-, merlin-extend
-, ppx_derivers
-, ppxlib
-, dune-build-info
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  ocaml,
+  cppo,
+  menhir,
+  menhirLib,
+  menhirSdk,
+  fix,
+  merlin-extend,
+  ppx_derivers,
+  ppxlib,
+  dune-build-info,
 }:
 
 buildDunePackage rec {
@@ -18,7 +19,7 @@ buildDunePackage rec {
   version = "3.11.0";
 
   src = builtins.fetchurl {
-    url = https://github.com/reasonml/reason/releases/download/3.11.0/reason-3.11.0.tbz;
+    url = "https://github.com/reasonml/reason/releases/download/3.11.0/reason-3.11.0.tbz";
     sha256 = "0l3jlahrhk18bgynqa3l6lsn9vhnxf553mcrxg44gw3r9bqkg255";
   };
 
@@ -32,11 +33,12 @@ buildDunePackage rec {
     dune-build-info
   ];
 
-  nativeBuildInputs = [ cppo menhir ];
-
-  patches = [
-    ./patches/0001-rename-labels.patch
+  nativeBuildInputs = [
+    cppo
+    menhir
   ];
+
+  patches = [ ./patches/0001-rename-labels.patch ];
 
   meta.mainProgram = "refmt";
 }

--- a/ocaml/reason/rtop.nix
+++ b/ocaml/reason/rtop.nix
@@ -1,10 +1,18 @@
-{ buildDunePackage, cppo, reason, utop }:
+{
+  buildDunePackage,
+  cppo,
+  reason,
+  utop,
+}:
 
 buildDunePackage {
   inherit (reason) src version;
   pname = "rtop";
   nativeBuildInputs = [ cppo ];
-  propagatedBuildInputs = [ utop reason ];
+  propagatedBuildInputs = [
+    utop
+    reason
+  ];
 
   meta.mainProgram = "rtop";
 }

--- a/ocaml/redemon/default.nix
+++ b/ocaml/redemon/default.nix
@@ -1,4 +1,12 @@
-{ lib, fetchFromGitHub, buildDunePackage, luv, cmdliner, logs, fmt }:
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  luv,
+  cmdliner,
+  logs,
+  fmt,
+}:
 
 buildDunePackage {
   pname = "redemon";
@@ -10,7 +18,12 @@ buildDunePackage {
     sha256 = "sha256-M3tBxNLjEkZmmVbjqBmMRMK1cmiNTzxYfnPvnk3jfAE=";
   };
 
-  propagatedBuildInputs = [ luv cmdliner logs fmt ];
+  propagatedBuildInputs = [
+    luv
+    cmdliner
+    logs
+    fmt
+  ];
   postPatch = ''
     substituteInPlace bin/main.ml \
       --replace-fail '%s" file' '%s" (Option.get file)' \

--- a/ocaml/redis/default.nix
+++ b/ocaml/redis/default.nix
@@ -1,14 +1,25 @@
-{ lib, fetchFromGitHub, buildDunePackage, uuidm, re, stdlib-shims }:
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  uuidm,
+  re,
+  stdlib-shims,
+}:
 
 buildDunePackage rec {
   pname = "redis";
   version = "0.7";
   src = builtins.fetchurl {
-    url = https://github.com/0xffea/ocaml-redis/releases/download/v0.7.1/redis-0.7.1.tbz;
+    url = "https://github.com/0xffea/ocaml-redis/releases/download/v0.7.1/redis-0.7.1.tbz";
     sha256 = "02llmcfjh8dplc456y8y3vvvslsdib1r679pn8baphfm8xn1zxqf";
   };
 
-  propagatedBuildInputs = [ uuidm re stdlib-shims ];
+  propagatedBuildInputs = [
+    uuidm
+    re
+    stdlib-shims
+  ];
 
   meta = {
     description = "Redis client";

--- a/ocaml/redis/lwt.nix
+++ b/ocaml/redis/lwt.nix
@@ -1,12 +1,25 @@
-{ lib, buildDunePackage, redis, lwt, ounit, containers }:
+{
+  lib,
+  buildDunePackage,
+  redis,
+  lwt,
+  ounit,
+  containers,
+}:
 
 buildDunePackage {
   pname = "redis-lwt";
   inherit (redis) src version;
 
-  propagatedBuildInputs = [ redis lwt ];
+  propagatedBuildInputs = [
+    redis
+    lwt
+  ];
 
-  checkInputs = [ ounit containers ];
+  checkInputs = [
+    ounit
+    containers
+  ];
 
   meta = {
     description = "Redis client (lwt interface)";

--- a/ocaml/redis/sync.nix
+++ b/ocaml/redis/sync.nix
@@ -1,10 +1,20 @@
-{ lib, buildDunePackage, redis, ounit, containers, camlp-streams }:
+{
+  lib,
+  buildDunePackage,
+  redis,
+  ounit,
+  containers,
+  camlp-streams,
+}:
 
 buildDunePackage {
   pname = "redis-sync";
   inherit (redis) src version;
 
-  propagatedBuildInputs = [ redis camlp-streams ];
+  propagatedBuildInputs = [
+    redis
+    camlp-streams
+  ];
 
   meta = {
     description = "Redis client (blocking)";

--- a/ocaml/reenv/default.nix
+++ b/ocaml/reenv/default.nix
@@ -1,12 +1,13 @@
-{ lib
-, fetchFromGitHub
-, buildDunePackage
-, alcotest
-, junit
-, junit_alcotest
-, reason
-, cmdliner
-, re
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  alcotest,
+  junit,
+  junit_alcotest,
+  reason,
+  cmdliner,
+  re,
 }:
 
 buildDunePackage {
@@ -19,12 +20,19 @@ buildDunePackage {
     sha256 = "sha256-p+RyVAmIEhUlRhLVrWJcrlcJ4fcyVbgo8YxZ0DT2c2w=";
   };
 
-  checkInputs = [ alcotest junit junit_alcotest ];
+  checkInputs = [
+    alcotest
+    junit
+    junit_alcotest
+  ];
 
   doCheck = true;
 
   nativeBuildInputs = [ reason ];
-  propagatedBuildInputs = [ cmdliner re ];
+  propagatedBuildInputs = [
+    cmdliner
+    re
+  ];
 
   meta = {
     description = "dotenv-cli written in reason";

--- a/ocaml/sendfile/default.nix
+++ b/ocaml/sendfile/default.nix
@@ -4,7 +4,7 @@ buildDunePackage {
   pname = "sendfile";
   version = "dev";
   src = builtins.fetchurl {
-    url = https://github.com/anmonteiro/ocaml-sendfile/archive/75c37fc.tar.gz;
+    url = "https://github.com/anmonteiro/ocaml-sendfile/archive/75c37fc.tar.gz";
     sha256 = "0nfsyi6r22yrdm1i1la23775dfm5cingawwrl2rfhsdzx0s46j26";
   };
 }

--- a/ocaml/session/default.nix
+++ b/ocaml/session/default.nix
@@ -1,4 +1,11 @@
-{ lib, fetchFromGitHub, buildDunePackage, mirage-crypto, mirage-crypto-rng, base64 }:
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  mirage-crypto,
+  mirage-crypto-rng,
+  base64,
+}:
 
 buildDunePackage {
   pname = "session";
@@ -10,7 +17,11 @@ buildDunePackage {
     sha256 = "sha256-3n3LN1lFWy/F24Gnoc7Bhp69VUEVLZFITaXLL1vMzG4=";
   };
 
-  propagatedBuildInputs = [ mirage-crypto mirage-crypto-rng base64 ];
+  propagatedBuildInputs = [
+    mirage-crypto
+    mirage-crypto-rng
+    base64
+  ];
 
   meta = {
     description = "A session manager for your everyday needs";

--- a/ocaml/session/redis.nix
+++ b/ocaml/session/redis.nix
@@ -1,10 +1,18 @@
-{ lib, buildDunePackage, redis-lwt, session }:
+{
+  lib,
+  buildDunePackage,
+  redis-lwt,
+  session,
+}:
 
 buildDunePackage {
   pname = "session-redis-lwt";
   inherit (session) src version;
 
-  propagatedBuildInputs = [ redis-lwt session ];
+  propagatedBuildInputs = [
+    redis-lwt
+    session
+  ];
 
   meta = {
     description = "A session manager for your everyday needs - Redis-specific support for Lwt";

--- a/ocaml/sherlodoc/default.nix
+++ b/ocaml/sherlodoc/default.nix
@@ -1,24 +1,24 @@
-{ lib
-, fetchFromGitHub
-, buildDunePackage
-, js_of_ocaml-compiler
-, result
-, tyxml
-, ppx_blob
-, lwt
-, fpath
-, decompress
-, cmdliner
-, brr
-, bigstringaf
-, base64
-, odoc
-, odoc-parser
-, menhir
-, fmt
-, dream
-, enableServe ? false
-,
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  js_of_ocaml-compiler,
+  result,
+  tyxml,
+  ppx_blob,
+  lwt,
+  fpath,
+  decompress,
+  cmdliner,
+  brr,
+  bigstringaf,
+  base64,
+  odoc,
+  odoc-parser,
+  menhir,
+  fmt,
+  dream,
+  enableServe ? false,
 }:
 
 buildDunePackage {
@@ -30,7 +30,10 @@ buildDunePackage {
     rev = "0.2";
     sha256 = "sha256-MEYKtlVoSYZhh4ernon1FHGFykfeCmv6qQi+cyy3LX8=";
   };
-  nativeBuildInputs = [ menhir js_of_ocaml-compiler ];
+  nativeBuildInputs = [
+    menhir
+    js_of_ocaml-compiler
+  ];
   propagatedBuildInputs = [
     result
     tyxml

--- a/ocaml/subscriptions-transport-ws/default.nix
+++ b/ocaml/subscriptions-transport-ws/default.nix
@@ -1,4 +1,10 @@
-{ lib, fetchFromGitHub, buildDunePackage, websocketaf, graphql }:
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  websocketaf,
+  graphql,
+}:
 
 buildDunePackage {
   pname = "subscriptions-transport-ws";
@@ -11,7 +17,10 @@ buildDunePackage {
     sha256 = "sha256-15zAWaYOM8ufYc6Ad5esXbqFHNGXZXBX2WrRZhsi0wI=";
   };
 
-  propagatedBuildInputs = [ websocketaf graphql ];
+  propagatedBuildInputs = [
+    websocketaf
+    graphql
+  ];
 
   meta = {
     license = lib.licenses.bsd3;

--- a/ocaml/timere/default.nix
+++ b/ocaml/timere/default.nix
@@ -1,12 +1,13 @@
-{ buildDunePackage
-, seq
-, timedesc-tzlocal
-, oseq
-, containers
-, fmt
-, timedesc
-, timedesc-sexp
-, diet
+{
+  buildDunePackage,
+  seq,
+  timedesc-tzlocal,
+  oseq,
+  containers,
+  fmt,
+  timedesc,
+  timedesc-sexp,
+  diet,
 }:
 
 buildDunePackage {

--- a/ocaml/timere/parse.nix
+++ b/ocaml/timere/parse.nix
@@ -1,10 +1,11 @@
-{ buildDunePackage
-, timere
-, oseq
-, re
-, containers
-, timedesc
-, mparser
+{
+  buildDunePackage,
+  timere,
+  oseq,
+  re,
+  containers,
+  timedesc,
+  mparser,
 }:
 
 buildDunePackage {

--- a/ocaml/timere/timedesc-json.nix
+++ b/ocaml/timere/timedesc-json.nix
@@ -1,4 +1,8 @@
-{ buildDunePackage, timedesc, yojson }:
+{
+  buildDunePackage,
+  timedesc,
+  yojson,
+}:
 
 buildDunePackage {
   pname = "timedesc-json";

--- a/ocaml/timere/timedesc-sexp.nix
+++ b/ocaml/timere/timedesc-sexp.nix
@@ -1,11 +1,15 @@
-{ buildDunePackage
-, timedesc
-, timedesc-tzlocal
-, sexplib
+{
+  buildDunePackage,
+  timedesc,
+  timedesc-tzlocal,
+  sexplib,
 }:
 
 buildDunePackage {
   pname = "timedesc-sexp";
   inherit (timedesc-tzlocal) src version;
-  propagatedBuildInputs = [ timedesc sexplib ];
+  propagatedBuildInputs = [
+    timedesc
+    sexplib
+  ];
 }

--- a/ocaml/timere/timedesc.nix
+++ b/ocaml/timere/timedesc.nix
@@ -1,13 +1,14 @@
-{ buildDunePackage
-, timedesc-tzdb
-, timedesc-tzlocal
-, seq
-, angstrom
-, ptime
-, crowbar
-, alcotest
-, qcheck-alcotest
-, qcheck
+{
+  buildDunePackage,
+  timedesc-tzdb,
+  timedesc-tzlocal,
+  seq,
+  angstrom,
+  ptime,
+  crowbar,
+  alcotest,
+  qcheck-alcotest,
+  qcheck,
 }:
 
 buildDunePackage {

--- a/ocaml/typedppxlib/default.nix
+++ b/ocaml/typedppxlib/default.nix
@@ -1,4 +1,9 @@
-{ fetchFromGitHub, buildDunePackage, ppx_optcomp, ocaml-migrate-types }:
+{
+  fetchFromGitHub,
+  buildDunePackage,
+  ppx_optcomp,
+  ocaml-migrate-types,
+}:
 
 buildDunePackage {
   pname = "typedppxlib";
@@ -9,5 +14,8 @@ buildDunePackage {
     rev = "658d0b1";
     sha256 = "sha256-Cocy+xxeRaEztptMkxEUqwFwoMgGjm3Zti6IBXd/V7U=";
   };
-  propagatedBuildInputs = [ ppx_optcomp ocaml-migrate-types ];
+  propagatedBuildInputs = [
+    ppx_optcomp
+    ocaml-migrate-types
+  ];
 }

--- a/ocaml/tyxml/jsx.nix
+++ b/ocaml/tyxml/jsx.nix
@@ -1,10 +1,23 @@
-{ lib, buildDunePackage, tyxml, tyxml-syntax, ppxlib, reason, alcotest }:
+{
+  lib,
+  buildDunePackage,
+  tyxml,
+  tyxml-syntax,
+  ppxlib,
+  reason,
+  alcotest,
+}:
 
 buildDunePackage {
   inherit (tyxml) src version;
   pname = "tyxml-jsx";
 
-  propagatedBuildInputs = [ tyxml tyxml-syntax ppxlib reason ];
+  propagatedBuildInputs = [
+    tyxml
+    tyxml-syntax
+    ppxlib
+    reason
+  ];
 
   nativeCheckInputs = [ reason ];
   checkInputs = [ alcotest ];

--- a/ocaml/tyxml/ppx.nix
+++ b/ocaml/tyxml/ppx.nix
@@ -1,18 +1,25 @@
-{ lib
-, buildDunePackage
-, tyxml
-, tyxml-syntax
-, ppxlib
-, reason
-, markup
-, alcotest
+{
+  lib,
+  buildDunePackage,
+  tyxml,
+  tyxml-syntax,
+  ppxlib,
+  reason,
+  markup,
+  alcotest,
 }:
 
 buildDunePackage {
   pname = "tyxml-ppx";
   inherit (tyxml) src version;
 
-  propagatedBuildInputs = [ tyxml tyxml-syntax ppxlib reason markup ];
+  propagatedBuildInputs = [
+    tyxml
+    tyxml-syntax
+    ppxlib
+    reason
+    markup
+  ];
 
   checkInputs = [ alcotest ];
   doCheck = true;

--- a/ocaml/tyxml/syntax.nix
+++ b/ocaml/tyxml/syntax.nix
@@ -1,10 +1,22 @@
-{ lib, buildDunePackage, ppxlib, uutf, re, tyxml, alcotest }:
+{
+  lib,
+  buildDunePackage,
+  ppxlib,
+  uutf,
+  re,
+  tyxml,
+  alcotest,
+}:
 
 buildDunePackage {
   pname = "tyxml-syntax";
   inherit (tyxml) src version;
 
-  propagatedBuildInputs = [ ppxlib uutf re ];
+  propagatedBuildInputs = [
+    ppxlib
+    uutf
+    re
+  ];
   checkInputs = [ alcotest ];
   doCheck = true;
 

--- a/static/default.nix
+++ b/static/default.nix
@@ -20,12 +20,19 @@ in
     configureFlags = o.configureFlags ++ [ "--enable-static" ];
   });
   readline-oc = super.readline-oc.overrideAttrs (o: {
-    configureFlags = (o.configureFlags or [ ]) ++ [ "--enable-static" "--disable-shared" ];
+    configureFlags = (o.configureFlags or [ ]) ++ [
+      "--enable-static"
+      "--disable-shared"
+    ];
   });
 
   libev-oc = super.libev-oc.override { static = true; };
-  libffi-oc = super.libffi-oc.overrideAttrs (_: { dontDisableStatic = true; });
-  libpq = super.libpq.overrideAttrs (_: { dontDisableStatic = true; });
+  libffi-oc = super.libffi-oc.overrideAttrs (_: {
+    dontDisableStatic = true;
+  });
+  libpq = super.libpq.overrideAttrs (_: {
+    dontDisableStatic = true;
+  });
   libxml2 = super.libxml2.override { zlib = self.zlib-oc; };
   lz4-oc = super.lz4-oc.override { enableStatic = true; };
   gmp-oc = super.gmp-oc.override { withStatic = true; };
@@ -35,20 +42,22 @@ in
     dontDisableStatic = true;
   });
 
-  rdkafka-oc = (super.rdkafka-oc.override {
-    zstd = self.zstd-oc;
-    zlib = self.zlib-oc;
-    openssl = self.openssl-oc;
-  }).overrideAttrs (o: {
-    postPatch = ''
-      ${o.postPatch}
-      # https://github.com/confluentinc/librdkafka/pull/4281
-      substituteInPlace mklove/Makefile.base --replace-fail 'ar -r' '$(AR) -r'
-    '';
-    configureFlags = [ "--enable-static" ];
-    STATIC_LIB_libzstd = "${self.zstd-oc}/lib/libzstd.a";
-    propagatedBuildInputs = o.buildInputs;
-  });
+  rdkafka-oc =
+    (super.rdkafka-oc.override {
+      zstd = self.zstd-oc;
+      zlib = self.zlib-oc;
+      openssl = self.openssl-oc;
+    }).overrideAttrs
+      (o: {
+        postPatch = ''
+          ${o.postPatch}
+          # https://github.com/confluentinc/librdkafka/pull/4281
+          substituteInPlace mklove/Makefile.base --replace-fail 'ar -r' '$(AR) -r'
+        '';
+        configureFlags = [ "--enable-static" ];
+        STATIC_LIB_libzstd = "${self.zstd-oc}/lib/libzstd.a";
+        propagatedBuildInputs = o.buildInputs;
+      });
 
   sqlite-oc = (super.sqlite-oc.override { zlib = self.zlib-oc; }).overrideAttrs (o: {
     dontDisableStatic = true;
@@ -60,7 +69,8 @@ in
   };
 
   zstd-oc = super.zstd-oc.override { static = true; };
-} // super.lib.overlayOCamlPackages {
+}
+// super.lib.overlayOCamlPackages {
   inherit super;
   overlays = [ (super.callPackage ./ocaml.nix { }) ];
   updateOCamlPackages = true;


### PR DESCRIPTION
Since [RFC 0166](https://github.com/NixOS/rfcs/pull/166) is now merged, `pkgs.nixfmt-rfc-style` can format nix files to be conformant.

This has some upsides such as: 

- Formatting matches what consumers might expect if they are coming from nixpkgs 
- Deprecated patterns such as URL literals can be automatically fixed

The latter is relevant to some use cases. 
For example, users on later versions of `nix` or those who set the `no-url-literals` experimental feature cannot evaluate URL literals. 
If a package depends on the OCaml Nix Overlays with these features, it will error out and fail to build.

This merge would format the repository to the RFC 0166 standard using `pkgs.nixfmt-rfc-style` and adopt all the automatic fixes it brings along.
