### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742450798,
-        "narHash": "sha256-lfOAAaX68Ed7R6Iy2nbFAkGj6B8kHBp3nqZhgZjxR5c=",
+        "lastModified": 1742541432,
+        "narHash": "sha256-hPzDbmo3T64R1rt8i8WonR/4VrSbE8ZxY6wFIguC4sc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b64ec1944ea40d9f3920f938e17ed39a9978c6c7",
+        "rev": "fa6ab1d7fdf29a4ff0ac65f01ffdaea84f105280",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b64ec1944ea40d9f3920f938e17ed39a9978c6c7",
+        "rev": "fa6ab1d7fdf29a4ff0ac65f01ffdaea84f105280",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=b64ec1944ea40d9f3920f938e17ed39a9978c6c7";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=fa6ab1d7fdf29a4ff0ac65f01ffdaea84f105280";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/4e80fc3c151bfcc7c0ac455ece10dc948ed52fc3"><pre>ocamlPackages.owl-base: add aarch64 to platforms

As of 1.2, Owl supports ARM.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/caf0c4e8ed3faae54f1615722b8e0cd6208c615c"><pre>ocamlPackages.owl-base: add aarch64 to platforms (#391349)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/797eae1db4130761e18f8fa6e7da364e9dfca3f5"><pre>vimPlugins.nvim-treesitter: revert ocamllex bump

Hash mismatch on darwin, for some reason.
error: hash mismatch in fixed-output derivation
\'/nix/store/97ladc5962id20y3d2m4a5j4k96yv83s-source.drv\':
         specified: sha256-eDJRTLYKHcL7yAgFL8vZQh9zp5fBxcZRsWChp8y3Am0=
            got:    sha256-UBGVc98lrtTCp/kYDEFM/8iG9n7Tekx+xbE7Wdyp2uQ=
error: 1 dependencies of derivation
\'/nix/store/sbmwhp3b7h5r5arw2y9b01mzaywsr365-ocamllex-grammar-0.0.0+rev=c5cf996.drv\'
failed to build
error: 1 dependencies of derivation
\'/nix/store/zb1pm9gm8bvs04g2lfzq3ss4zsk0y5x1-vimplugin-treesitter-grammar-ocamllex.drv\'
failed to build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e0f24240b733d95ca02a248a232bb98ceebdc6d6"><pre>vimPlugins.nvim-treesitter: revert ocamllex bump (#391688)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fa6ab1d7fdf29a4ff0ac65f01ffdaea84f105280"><pre>python3Packages.datasets: 3.2.0 -> 3.4.1 (#391372)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/b64ec1944ea40d9f3920f938e17ed39a9978c6c7...fa6ab1d7fdf29a4ff0ac65f01ffdaea84f105280