### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740848276,
-        "narHash": "sha256-bYeI3FEs824X+MJYksKboNlmglehzplqzn+XvcojWMc=",
+        "lastModified": 1741171237,
+        "narHash": "sha256-3IJy05lcahEv8KM2QUsvdukmyxlNfRfGSYzZqWMPBcU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9b0ff70ddc61c42548501b0fafb86bb49cca858",
+        "rev": "59e3cd3bfcd5e27bb7f4498a5bd15084cecdb77c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9b0ff70ddc61c42548501b0fafb86bb49cca858",
+        "rev": "59e3cd3bfcd5e27bb7f4498a5bd15084cecdb77c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e9b0ff70ddc61c42548501b0fafb86bb49cca858";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=59e3cd3bfcd5e27bb7f4498a5bd15084cecdb77c";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/29cee7df19e1172552dc3448d6dc36503cf0295d"><pre>ocamlPackages.posix-socket: disable for OCaml < 4.12</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a7e1ef28c44a655b4638500274977860a0a4c2da"><pre>ocamlPackages.posix-math2: init at 2.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e81e75f86e8dd0a5e5a52135ff012c97d92db2ab"><pre>ocamlPackages.mirage-sleep: init at 4.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/21409b645064edd905c1bcfadcbb1fda95dd2f39"><pre>ocamlPackages.mirage-mtime: init at 5.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1e9f22f118be8661049bf1391b52ed59912db014"><pre>ocamlPackages.arp: 3.1.1 → 4.0.0

ocamlPackages.tcpip: 8.2.0 → 9.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/56e397616bde95fdd94fb834789e928bbae99af1"><pre>ocamlPackages.posix-math2: init at 2.2.0 (#385383)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ca735645a1dd4d0f3ef47b73cf1d36744deee890"><pre>ocamlPackages.tcpip: 8.2.0 → 9.0.0; ocamlPackages.arp: 3.1.1 → 4.0.0 (#385499)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e9b0ff70ddc61c42548501b0fafb86bb49cca858...59e3cd3bfcd5e27bb7f4498a5bd15084cecdb77c