### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727061148,
-        "narHash": "sha256-EzxYQ3p2pMCF+BbpI8gRb1IMJ93HpTOAryXJ5luL8sc=",
+        "lastModified": 1727104955,
+        "narHash": "sha256-m6kgjR4zAwyMe1Pn4RGXLCzArtoBp1qzhb2AUlPeVh4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2c10d90570266d558ec233b4cd472076d06676c",
+        "rev": "d266adc5a77ec8c10ed941c7251b2673004dbd62",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2c10d90570266d558ec233b4cd472076d06676c",
+        "rev": "d266adc5a77ec8c10ed941c7251b2673004dbd62",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e2c10d90570266d558ec233b4cd472076d06676c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=d266adc5a77ec8c10ed941c7251b2673004dbd62";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/5e6bd6eb1d3e3075942f3a0973245a821c98b2bb"><pre>ocamlPackages.angstrom: 0.16.0 → 0.16.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fa12063f122652e90bb617ce3c84d4762e342152"><pre>ocamlPackages.ocamlbuild: use version 0.14.3 with OCaml 4.07</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/94d0d228173faff39670bc1157ddba8e56012a8d"><pre>ocamlPackages.elpi: use release tarball (#343266)

coqPackages.metaFetch: Adding a github artifact option

Co-authored-by: Cyril Cohen <cohen@crans.org></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d266adc5a77ec8c10ed941c7251b2673004dbd62"><pre>crowdin-cli: 4.1.2 -> 4.2.0 (#343957)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d266adc5a77ec8c10ed941c7251b2673004dbd62"><pre>crowdin-cli: 4.1.2 -> 4.2.0 (#343957)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d266adc5a77ec8c10ed941c7251b2673004dbd62"><pre>crowdin-cli: 4.1.2 -> 4.2.0 (#343957)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e2c10d90570266d558ec233b4cd472076d06676c...d266adc5a77ec8c10ed941c7251b2673004dbd62