### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -102,6 +102,7 @@ let
     ## Doesn't work with latest lsp on 5.2
     "linol"
     "linol-lwt"
+    "dolmen-lsp"
 
     ## Broken on GCC14 or clang19
     "mopsa"

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -102,7 +102,7 @@ let
     ## Doesn't work with latest lsp on 5.2
     "linol"
     "linol-lwt"
-    "dolmen-lsp"
+    "dolmen_lsp"
 
     ## Broken on GCC14 or clang19
     "mopsa"

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739184465,
-        "narHash": "sha256-7Z9kNbr6qZwPG1z/6Hn/re4SS9nu1krxyknyNeCBh/o=",
+        "lastModified": 1739611738,
+        "narHash": "sha256-3bnOIZz8KXtzcaXGuH9Eriv0HiQyr1EIfcye+VHLQZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58edd1e2acbc9be9fe29964344c6419db013141e",
+        "rev": "31ff66eb77d02e9ac34b7256a02edb1c43fb9998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58edd1e2acbc9be9fe29964344c6419db013141e",
+        "rev": "31ff66eb77d02e9ac34b7256a02edb1c43fb9998",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=58edd1e2acbc9be9fe29964344c6419db013141e";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=31ff66eb77d02e9ac34b7256a02edb1c43fb9998";
   };
 
   outputs = { self, nixpkgs }:

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2668,8 +2668,8 @@ with oself;
           {
             owner = "fpottier";
             repo = "visitors";
-            rev = "20250207";
-            hash = "sha256-tYlPcVJrXCJ276wo3eHe7WRtpeH+o5prD946eqGkQyY=";
+            rev = "20250212";
+            hash = "sha256-AFD4+vriwVGt6lzDyIDuIMadakcgB4j235yty5qqFgQ=";
             domain = "gitlab.inria.fr";
           } else o.src;
     propagatedBuildInputs = [ ppxlib ppx_deriving ];


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/69e14e43b5a6afceaa75dce9d24407ba3ca35d77"><pre>ocamlPackages.lablgtk: unpin gnumake42</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8e260adb6d42ff196366652e2bba994d53c9e9d3"><pre>ocamlPackages.shell: disable tests of version 0.15</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/76320c89a8dca7477bd8e0ff9d4eae4eaf14752c"><pre>ocamlPackages.async_ssl: fix build of version 0.16.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4f094f4a2ee6bcb449de091f1b3c7e658409d58f"><pre>ocamlPackages.easy-format: 1.3.3 -> 1.3.4
Changelog: https://github.com/ocaml-community/easy-format/releases/tag/1.3.4
Diff: https://github.com/ocaml-community/easy-format/compare/1.3.3...1.3.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/da85d37aa491d6df3087d5f1f4fe959b50c48051"><pre>ocamlPackages.easy-format: modernized derivation
- Removed with lib
- Added changelog and longDescription to meta
- Replaced sha256 with hash</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fa4301e30443a65c2a8b6bfa21021c2b834fb11d"><pre>ocamlPackages.multipart_form: init at 0.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3fd6fcf0a896c789573955df6e674e7dad64da67"><pre>ocamlPackages.multipart_form-lwt: init at 0.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/158f4614ed461c52514f9d35391456c9360f6fe4"><pre>ocamlPackages.atd: 2.15.0 → 2.16.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9361081879eb1cc2ceab714eb273a5befa4cf8f0"><pre>ocamlPackages.httpun-lwt: init at 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8e1bf1897df2222a076db70ff8d30960feaee739"><pre>ocamlPackages.httpun-lwt-unix: init at 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7811100be841d4af298096eff44ab7e0baf09051"><pre>soupault: remove references to ocaml</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a69b193a613c1efc77382e3d8e1967b78186f5fd"><pre>coqPackages.autosubst-ocaml: 1.1+8.19 -> 1.1+8.20</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4a2be1f7d75fea250fb052e2b9864edbe0bf8b19"><pre>ocamlPackages.lablgtk: unpin gnumake42 (#372804)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8ba337117121ab3774d7b623e3d5607b7d8de3df"><pre>ocamlPackages.atd: 2.15.0 → 2.16.0 (#381337)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3411a4ae3b2769f41d22ab45e88ff306c72b24a8"><pre>ocamlPackages.sel: 0.5.0 → 0.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/942907da9f4396a14a56884752f3441f896a575a"><pre>ocamlPackages.visitors: 20210608 -> 20250212</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1de88d0796202a27005c5a74474fd3cfb3069b82"><pre>ocamlPackages.seqes: 0.2 → 0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/de1b2782c95760818dcefc461f73264eb98300c7"><pre>ocamlPackages.arg-complete: init at 0.2.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9c1f15d84574fbf20cfc4e766523c5a2a9a060a2"><pre>ocamlPackages.mopsa: 1.0 → 1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9f162bf862b633779fc1544949cf4844f88fe45a"><pre>ocamlPackages.seqes: 0.2 → 0.4 (#381955)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cc1354cdc7dc79aa040cca684d6ba14c58d3bdcb"><pre>ocamlPackages.mopsa: 1.0 → 1.1 (#381991)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/62172c1d3a55eb82a277908f045ebac7db272e9a"><pre>ocamlPackages.qcheck-core: 0.22 -> 0.23</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/61bf77bebdbe3bcab9c03241cf2f06de0de186d0"><pre>ocamlPackages.visitors: 20210608 -> 20250212 (#381913)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/58edd1e2acbc9be9fe29964344c6419db013141e...31ff66eb77d02e9ac34b7256a02edb1c43fb9998