### PR TITLE
add systemd

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -147,6 +147,7 @@ let
     "pam"
     "netsnmp"
     "ocaml-probes"
+    "systemd"
 
     "gapi-ocaml"
     "bz2"

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -30,6 +30,7 @@
 , nodejs_latest
 , pcre-oc
 , sqlite-oc
+, systemdLibs
 , makeWrapper
 , darwin
 , stdenv
@@ -2519,6 +2520,19 @@ with oself;
       sha256 = "1i43yqg0i304vpiy3sf6kvjpapkdm6spkf83mj9ql1d4f7jg6c58";
     };
     propagatedBuildInputs = [ xmlm uri ptime ];
+  };
+
+  systemd = buildDunePackage {
+    pname = "systemd";
+    version = "1.3";
+    src = fetchFromGitHub {
+      owner = "juergenhoetzel";
+      repo = "ocaml-systemd";
+      rev = "v1.3";
+      hash = "sha256-/FV+mFhuB3mEZv34XZrA4gO6+QIYssXqurnvkNBTJ2o=";
+    };
+    minimalOCamlVersion = "4.06";
+    propagatedBuildInputs = [ systemdLibs ];
   };
 
   taglib = osuper.taglib.overrideAttrs (o: {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2528,7 +2528,7 @@ with oself;
     src = fetchFromGitHub {
       owner = "juergenhoetzel";
       repo = "ocaml-systemd";
-      rev = "v1.3";
+      rev = "1.3";
       hash = "sha256-/FV+mFhuB3mEZv34XZrA4gO6+QIYssXqurnvkNBTJ2o=";
     };
     minimalOCamlVersion = "4.06";

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2533,6 +2533,7 @@ with oself;
     };
     minimalOCamlVersion = "4.06";
     propagatedBuildInputs = [ systemdLibs ];
+    meta.platform = lib.platforms.linux;
   };
 
   taglib = osuper.taglib.overrideAttrs (o: {


### PR DESCRIPTION
This PR adds the `systemd` library, which provides `Daemon` and `Journald` modules intended for writing fuller systemd services with features such as socket activation and proper journaling. 