### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719763542,
-        "narHash": "sha256-mXkOj9sJ0f69Nkc2dGGOWtof9d1YNY8Le/Hia3RN+8Q=",
+        "lastModified": 1719824438,
+        "narHash": "sha256-pY0wosAgcr9W4vmGML0T3BVhQiGuKoozCbs2t+Je1zc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6cdd8a11b26b4d60593733106042141756b54a3",
+        "rev": "7f993cdf26ccef564eabf31fdb40d140821e12bc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6cdd8a11b26b4d60593733106042141756b54a3",
+        "rev": "7f993cdf26ccef564eabf31fdb40d140821e12bc",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e6cdd8a11b26b4d60593733106042141756b54a3";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=7f993cdf26ccef564eabf31fdb40d140821e12bc";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/7f993cdf26ccef564eabf31fdb40d140821e12bc"><pre>openssh: 9.7p1 -> 9.8p1

Fixes a critical security bug allowing remote code execution as root:
<https://www.openssh.com/txt/release-9.8>

This may be CVE-2024-6387 (currently embargoed):
<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-6387></pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e6cdd8a11b26b4d60593733106042141756b54a3...7f993cdf26ccef564eabf31fdb40d140821e12bc