### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732446744,
-        "narHash": "sha256-yXqgr+GiC/RBr8n/6Bn9eRagitXbKXNcoSaZUCovuwI=",
+        "lastModified": 1732573178,
+        "narHash": "sha256-jgU18D74sbjOCn0MTL33kXQh9HXtaD+diuB/dsw911U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2570b87e71ea16daadf0a93f1eae2d3ad4478a94",
+        "rev": "8586e0559fc8687f06a63b454f156e1738f9e2b2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2570b87e71ea16daadf0a93f1eae2d3ad4478a94",
+        "rev": "8586e0559fc8687f06a63b454f156e1738f9e2b2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=2570b87e71ea16daadf0a93f1eae2d3ad4478a94";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=8586e0559fc8687f06a63b454f156e1738f9e2b2";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/32a6049ad5fc6d418a1b193310078b3ab25993de"><pre>ocamlPackages.menhir: support --suggest-menhirLib

menhir provides a \`--suggest-menhirLib\` option that tries to infer the
path of the menhir library from the path of the menhir binary.

Since the menhir library and the menhir binary are built as different
derivations, this does not work.

This patch hardcodes the location of the menhir library into the menhir
binary, making \`--suggest-menhirLib\` work.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aa33fe730061ad31db9319bb5efb0ae51368d8b2"><pre>ocamlPackages.ssl: fix darwin sandbox build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/65b37917edec8a01cd3d1503380be2fd6dca6d6c"><pre>ocamlPackages.domain-local-await: fix darwin sandbox build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/10c475aeb9d30451786d9d4319b4861dce7febca"><pre>ocamlPackages: add __darwinAllowLocalNetworking to fix sandbox builds (#358360)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4633a7c72337ea8fd23a4f2ba3972865e3ec685d"><pre>ocamlPackages.menhir: support --suggest-menhirLib (#358146)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/af64a865e434a266032beabaaa1e00222cc16d8e"><pre>ocamlPackages.eio: 1.1 → 1.2</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/2570b87e71ea16daadf0a93f1eae2d3ad4478a94...8586e0559fc8687f06a63b454f156e1738f9e2b2