### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737083351,
-        "narHash": "sha256-hCddtSuk6m6XROmdOC0te0j2sLeUr28QIzNRk0qF1as=",
+        "lastModified": 1737274611,
+        "narHash": "sha256-tmD7875tu1P0UvhI3Q/fXvIe8neJo7H9ZrPQ+QF7Q3E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0993fc268872148cebcd1fac8660a8b8ced49542",
+        "rev": "50165c4f7eb48ce82bd063e1fb8047a0f515f8ce",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0993fc268872148cebcd1fac8660a8b8ced49542",
+        "rev": "50165c4f7eb48ce82bd063e1fb8047a0f515f8ce",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=0993fc268872148cebcd1fac8660a8b8ced49542";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=50165c4f7eb48ce82bd063e1fb8047a0f515f8ce";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/ab255a671aa6b5d390e37425fc3ed6f93564b71d"><pre>coqPackages.coq-elpi: enable to override ocamlPackages.elpi version</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b1d65bff40e3d3fa62a836f4cba2a08365a78d44"><pre>Add missing mlPlugin

They now seem necessary with Coq master (future Rocq 9.0),
maybe linked to the now mandatory use of ocamlfind to load plugins.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/0993fc268872148cebcd1fac8660a8b8ced49542...50165c4f7eb48ce82bd063e1fb8047a0f515f8ce