### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732007104,
-        "narHash": "sha256-qaWPxgLAvtIHTDcm0qJuc+WNYjcy4ZKigOyn2ag4ihM=",
+        "lastModified": 1732093569,
+        "narHash": "sha256-izJY2l1fZou1aS2oVtMH998OHgR1OIBizz8uh4NvA8g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0705964c881cea8896474610188905ba41b59b08",
+        "rev": "bf2dfaa7c788045039aeb544d36015601126b848",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0705964c881cea8896474610188905ba41b59b08",
+        "rev": "bf2dfaa7c788045039aeb544d36015601126b848",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=0705964c881cea8896474610188905ba41b59b08";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=bf2dfaa7c788045039aeb544d36015601126b848";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1311,6 +1311,7 @@ with oself;
       hash = "sha256-N0rtBuxoHg45BqTf+aR8f6SfCEtiFVAspDgWfSkjH6w=";
       fetchSubmodules = true;
     };
+    patches = [ ];
     doCheck = false;
   });
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/8330c77eab5d8aa4cc286e50e80db37febe463fa"><pre>ocamlPackages.luv: backport patch; fix clang build

clang build fails with an incompatible pointer type error. Backport a
patch from 0.5.14 which fixes this. Can not just update to 0.5.14 as it
contains breaking changes and breaks most of luv\'s consumers.

https://github.com/aantron/luv/commit/ad7f953fccb8732fe4eb9018556e8d4f82abf8f2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3c6b18fcb0d560f1a609ee886389157c63aef44c"><pre>ocamlPackages.luv: fix clang build (#356635)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bf2dfaa7c788045039aeb544d36015601126b848"><pre>mission-center: use RUSTFLAGS to link libGL and libvulkan; adopt (#357219)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bf2dfaa7c788045039aeb544d36015601126b848"><pre>mission-center: use RUSTFLAGS to link libGL and libvulkan; adopt (#357219)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/0705964c881cea8896474610188905ba41b59b08...bf2dfaa7c788045039aeb544d36015601126b848