### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736429638,
-        "narHash": "sha256-dDWqQqSgMQXw5eFtcyoVijv7HbYJZOIo+jWQdJtsxn4=",
+        "lastModified": 1736560554,
+        "narHash": "sha256-+JU6o3GAOWtFfmbf1yfHI7Tu8E+sn8Uo6/0argLzsB4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f81eabd5dd7c9213516fa2d3fc1d108a751340d4",
+        "rev": "cef47c71b16e96b15ef2ee88be39d030f1961437",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f81eabd5dd7c9213516fa2d3fc1d108a751340d4",
+        "rev": "cef47c71b16e96b15ef2ee88be39d030f1961437",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=f81eabd5dd7c9213516fa2d3fc1d108a751340d4";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=cef47c71b16e96b15ef2ee88be39d030f1961437";
   };
 
   outputs = { self, nixpkgs }:

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -97,13 +97,13 @@ let
       ocamlPackages_5_3 = newOCamlScope {
         major_version = "5";
         minor_version = "3";
-        patch_version = "0~beta2";
+        patch_version = "0";
         hardeningDisable = [ "strictoverflow" ];
         src = super.fetchFromGitHub {
           owner = "ocaml";
           repo = "ocaml";
-          rev = "5.3.0-rc1";
-          hash = "sha256-cin+1NvDvGXc+no0iRAh4tWU1i6/Y+NH3C/kmrvaXr0=";
+          rev = "5.3.0";
+          hash = "sha256-OxvfM0OF1XjtAMgAd+4Lm67iMKV7PD1sFmGPYn/yUBY=";
         };
       };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/7b32c640f8fdb79afa4db5f499e980b9ac4b33b0"><pre>ocamlPackages.merlin: fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7b06fb24664256ef2b8c913186355a458d4f9b6d"><pre>ocamlPackages_5_3.ocaml: init at 5.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/71195d12657f2c7f70a690175d7f4a34a77f3f7a"><pre>ocamlPackages.mlx: fix build with OCaml 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/594dd76c494e2ea49e3bd7c9e7486a2db365a48b"><pre>ocamlPackages.systemd: init at 1.3 (#372037)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5a51e70e7545cc72816eb01c4f840459160cd316"><pre>opam: fix opam sandboxing on nixos, cleanup

To make opam sandboxing (via bwrap) work on nixos, the following had been used
here:
  --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/
However, OPAM_USER_PATH_RO has been removed in opam 2.2.0, requiring a
new workaround: https://github.com/ocaml/opam/commit/9b6370d6fef68750f41435261ee2965c49e8806a
(Before this commit, executing \`opam init\` would display that sandboxing fails
with \"bwrap: execvp sh: No such file or directory\".)

- Removes outdated workarounds for ocp-build and argv0, cleans postInstall
- Fixes link to the changelog which was broken because of \"with lib;\"</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/667604e1d2bd606f64e6a264adcb767c9c39b5bf"><pre>ocamlPackages_5_3.ocaml: init at 5.3.0 (#372267)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f1f939c402f769f6fd249a6d67a86f2a5a156a10"><pre>ocamlPackages.mlx: fix build with OCaml 5.3 (#372481)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/052d9ba9ee8f404529d604adbfe2a13d1c59af90"><pre>ocamlPackages.merlin: fix build (#371361)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c1a6549febc3c3052931e167e56cd5aaf0d43ab7"><pre>ocamlPackages.lo: fix build with liblo 0.32</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/61b77b92ab78c6c4eed66823ef619a1cbe0337c4"><pre>ocamlPackages.lo: fix build with liblo 0.32 (#371656)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cef47c71b16e96b15ef2ee88be39d030f1961437"><pre>sudachi-rs: 0.6.9 -> 0.6.10 (#372682)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cef47c71b16e96b15ef2ee88be39d030f1961437"><pre>sudachi-rs: 0.6.9 -> 0.6.10 (#372682)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cef47c71b16e96b15ef2ee88be39d030f1961437"><pre>sudachi-rs: 0.6.9 -> 0.6.10 (#372682)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cef47c71b16e96b15ef2ee88be39d030f1961437"><pre>sudachi-rs: 0.6.9 -> 0.6.10 (#372682)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/f81eabd5dd7c9213516fa2d3fc1d108a751340d4...cef47c71b16e96b15ef2ee88be39d030f1961437