### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730858696,
-        "narHash": "sha256-us4xhqqW6OkjCihXYuFArhwx91cTzns8FEY8lE4v7JQ=",
+        "lastModified": 1730945957,
+        "narHash": "sha256-fhkxOv9RGEoPZNyl7VOpHf0Xoqc+bu0J/uW3BSg7tOs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8541b4db5adb9dd835ed5d0023dec229987b7391",
+        "rev": "0093b93ec307d42f51ced7ce90dda6c37516e98a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8541b4db5adb9dd835ed5d0023dec229987b7391",
+        "rev": "0093b93ec307d42f51ced7ce90dda6c37516e98a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=8541b4db5adb9dd835ed5d0023dec229987b7391";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=0093b93ec307d42f51ced7ce90dda6c37516e98a";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/54313e993e22b302539582f992aff63be5049a06"><pre>ocamlPackages.theora: 0.4.0 -> 0.4.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4935b06f4f8bb490ab2dfe4f280eab25164894f1"><pre>ocamlPackages.mm: 0.8.5 -> 0.8.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4becb3821e08d02388045f40044c0fefa36cdec5"><pre>ocaml: build defaultentry not bootstrap on 5.2+

Building ocaml fails occasionally on aarch64-darwin. Using the
defaultentry target to build on ocaml 5.2 and greater may rectify this.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3268610346c449150b36ea156edabcaaa6ff7f06"><pre>ocamlPackages.theora: 0.4.0 -> 0.4.1 (#352261)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a2d1cc18395f6037e67a53bc2e099dfdfc5178f5"><pre>ocamlPackages.mm: 0.8.5 -> 0.8.6 (#352264)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0093b93ec307d42f51ced7ce90dda6c37516e98a"><pre>lemurs: fix build error caused by rust-lang/rust/issues/115010 (#353820)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0093b93ec307d42f51ced7ce90dda6c37516e98a"><pre>lemurs: fix build error caused by rust-lang/rust/issues/115010 (#353820)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0093b93ec307d42f51ced7ce90dda6c37516e98a"><pre>lemurs: fix build error caused by rust-lang/rust/issues/115010 (#353820)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/8541b4db5adb9dd835ed5d0023dec229987b7391...0093b93ec307d42f51ced7ce90dda6c37516e98a