### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742095305,
-        "narHash": "sha256-L8qjRx4MbX/juwbo8+4qYbqQy0MFUzUJLV5o8oujvaA=",
+        "lastModified": 1742140672,
+        "narHash": "sha256-WhUVudt/iXRFhMTzuT594/Ho/zCZ3KH3IkwInRD3xa4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f985965fff9d4e5df55df0489ef113d09a6ee08d",
+        "rev": "329ca25a90a27b20526164767a3309d0066a00ca",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f985965fff9d4e5df55df0489ef113d09a6ee08d",
+        "rev": "329ca25a90a27b20526164767a3309d0066a00ca",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=f985965fff9d4e5df55df0489ef113d09a6ee08d";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=329ca25a90a27b20526164767a3309d0066a00ca";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/d687ef9f68c5bb71e55d86cabd6b30e283402403"><pre>ocamlPackages.duppy: 0.9.4 -> 0.9.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c87f915985b4de80c065bac3f6de5a6be9599df7"><pre>ocamlPackages.srt: 0.3.1 -> 0.3.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/67474b79cb9a5869173b23e92650a315b671aaed"><pre>ocamlPackages.duppy: 0.9.4 -> 0.9.5 (#388375)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/98508ee495151890a849a8873e5747260c33ec42"><pre>ocamlPackages.srt: 0.3.1 -> 0.3.3 (#388740)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/329ca25a90a27b20526164767a3309d0066a00ca"><pre>terraform-providers.pagerduty: 3.21.0 -> 3.22.0 (#390199)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/329ca25a90a27b20526164767a3309d0066a00ca"><pre>terraform-providers.pagerduty: 3.21.0 -> 3.22.0 (#390199)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/329ca25a90a27b20526164767a3309d0066a00ca"><pre>terraform-providers.pagerduty: 3.21.0 -> 3.22.0 (#390199)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/f985965fff9d4e5df55df0489ef113d09a6ee08d...329ca25a90a27b20526164767a3309d0066a00ca