### PR TITLE
Fix building ocamlPackages_flambda2

### DIFF
--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -179,6 +179,7 @@ let
                 super.autoconf
                 super.libtool
                 super.rsync
+                super.which
               ];
             buildInputs = o.buildInputs ++ (with ocaml14Scope; [ menhirLib ]);
           };

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -156,6 +156,9 @@ let
               substituteInPlace "tools/merge_dot_a_files.sh" --replace-fail \
               'exec libtool -static -o $target $archives' \
               'exec ar cr "$target" $archives && exec ranlib "$target"'
+              substituteInPlace Makefile ocaml/Makefile.jst --replace-fail \
+              "SHELL = /usr/bin/env bash" \
+              "SHELL = ${super.bash}/bin/bash"
               cd ocaml && autoconf && cd ..
               autoconf
             '';


### PR DESCRIPTION
I had trouble building flambda2, the Makefile was referencing `/usr/bin/env bash` substituting it with nix store path fixed it. 