### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729450260,
-        "narHash": "sha256-3GNZr0V4b19RZ5mlyiY/4F8N2pzitvjDU6aHMWjAqLI=",
+        "lastModified": 1729674553,
+        "narHash": "sha256-avsQc594jov0sLa64mhuEbBTZY+cUuNTnLudrt/0JQo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3f55158e7587c5a5fdb0e86eb7ca4f455f0928f",
+        "rev": "c0915172d935f94d92abd5e0d048903446e22c42",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3f55158e7587c5a5fdb0e86eb7ca4f455f0928f",
+        "rev": "c0915172d935f94d92abd5e0d048903446e22c42",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e3f55158e7587c5a5fdb0e86eb7ca4f455f0928f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c0915172d935f94d92abd5e0d048903446e22c42";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/3fb71380330bcb254b16ac394c111a0f15b5a73d"><pre>ocamlPackages.cohttp_async_websocket: add missing dependency</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/33546d99d4db50d1656f2e98f9dad40a25f0a302"><pre>ocamlPackages.ohex: init at 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ea573ca476915e0ccefb99be5687e4150fa049b"><pre>ocamlPackages.mirage-crypto: 0.11.3 → 1.1.0

ocamlPackages.asn1-combinators: 0.2.6 → 0.3.1
ocamlPackages.awa: 0.3.1 → 0.4.0
ocamlPackages.ca-certs: 0.2.3 → 1.0.0
ocamlPackages.ca-certs-nss: 3.101 → 3.103
ocamlPackages.conduit: 6.2.3 → 7.0.0
ocamlPackages.dns: 8.0.0 → 9.0.0
ocamlPackages.erm_xmpp: 0.3+20220404 → 0.3+20241009
ocamlPackages.git: 3.16.1 → 3.17.0
ocamlPackages.hkdf: 1.0.4 → 2.0.0
ocamlPackages.http-mirage-client: 0.0.6 → 0.0.7
ocamlPackages.letsencrypt: 0.5.1 → 1.0.0
ocamlPackages.paf: 0.6.0 → 0.7.0
ocamlPackages.pbkdf: 1.2.0 → 2.0.0
ocamlPackages.randomconv: 0.1.3 → 0.2.0
ocamlPackages.tcpip: 8.1.0 → 8.2.0
ocamlPackages.tls: 0.17.5 → 1.0.1
ocamlPackages.x509: 0.16.5 → 1.0.2

ocamlPackages.mrmime: disable tests

ocamlPackages.chacha: mark as broken
ocamlPackages.opium: mark as broken
ocamlPackages.otr: mark as broken
ocamlPackages.riot: mark as broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/012e588480eb0bf9ac51991afda957a1a8bfbf27"><pre>guestfs-tools: fix build

OCaml was unpinned in #349339, but gettext is only available for OCaml < 5.0.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e3f55158e7587c5a5fdb0e86eb7ca4f455f0928f...c0915172d935f94d92abd5e0d048903446e22c42