### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729493358,
-        "narHash": "sha256-Ti+Y9nWt5Fcs3JlarxLPgIOVlbqQo7jobz/qOwOaziM=",
+        "lastModified": 1729939720,
+        "narHash": "sha256-F7jTiYAxLF0Hcv92Xa5dIufzH1plmS9nbwO50j/9Kxw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5e6a9e979367ee14f65d9c38119c30272f8455f",
+        "rev": "c93e398e719021a9ad9da56af1589d23029f3cea",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5e6a9e979367ee14f65d9c38119c30272f8455f",
+        "rev": "c93e398e719021a9ad9da56af1589d23029f3cea",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=a5e6a9e979367ee14f65d9c38119c30272f8455f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c93e398e719021a9ad9da56af1589d23029f3cea";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/012e588480eb0bf9ac51991afda957a1a8bfbf27"><pre>guestfs-tools: fix build

OCaml was unpinned in #349339, but gettext is only available for OCaml < 5.0.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/a5e6a9e979367ee14f65d9c38119c30272f8455f...c93e398e719021a9ad9da56af1589d23029f3cea