### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738133703,
-        "narHash": "sha256-wYgv4GjKKehMuPrROaKS003JEeSvSufgJ17fg6L1srI=",
+        "lastModified": 1738310300,
+        "narHash": "sha256-bRvUuk8A0O5jm/3fRN9Y5eFqLmO2b6bCC0YtPMxmWCI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "11c8e6aebf3a42be1f824200c98250b00f854814",
+        "rev": "e2807b247ea4704655f71a36403a68ee04b634db",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "11c8e6aebf3a42be1f824200c98250b00f854814",
+        "rev": "e2807b247ea4704655f71a36403a68ee04b634db",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=11c8e6aebf3a42be1f824200c98250b00f854814";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=e2807b247ea4704655f71a36403a68ee04b634db";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/30b1f5652a3b4a43988758b5f77ab7f2f564209c"><pre>ocamlPackages.gluon: fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3d769188ec980c2ee78cb2cfa91c62e29a19e846"><pre>ocamlPackages.core_unix: fix for OCaml 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/866496759ff239ca55063fa6d76043c14f72d20f"><pre>ocamlPackages.async_ssl: fix for OCaml 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/95dc3c9fadec65722715dbfcb0f16013c2f90ead"><pre>ocamlPackages.secp256k1: fix for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/366f4c3db10a4194c053eadf2ea99ef8f71f6154"><pre>ocamlPackages.ppxlib_jane: 0.17.1 → 0.17.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a8bd62adaf5f0172cfd2bf804b0134e9a494c8e7"><pre>ocamlPackages.labltk: add version 8.06.15 for OCaml 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2c22ac2fb68a155c8ce03b0143dad77b98acf09a"><pre>ocamlPackages.lsp: add version 1.22.0 for OCaml 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ea2225cd690eb2cba329d74ac1521a83549dc07a"><pre>ocamlPackages.mem_usage: init at 0.1.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bb136ef6dc4aabfb5e222181350526ab4a0574ce"><pre>liquidsoap: 2.2.5 → 2.3.0

ocamlPackages.ffmpeg: 1.1.11 -> 1.2.1
Changelog: https://github.com/savonet/ocaml-ffmpeg/releases/tag/v1.2.1
Diff: https://github.com/savonet/ocaml-ffmpeg/compare/v1.1.11...v1.2.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/006a5f3ee4e07c33d1253070fd2e9e33bc204f1c"><pre>ocamlPackages: a few fixes for OCaml 5.3 (#377543)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/11c8e6aebf3a42be1f824200c98250b00f854814...e2807b247ea4704655f71a36403a68ee04b634db