### PR TITLE
Make overlay idempotent

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
             */
         pkgs.appendOverlays extraOverlays;
 
-      overlays.default = final: prev: if (prev ? ocaml-overlay-present) then { } else overlay final prev;
+      overlays.default = final: prev: if (prev ? __nix-ocaml-overlays-applied) then { } else overlay final prev;
 
       legacyPackages = nixpkgs.lib.genAttrs
         nixpkgs.lib.systems.flakeExposed

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
             */
         pkgs.appendOverlays extraOverlays;
 
-      overlays.default = final: prev: overlay final prev;
+      overlays.default = final: prev: if (prev ? ocaml-overlay-present) then {} else overlay final prev;
 
       legacyPackages = nixpkgs.lib.genAttrs
         nixpkgs.lib.systems.flakeExposed

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
             */
         pkgs.appendOverlays extraOverlays;
 
-      overlays.default = final: prev: if (prev ? ocaml-overlay-present) then {} else overlay final prev;
+      overlays.default = final: prev: if (prev ? ocaml-overlay-present) then { } else overlay final prev;
 
       legacyPackages = nixpkgs.lib.genAttrs
         nixpkgs.lib.systems.flakeExposed

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -40,7 +40,7 @@ in
   ];
 }) // {
   # Place a canary
-  ocaml-overlay-present = 1;
+  __nix-ocaml-overlays-applied = 1;
 
   # Cross-compilation / static overlays
   pkgsMusl = staticLightExtend super.pkgsMusl;

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -39,6 +39,9 @@ in
     })
   ];
 }) // {
+  # Place a canary
+  ocaml-overlay-present = 1;
+
   # Cross-compilation / static overlays
   pkgsMusl = staticLightExtend super.pkgsMusl;
   pkgsStatic = staticLightExtend super.pkgsStatic;


### PR DESCRIPTION
This solves a problem where the overlay can be applied twice if two nixosModules which use the overlay are both used in one system configuration.