### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719451888,
-        "narHash": "sha256-Ky0sgEEJMcBmNEJztY6KcVn+6bq74EKM7pd1CR1wnPQ=",
+        "lastModified": 1719674260,
+        "narHash": "sha256-mlxmTqtlBR2CwbucuDpZ49ROKRJGeojCHkkY1Nd6Kw8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3664857c48feacb35770c00abfdc671e55849be5",
+        "rev": "eb1ba314aff505efb42bce45f47542a517fc3c03",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3664857c48feacb35770c00abfdc671e55849be5",
+        "rev": "eb1ba314aff505efb42bce45f47542a517fc3c03",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=3664857c48feacb35770c00abfdc671e55849be5";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=eb1ba314aff505efb42bce45f47542a517fc3c03";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/ea780bcedbe728b5e7447d3730bcef976b0063cc"><pre>ocamlPackages.reason-native: 2022-08-31-a0ddab6 -> <version>-unstable-2024-05-07

Upstream doesn\'t use releases, branches, or tags, so this is the most recent commit: https://github.com/reasonml/reason-native/commit/20b1997b6451d9715dfdbeec86a9d274c7430ed8

* ocamlPackages.reason-native.cli: init at 0.0.1-alpha-unstable-2024-05-07
* ocamlPackages.reason-native.console: 2022-08-31-a0ddab6 -> 0.1.0-unstable-2024-05-07
* ocamlPackages.reason-native.dir: 2022-08-31-a0ddab6 -> 0.0.1-unstable-2024-05-07
* ocamlPackages.reason-native.file-context-printer: 2022-08-31-a0ddab6 -> 0.0.3-unstable-2024-05-07
* ocamlPackages.reason-native.fp: 2022-08-31-a0ddab6 -> 0.0.1-unstable-2024-05-07
* ocamlPackages.reason-native.frame: init at 0.0.1-unstable-2024-05-07
* ocamlPackages.reason-native.fs: init at 0.0.2-unstable-2024-05-07
* ocamlPackages.reason-native.pastel: 2022-08-31-a0ddab6 -> 0.3.0-unstable-2024-05-07
* ocamlPackages.reason-native.pastel-console: 2022-08-31-a0ddab6 -> 0.0.0-unstable-2024-05-07
* ocamlPackages.reason-native.qcheck-rely: 2022-08-31-a0ddab6 -> 1.0.2-unstable-2024-05-07
* ocamlPackages.reason-native.refmterr: 2022-08-31-a0ddab6 -> 3.3.0-unstable-2024-05-07
* ocamlPackages.reason-native.rely: 2022-08-31-a0ddab6 -> 4.0.0-unstable-2024-05-07
* ocamlPackages.reason-native.rely-junit-reporter: 2022-08-31-a0ddab6 -> 1.0.0-unstable-2024-05-07
* ocamlPackages.reason-native.unicode: init at 0.0.0-unstable-2024-05-07
* ocamlPackages.reason-native.unicode-config: init at 0.0.0-unstable-2024-05-07
* ocamlPackages.reason-native.utf8: init at 0.1.0-unstable-2024-05-07

The version numbers are taken from upstream\'s \`<package>.json\` file.

I also fixed and updated \`ocamlPackages.reason-native.console.tests\` so that it builds and no longer includes its \`default.nix\` file.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/3664857c48feacb35770c00abfdc671e55849be5...eb1ba314aff505efb42bce45f47542a517fc3c03