### PR TITLE
buildDunePackage: disable dune cache

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -279,6 +279,11 @@ with oself;
     propagatedBuildInputs = [ ppxlib cmdliner ];
   });
 
+  buildDunePackage = args: osuper.buildDunePackage ({
+    DUNE_CACHE = "disabled";
+  } // args);
+
+
   bz2 = buildDunePackage {
     pname = "bz2";
     version = "0.7.0-dev";


### PR DESCRIPTION
Dune enabled the dune cache by default in a recent version and that causes an annoying log line to be printed in the nix context since the home dir isn't defined.