### PR TITLE
Remove unnecessary dependencies (flake-utils)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1732674886,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     let
       overlay = import ./overlay nixpkgs;
     in
-    rec {
+    {
       lib = nixpkgs.lib;
 
       hydraJobs = nixpkgs.lib.genAttrs

--- a/flake.nix
+++ b/flake.nix
@@ -8,50 +8,46 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=a622540b81692a9ae427e4e9c84b60c1ad2513d8";
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs }:
     let
       overlay = import ./overlay nixpkgs;
     in
-    nixpkgs.lib.recursiveUpdate
-      {
-        lib = nixpkgs.lib;
+    rec {
+      lib = nixpkgs.lib;
 
-        hydraJobs = builtins.listToAttrs (map
-          (system: {
-            name = system;
-            value = import ./ci/hydra.nix {
-              inherit system;
-              pkgs = self.legacyPackages.${system};
+      hydraJobs = nixpkgs.lib.genAttrs
+        [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ]
+        (system: import ./ci/hydra.nix {
+          inherit system;
+          pkgs = self.legacyPackages.${system};
+        });
+
+      makePkgs = { system, extraOverlays ? [ ], ... }@attrs:
+        let
+          pkgs = import nixpkgs ({
+            inherit system;
+            overlays = [ overlay ];
+            config = {
+              allowUnfree = true;
+            } // nixpkgs.lib.optionalAttrs (system == "x86_64-darwin") {
+              config.replaceStdenv = { pkgs, ... }: pkgs.clang11Stdenv;
             };
-          })
-          [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ]);
-
-        makePkgs = { system, extraOverlays ? [ ], ... }@attrs:
-          let
-            pkgs = import nixpkgs ({
-              inherit system;
-              overlays = [ overlay ];
-              config = {
-                allowUnfree = true;
-              } // nixpkgs.lib.optionalAttrs (system == "x86_64-darwin") {
-                config.replaceStdenv = { pkgs, ... }: pkgs.clang11Stdenv;
-              };
-            } // attrs);
-          in
-            /*
+          } // attrs);
+        in
+          /*
             You might read
             https://nixos.org/manual/nixpkgs/stable/#sec-overlays-argument and
             want to change this but because of how we're doing overlays we will
             be overriding any extraOverlays if we don't use `appendOverlays`
             */
-          pkgs.appendOverlays extraOverlays;
+        pkgs.appendOverlays extraOverlays;
 
-        overlays.default = final: prev: overlay final prev;
-      }
-      (flake-utils.lib.eachDefaultSystem (system: {
-        legacyPackages = self.makePkgs { inherit system; };
-      }));
+      overlays.default = final: prev: overlay final prev;
+
+      legacyPackages = nixpkgs.lib.genAttrs
+        nixpkgs.lib.systems.flakeExposed
+        (system: self.makePkgs { inherit system; });
+    };
 }


### PR DESCRIPTION
This project/overlay was using both `flake-utils` ~~& `nix-filter`~~. The former is obsoleted (in this context) by `lib.genAttrs […]` ~~& the latter by `lib.fileset`~~. Where `flake-utils` makes sense is only in the context of distributing a flake for users while not having `nixpkgs` & its `lib` as a dependency—but since `nixpkgs` is dependency & is coming from the flake input in this project/overlay, there is no need to depend on `flake-utils`.

As this project is used by downstream projects, it is important to keep the flake inputs to the bare minimum since all inputs will become dependencies in those downstream projects (where all dependencies require maintenance & auditing). It is also virtuous to set a good example for those projects since a lot of those users will be primarily OCaml developers, not Nix developers & therefore using Nix as primarily a tool for a job while looking to upstream for best practices.

Not only does this eliminate dependencies, but the diff shows ~~-69~~ **-38** lines of code changed… & less code means less to maintain.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.