### PR TITLE
chore: bump dune version to 3.17.2

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -732,10 +732,10 @@ with oself;
   dune_2 = dune_3;
 
   dune_3 = osuper.dune_3.overrideAttrs (o: {
-    version = "3.17.0";
+    version = "3.17.2";
     src = builtins.fetchurl {
-      url = "https://github.com/ocaml/dune/releases/download/3.17.1/dune-3.17.1.tbz";
-      sha256 = "1ijshcyk0hqk6xy0pqqn3i5b8mpbbmnaqwsiljfacy8k0pnyb7kb";
+      url = "https://github.com/ocaml/dune/releases/download/3.17.2/dune-3.17.2.tbz";
+      sha256 = "0r7al83jwkdfk6qvb53vrlzzfr08gwcydn1ccigfdsfg1vnzxslx";
     };
     nativeBuildInputs = o.nativeBuildInputs ++ [ makeWrapper ];
     postFixup =


### PR DESCRIPTION
This PR updates the version of Dune with the newly release version. This time I used ` nix-prefetch-url --type sha256 https://github.com/ocaml/dune/releases/download/3.17.2/dune-3.17.2.tbz` to generate the hash, as suggested in the previous PR :+1:
