### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741516043,
-        "narHash": "sha256-Hv0S630U4GVZBM1Q+NCEwyN5ct7cic+8r6qLIaUaVqI=",
+        "lastModified": 1741605585,
+        "narHash": "sha256-1bgzejf8fwsbzr/5cRK7jPArxf7xGyQqKsy05J5p05o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8adda98a4e637d0d8a867f19ace5ed6680ecc94a",
+        "rev": "77172a85a0cdca4a9cc2aed74de9bbb14c7c8e43",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8adda98a4e637d0d8a867f19ace5ed6680ecc94a",
+        "rev": "77172a85a0cdca4a9cc2aed74de9bbb14c7c8e43",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=8adda98a4e637d0d8a867f19ace5ed6680ecc94a";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=77172a85a0cdca4a9cc2aed74de9bbb14c7c8e43";
   };
 
   outputs = { self, nixpkgs }:

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1724,12 +1724,6 @@ with oself;
   ppx_debug = callPackage ./typedppxlib/ppx_debug.nix { };
 
   ocamlbuild = osuper.ocamlbuild.overrideAttrs (o: {
-    src = fetchFromGitHub {
-      owner = "ocaml";
-      repo = "ocamlbuild";
-      rev = "0.16.1";
-      hash = "sha256-RpHVX0o4QduN73j+omlZlycRJaGZWfwHO5kq/WsEGZE=";
-    };
     nativeBuildInputs = o.nativeBuildInputs ++ [ makeWrapper ];
 
     patches =
@@ -2003,12 +1997,7 @@ with oself;
     meta = owl-base.meta;
   });
 
-  ocaml_pcre = (osuper.ocaml_pcre.override { pcre = pcre-oc; }).overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = "https://github.com/mmottl/pcre-ocaml/releases/download/8.0.3/pcre-8.0.3.tbz";
-      sha256 = "0ybz1plnni2phllnisrawgfrqzbc595b3kd6zzxsq70025w0520l";
-    };
-  });
+  ocaml_pcre = (osuper.ocaml_pcre.override { pcre = pcre-oc; });
 
   otfed = osuper.otfed.overrideAttrs (o: {
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ stdio ];


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a6d3a11af3c8c63eb077a1360d1bb2e827bc9f53"><pre>ocamlPackages.ocamlbuild: 0.15.0 -> 0.16.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ecd29f7fbdcbdf330ce5d8b0958c8e2cea8bdae"><pre>ocamlPackages.qcheck-core: 0.23 -> 0.24</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a930c46ce149bd7f017f4b220c4e773c8cdc404"><pre>ocamlPackages.ocaml_pcre: 7.5.0 -> 8.0.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2eae096472e7ead3f1b2b3ce3e6e377cf32b8c29"><pre>ocamlPackages.qcheck-core: 0.23 -> 0.24 (#385704)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7cb61ebae7e7b48199b9d8243c29eb3b894fb39f"><pre>ocamlPackages.ocamlbuild: 0.15.0 -> 0.16.1 (#381938)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9773378006bcc11232167f6659bfcc85c59c1c7e"><pre>ocamlPackages.ocaml_pcre: 7.5.0 -> 8.0.3 (#362820)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/77172a85a0cdca4a9cc2aed74de9bbb14c7c8e43"><pre>flatter: 0-unstable-2024-03-04 -> 0-unstable-2025-02-03 (#387985)

Co-authored-by: josephsurin <joseph.surin@gmail.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/77172a85a0cdca4a9cc2aed74de9bbb14c7c8e43"><pre>flatter: 0-unstable-2024-03-04 -> 0-unstable-2025-02-03 (#387985)

Co-authored-by: josephsurin <joseph.surin@gmail.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/77172a85a0cdca4a9cc2aed74de9bbb14c7c8e43"><pre>flatter: 0-unstable-2024-03-04 -> 0-unstable-2025-02-03 (#387985)

Co-authored-by: josephsurin <joseph.surin@gmail.com></pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/8adda98a4e637d0d8a867f19ace5ed6680ecc94a...77172a85a0cdca4a9cc2aed74de9bbb14c7c8e43