### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740848276,
-        "narHash": "sha256-bYeI3FEs824X+MJYksKboNlmglehzplqzn+XvcojWMc=",
+        "lastModified": 1740981371,
+        "narHash": "sha256-Up7YlXIupmT7fEtC4Oj676M91INg0HAoamiswAsA3rc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9b0ff70ddc61c42548501b0fafb86bb49cca858",
+        "rev": "1d2fe0135f360c970aee1d57a53f816f3c9bddae",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9b0ff70ddc61c42548501b0fafb86bb49cca858",
+        "rev": "1d2fe0135f360c970aee1d57a53f816f3c9bddae",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e9b0ff70ddc61c42548501b0fafb86bb49cca858";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=1d2fe0135f360c970aee1d57a53f816f3c9bddae";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/29cee7df19e1172552dc3448d6dc36503cf0295d"><pre>ocamlPackages.posix-socket: disable for OCaml < 4.12</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a7e1ef28c44a655b4638500274977860a0a4c2da"><pre>ocamlPackages.posix-math2: init at 2.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/56e397616bde95fdd94fb834789e928bbae99af1"><pre>ocamlPackages.posix-math2: init at 2.2.0 (#385383)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d2fe0135f360c970aee1d57a53f816f3c9bddae"><pre>lutris: 0.5.18 -> 0.5.19 (#385282)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d2fe0135f360c970aee1d57a53f816f3c9bddae"><pre>lutris: 0.5.18 -> 0.5.19 (#385282)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d2fe0135f360c970aee1d57a53f816f3c9bddae"><pre>lutris: 0.5.18 -> 0.5.19 (#385282)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d2fe0135f360c970aee1d57a53f816f3c9bddae"><pre>lutris: 0.5.18 -> 0.5.19 (#385282)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d2fe0135f360c970aee1d57a53f816f3c9bddae"><pre>lutris: 0.5.18 -> 0.5.19 (#385282)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e9b0ff70ddc61c42548501b0fafb86bb49cca858...1d2fe0135f360c970aee1d57a53f816f3c9bddae