### PR TITLE
Update Dune 3.17.1

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -766,7 +766,7 @@ with oself;
     version = "3.17.0";
     src = builtins.fetchurl {
       url = "https://github.com/ocaml/dune/releases/download/3.17.1/dune-3.17.1.tbz";
-      sha256 = "6b9ee5ed051379a69ca45173ac6c5deb56b44a1c16e30b7c371343303d835ac6";
+      sha256 = "1ijshcyk0hqk6xy0pqqn3i5b8mpbbmnaqwsiljfacy8k0pnyb7kb";
     };
     nativeBuildInputs = o.nativeBuildInputs ++ [ makeWrapper ];
     postFixup =

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -765,8 +765,8 @@ with oself;
   dune_3 = osuper.dune_3.overrideAttrs (o: {
     version = "3.17.0";
     src = builtins.fetchurl {
-      url = "https://github.com/ocaml/dune/releases/download/3.17.0/dune-3.17.0.tbz";
-      sha256 = "0z2h2v4fk75579km3z0shh807n3bh3s7ab9939n3v7nk3v2acfic";
+      url = "https://github.com/ocaml/dune/releases/download/3.17.1/dune-3.17.1.tbz";
+      sha256 = "6b9ee5ed051379a69ca45173ac6c5deb56b44a1c16e30b7c371343303d835ac6";
     };
     nativeBuildInputs = o.nativeBuildInputs ++ [ makeWrapper ];
     postFixup =


### PR DESCRIPTION
This PR updates the dune version to `3.17.1`. I have computed the sha using `sha256sum` as it is my first time with Nix, does it work, or should I do it another way?
