### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720149507,
-        "narHash": "sha256-OFJoD1jjxzFlY1tAsehEWVA88DbU5smzDPQuu9SmnXY=",
+        "lastModified": 1720501375,
+        "narHash": "sha256-+uhyVoqSWA3+dQAeeWwovRmoD9eeqCWaAnpOuuqalNk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d9c0b9d611277e42e6db055636ba0409c59db6d2",
+        "rev": "bb1588c3045cfdc18154cb45a2f2186122cbbad8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d9c0b9d611277e42e6db055636ba0409c59db6d2",
+        "rev": "bb1588c3045cfdc18154cb45a2f2186122cbbad8",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=d9c0b9d611277e42e6db055636ba0409c59db6d2";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=bb1588c3045cfdc18154cb45a2f2186122cbbad8";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/6e140aaf3fb2d15c041d35de7a3815543f98d029"><pre>ocamlPackages.ocamlfuse: 2.7.1_cvs9 -> 2.7.1_cvs11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/67a80a7f5e5dfc4f3b5e424043c890347dc7bcfd"><pre>ocamlPackages.unisim_archisec: 0.0.5 -> 0.0.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/60f36e58fdc809c3a4edf180155feb979c5ff5a1"><pre>ocamlPackages.hidapi: 1.1.2 -> 1.2.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6190f2844ce3bdf4e321e00b04f75f59d37e40f3"><pre>ocamlPackages.ocsigen_server: 5.1.0 -> 5.1.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8ca428d9994e49d2f7bf5c3c4be32c30edafa153"><pre>ocamlPackages.kqueue: 0.3.0 -> 0.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a0010c88d4294b9932ce9970eb9d040b85df5a8b"><pre>ocamlPackages.terminal: 0.2.2 -> 0.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2aa653193fc71b70b098b0dc12419362088b3f63"><pre>ocamlPackages.macaddr: 5.5.0 -> 5.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a7cf502c5d338d0f931aafc380cc8f29eac2ae99"><pre>ocamlPackages.miou: 0.1.0 -> 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fd276f75c868c3a3e62f16c54b0d52e1d48bec66"><pre>ocamlPackages.lablgl: simplify build and fix Darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ad717476ad5167c2904beba6994a933fe4f4bea9"><pre>ocamlPackages.yojson: 2.2.1 -> 2.2.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6cbd5fdd190d4f1f64b0a6e621a16ade5d518110"><pre>ocamlPackages.ocamlbuild: 0.14.3 -> 0.15.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/13b71b25f334fbc87ee7fc271264c528c5c29796"><pre>ocamlPackages.dscheck: 0.4.0 -> 0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c1ee3e7ed5eaf98db10db0d165bb22bf2b47ee76"><pre>ocamlPackages.gitlab: init at 0.1.8

Release: https://github.com/tmcgilchrist/ocaml-gitlab/releases/tag/0.1.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b3b92bd3ea3da22c97eb0bfeee83d86b1d127f20"><pre>Merge pull request #323181 from r-ryantm/auto-update/ocamlPackages.yojson

ocamlPackages.yojson: 2.2.1 -> 2.2.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d179c0d8010ae7e8f03342b7e2a9b5d41835a7d2"><pre>Merge pull request #323393 from r-ryantm/auto-update/ocamlPackages.ocamlbuild

ocamlPackages.ocamlbuild: 0.14.3 -> 0.15.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/98293b02378bae7a47c19418fd4526d2df9f0c5c"><pre>Merge pull request #313703 from r-ryantm/auto-update/ocamlPackages.macaddr

ocamlPackages.macaddr: 5.5.0 -> 5.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/11498a2258405d344599ae4339167f2d9c3f6e66"><pre>Merge pull request #317337 from r-ryantm/auto-update/ocamlPackages.miou

ocamlPackages.miou: 0.1.0 -> 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7132c833b450c15be751cc1519a40ef3412c23d3"><pre>Merge pull request #324790 from zazedd/ocamlPackages-gitlab

ocamlPackages.gitlab: init at 0.1.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/550fb357639fdecd56d50ffb38eb82b0d232d27e"><pre>ocamlPackages.mccs: 1.1+13 -> 1.1+17</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/28a0b69be55d4c699f8089c8252a04559f2d4535"><pre>Merge pull request #305657 from r-ryantm/auto-update/ocamlPackages.ocamlfuse

ocamlPackages.ocamlfuse: 2.7.1_cvs9 -> 2.7.1_cvs11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/be44c5d411d5420b020ea4fe97b85eff20191a05"><pre>Merge pull request #305897 from r-ryantm/auto-update/ocamlPackages.unisim_archisec

ocamlPackages.unisim_archisec: 0.0.5 -> 0.0.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bb53da2db0129be493e8d33f2c93e2271c258c3f"><pre>Merge pull request #305934 from r-ryantm/auto-update/ocamlPackages.ocsigen_server

ocamlPackages.ocsigen_server: 5.1.0 -> 5.1.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/277d2c3ae8c18cce372589a464bffed3a0a62a81"><pre>Merge pull request #305941 from r-ryantm/auto-update/ocamlPackages.kqueue

ocamlPackages.kqueue: 0.3.0 -> 0.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/91f21f7f0b2d265d935f4952b3d4b4555072f138"><pre>ocamlPackages.mirage-logs: 1.3.0 -> 2.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/042fc127b85f82bed660b6b757f5573c41452dab"><pre>Merge pull request #305928 from r-ryantm/auto-update/ocamlPackages.terminal

ocamlPackages.terminal: 0.2.2 -> 0.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fbc006a7b70bee310f474aa638ecbf420a42ab79"><pre>Merge pull request #305912 from r-ryantm/auto-update/ocamlPackages.hidapi

ocamlPackages.hidapi: 1.1.2 -> 1.2.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ce632a201205f11337685a32f051c93fe7a3fee"><pre>Merge pull request #305545 from r-ryantm/auto-update/ocamlPackages.mccs

ocamlPackages.mccs: 1.1+13 -> 1.1+17</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b952554a81d842392bbfdca2ddf0164b9b0794c4"><pre>ocamlPackages.xenstore: drop cstruct dependency

Also begins fetching sources from git, instead of the release.

Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/736c4e1a81a0c2ee2959601dbd25ea51db548eaa"><pre>Merge pull request #305953 from r-ryantm/auto-update/ocamlPackages.mirage-logs

ocamlPackages.mirage-logs: 1.3.0 -> 2.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/99739994e551557138987d2a014ab2067c12965a"><pre>Merge pull request #324913 from SigmaSquadron/ocaml-xenstore

ocamlPackages.xenstore: drop cstruct dependency</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/78d3ff1007b42ef7e61bf4d2ff3a58138a857df2"><pre>Merge pull request #324705 from r-ryantm/auto-update/ocamlPackages.dscheck

ocamlPackages.dscheck: 0.4.0 -> 0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4495fc33866ebf69e9bd42f760a83be5e4a96e72"><pre>ocamlPackages.biotk: 0.2.0 → 0.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/93837d788cda788e660bc5db731bec9f6df4a6cb"><pre>ocamlPackages.merlin: 4.14-501 → 4.16-501, 5.1-502</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/d9c0b9d611277e42e6db055636ba0409c59db6d2...bb1588c3045cfdc18154cb45a2f2186122cbbad8