### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722495206,
-        "narHash": "sha256-kJ/MgnoLxuVVnGcVrnZuzZ2eUasKhD7SJG/HI8ugWVQ=",
+        "lastModified": 1722539632,
+        "narHash": "sha256-g4L+I8rDl7RQy5x8XcEMqNO49LFhrHTzVBqXtG2+FGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "43c433f2931b803dbe7853e0438ea0744ee48574",
+        "rev": "f2d6c7123138044e0c68902268bd8f37dd7e2fa7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "43c433f2931b803dbe7853e0438ea0744ee48574",
+        "rev": "f2d6c7123138044e0c68902268bd8f37dd7e2fa7",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=43c433f2931b803dbe7853e0438ea0744ee48574";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=f2d6c7123138044e0c68902268bd8f37dd7e2fa7";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/467d6e00434238ca23123e791ec477f569c1ec1c"><pre>ocamlPackages.linol: 0.5 → 0.6

Also use upstream release artifact rather that a source-code snapshot,
as per upstream suggestion.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0a04c762ffa654df9c546d1a7d618ff568411a28"><pre>Merge pull request #331337 from vbgl/ocaml-linol-0.6

ocamlPackages.linol: 0.5 → 0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f2d6c7123138044e0c68902268bd8f37dd7e2fa7"><pre>Merge pull request #331392 from SuperSandro2000/gruvbox-gtk-theme

gruvbox-gtk-theme: drop dependency on gnome-shell, mutter and many more</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/43c433f2931b803dbe7853e0438ea0744ee48574...f2d6c7123138044e0c68902268bd8f37dd7e2fa7