### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732446744,
-        "narHash": "sha256-yXqgr+GiC/RBr8n/6Bn9eRagitXbKXNcoSaZUCovuwI=",
+        "lastModified": 1732632041,
+        "narHash": "sha256-3nnq3M2rsGu9doFG9pj2kFKgVv8S19kd68EQkwuCwSI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2570b87e71ea16daadf0a93f1eae2d3ad4478a94",
+        "rev": "bd4d2031f34254e597eaee1ad618749acb33ad86",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2570b87e71ea16daadf0a93f1eae2d3ad4478a94",
+        "rev": "bd4d2031f34254e597eaee1ad618749acb33ad86",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=2570b87e71ea16daadf0a93f1eae2d3ad4478a94";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=bd4d2031f34254e597eaee1ad618749acb33ad86";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -865,13 +865,6 @@ with oself;
       '';
     });
 
-  eio = osuper.eio.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = "https://github.com/ocaml-multicore/eio/releases/download/v1.2/eio-1.2.tbz";
-      sha256 = "0h5wssgslv4nnbqw3whcjyqi5lp44lc0hwwgwfr4njcdpl9fk4ip";
-    };
-  });
-
   eio-ssl =
     if lib.versionAtLeast ocaml.version "5.0" then
       callPackage ./eio-ssl { }
@@ -926,15 +919,6 @@ with oself;
       o.propagatedBuildInputs ++
       lib.optionals stdenv.isDarwin
         (with darwin.apple_sdk.frameworks; [ AVFoundation ]);
-  });
-
-  findlib = osuper.findlib.overrideAttrs (_: {
-    src = fetchFromGitHub {
-      owner = "ocaml";
-      repo = "ocamlfind";
-      rev = "findlib-1.9.8";
-      hash = "sha256-cc78SiIlGQFu2EJ1EDuIEnk6zmNbY+yzsYLyOhzvFag=";
-    };
   });
 
   fix = osuper.fix.overrideAttrs (_: {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/32a6049ad5fc6d418a1b193310078b3ab25993de"><pre>ocamlPackages.menhir: support --suggest-menhirLib

menhir provides a \`--suggest-menhirLib\` option that tries to infer the
path of the menhir library from the path of the menhir binary.

Since the menhir library and the menhir binary are built as different
derivations, this does not work.

This patch hardcodes the location of the menhir library into the menhir
binary, making \`--suggest-menhirLib\` work.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aa33fe730061ad31db9319bb5efb0ae51368d8b2"><pre>ocamlPackages.ssl: fix darwin sandbox build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/65b37917edec8a01cd3d1503380be2fd6dca6d6c"><pre>ocamlPackages.domain-local-await: fix darwin sandbox build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/10c475aeb9d30451786d9d4319b4861dce7febca"><pre>ocamlPackages: add __darwinAllowLocalNetworking to fix sandbox builds (#358360)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4633a7c72337ea8fd23a4f2ba3972865e3ec685d"><pre>ocamlPackages.menhir: support --suggest-menhirLib (#358146)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/af64a865e434a266032beabaaa1e00222cc16d8e"><pre>ocamlPackages.eio: 1.1 → 1.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3d20b485d9acfe4290c0296f0d75d7d8d2c2520a"><pre>ocamlPackages.findlib: 1.9.7 → 1.9.8</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/2570b87e71ea16daadf0a93f1eae2d3ad4478a94...bd4d2031f34254e597eaee1ad618749acb33ad86