### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736019633,
-        "narHash": "sha256-Mi8oC22DXsgX/Tdwb8mbXrxaG7wdZXP9d3TqCtWvmGI=",
+        "lastModified": 1736077418,
+        "narHash": "sha256-2LwAcQXlLkqWyibkYGiS1SfXsewxRuhpYtzrMQSYElc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14c58c5918427906794936529c88a00b0d0e483f",
+        "rev": "e554bf17658bd1bfe393dcaca8b8eee6014ddfa1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14c58c5918427906794936529c88a00b0d0e483f",
+        "rev": "e554bf17658bd1bfe393dcaca8b8eee6014ddfa1",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=14c58c5918427906794936529c88a00b0d0e483f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=e554bf17658bd1bfe393dcaca8b8eee6014ddfa1";
   };
 
   outputs = { self, nixpkgs }:

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1835,15 +1835,6 @@ with oself;
     };
   });
 
-  ocaml-version = osuper.ocaml-version.overrideAttrs (_: {
-    src = fetchFromGitHub {
-      owner = "ocurrent";
-      repo = "ocaml-version";
-      rev = "v3.7.2";
-      hash = "sha256-eEw7MBuT2cfJ5+FTebssJIJEH0pFRq9VmREJzJwiUWw=";
-    };
-  });
-
   ocp-indent = osuper.ocp-indent.overrideAttrs (o: {
     postPatch = ''
       substituteInPlace src/dune --replace-fail "libraries bytes" "libraries "
@@ -1855,8 +1846,8 @@ with oself;
     src = fetchFromGitHub {
       owner = "OCamlPro";
       repo = "ocp-index";
-      rev = "77cd8eb2ae1ee142ae1344dc9892c49ca4dd7631";
-      hash = "sha256-jIizvs2hCWTOdH1mGHO22VQiRHIPlxy0mNU40Va2r1g=";
+      rev = "1.3.7";
+      hash = "sha256-FbkVJRbFNSho/E59QMUoGK+TrdnnacmykJWWG2JVDVA=";
     };
   });
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/39c3f09f30db0c65828df02e3012568286ca48c0"><pre>ocamlPackages.reason: 3.13.0 -> 3.14.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/34e13b3ace62cd2c2d1986ec1270a9f804bc9559"><pre>ocamlPackages.lacaml: 11.1.0 -> 11.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f68400f3daf459304d0af6ed62641cb3e1e3207e"><pre>ocamlPackages.higlo: 0.9 -> 0.10.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3cdfa269d2d685f93dc1e9836fe1b2996880dfc9"><pre>ocamlPackages.ocaml-version: 3.6.9 -> 3.7.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d6d1d5d88b6e06b6fee9763fe3fe719c81ae0ed5"><pre>ocamlPackages.ocaml-version: 3.6.9 -> 3.7.2 (#369030)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/27e409196f12cccc72eb56d10fc4b310c22a7043"><pre>ocamlPackages.lacaml: 11.1.0 -> 11.1.1 (#364846)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/be95b44977debcede53d39d206dee50fa1da61c5"><pre>ocamlPackages.higlo: 0.9 -> 0.10.0 (#366802)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4a0ad9480aebb4bb238482431996553a0f2d3bc7"><pre>ocamlPackages.reason: 3.13.0 -> 3.14.0 (#360833)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e554bf17658bd1bfe393dcaca8b8eee6014ddfa1"><pre>Revert \"unbound: pull changes to master\" (#371103)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e554bf17658bd1bfe393dcaca8b8eee6014ddfa1"><pre>Revert \"unbound: pull changes to master\" (#371103)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e554bf17658bd1bfe393dcaca8b8eee6014ddfa1"><pre>Revert \"unbound: pull changes to master\" (#371103)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e554bf17658bd1bfe393dcaca8b8eee6014ddfa1"><pre>Revert \"unbound: pull changes to master\" (#371103)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/14c58c5918427906794936529c88a00b0d0e483f...e554bf17658bd1bfe393dcaca8b8eee6014ddfa1