### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737873842,
-        "narHash": "sha256-3SAvSPxkeOgECitk8fImL0gz+xa2m1I4mmwam6mymOM=",
+        "lastModified": 1737917096,
+        "narHash": "sha256-wOo5jWu88VRbm0TTNl9KxE4nIkfnXVKxLvZwpTn75wk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42143ec28c329664fd1337579067c156230beaf7",
+        "rev": "a47cb26bbe26d63321cbb96de6d1981d790d9748",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42143ec28c329664fd1337579067c156230beaf7",
+        "rev": "a47cb26bbe26d63321cbb96de6d1981d790d9748",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=42143ec28c329664fd1337579067c156230beaf7";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=a47cb26bbe26d63321cbb96de6d1981d790d9748";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/b4d50c6208e3b4d2dfaf3883fe17fb99790915e2"><pre>ocamlPackages.mccs: 1.1+18 -> 1.1+19</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d5cf0d2fd4373b5ab862d03faf26b5e97c178a76"><pre>ocamlPackages.mccs: 1.1+18 -> 1.1+19 (#372379)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a47cb26bbe26d63321cbb96de6d1981d790d9748"><pre>matrix-hookshot: useFetchCargoVendor

Cargo 1.84.0 seems to have changed the output format of cargo vendor
again, once again invalidating fetchCargoTarball FOD hashes.  It\'s
time to fix this once and for all, switching across the board to
fetchCargoVendor, which is not dependent on cargo vendor\'s output
format.</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/42143ec28c329664fd1337579067c156230beaf7...a47cb26bbe26d63321cbb96de6d1981d790d9748