### PR TITLE
auto update: skip adding a reviewer/assignee

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -49,6 +49,4 @@ jobs:
           source_branch: auto-update-sources-${{ github.run_id }}
           pr_title: "Update sources"
           pr_body: ":robot_face: Updating sources to the latest version.\n${{steps.update-sources.outputs.result}}"
-          pr_reviewer: "anmonteiro,ulrikstrid"
-          pr_assignee: "anmonteiro,ulrikstrid"
           github_token: ${{ secrets.GH_PAT_ANMONTEIRO }}


### PR DESCRIPTION
i used my PAT and github was complaining i couldn't add myself as a reviewer