### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739184465,
-        "narHash": "sha256-7Z9kNbr6qZwPG1z/6Hn/re4SS9nu1krxyknyNeCBh/o=",
+        "lastModified": 1739435815,
+        "narHash": "sha256-jZJQhOpQDXo2WrebnefZcSfiJLhyFuSiIU87vXIhpcc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58edd1e2acbc9be9fe29964344c6419db013141e",
+        "rev": "56d5c4206950cf5775996e20757cc42c845ba293",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58edd1e2acbc9be9fe29964344c6419db013141e",
+        "rev": "56d5c4206950cf5775996e20757cc42c845ba293",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=58edd1e2acbc9be9fe29964344c6419db013141e";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=56d5c4206950cf5775996e20757cc42c845ba293";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/8e260adb6d42ff196366652e2bba994d53c9e9d3"><pre>ocamlPackages.shell: disable tests of version 0.15</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/76320c89a8dca7477bd8e0ff9d4eae4eaf14752c"><pre>ocamlPackages.async_ssl: fix build of version 0.16.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4f094f4a2ee6bcb449de091f1b3c7e658409d58f"><pre>ocamlPackages.easy-format: 1.3.3 -> 1.3.4
Changelog: https://github.com/ocaml-community/easy-format/releases/tag/1.3.4
Diff: https://github.com/ocaml-community/easy-format/compare/1.3.3...1.3.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/da85d37aa491d6df3087d5f1f4fe959b50c48051"><pre>ocamlPackages.easy-format: modernized derivation
- Removed with lib
- Added changelog and longDescription to meta
- Replaced sha256 with hash</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fa4301e30443a65c2a8b6bfa21021c2b834fb11d"><pre>ocamlPackages.multipart_form: init at 0.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3fd6fcf0a896c789573955df6e674e7dad64da67"><pre>ocamlPackages.multipart_form-lwt: init at 0.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9361081879eb1cc2ceab714eb273a5befa4cf8f0"><pre>ocamlPackages.httpun-lwt: init at 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8e1bf1897df2222a076db70ff8d30960feaee739"><pre>ocamlPackages.httpun-lwt-unix: init at 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7811100be841d4af298096eff44ab7e0baf09051"><pre>soupault: remove references to ocaml</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a69b193a613c1efc77382e3d8e1967b78186f5fd"><pre>coqPackages.autosubst-ocaml: 1.1+8.19 -> 1.1+8.20</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/58edd1e2acbc9be9fe29964344c6419db013141e...56d5c4206950cf5775996e20757cc42c845ba293