### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743343031,
-        "narHash": "sha256-cBhTGErBVy9jmlvH1/B+LF1dncZouofdFoOgz+CTEzU=",
+        "lastModified": 1743386251,
+        "narHash": "sha256-aRAFj+SzZGUlCMDBbd6yI09ffo9lMgx726VTZMMCRGA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7dbd61d5167a183bfb5a29fb9248cdee6d7ca2e",
+        "rev": "1d3a750cb7d8e1058a425810c80790a3842ef27b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7dbd61d5167a183bfb5a29fb9248cdee6d7ca2e",
+        "rev": "1d3a750cb7d8e1058a425810c80790a3842ef27b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=c7dbd61d5167a183bfb5a29fb9248cdee6d7ca2e";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=1d3a750cb7d8e1058a425810c80790a3842ef27b";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/81b7aa80338f2c6dcd11b54c0f1e06341634345b"><pre>ocamlPackages.ocaml-version: 3.7.3 -> 4.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/af0a43f797e72198af6d040c0763419c86541be7"><pre>vimPlugins.nvim-treesitter: revert ocamllex bump

Hash mismatch on darwin, for some reason.
error: hash mismatch in fixed-output derivation
\'/nix/store/97ladc5962id20y3d2m4a5j4k96yv83s-source.drv\':
         specified: sha256-eDJRTLYKHcL7yAgFL8vZQh9zp5fBxcZRsWChp8y3Am0=
            got:    sha256-UBGVc98lrtTCp/kYDEFM/8iG9n7Tekx+xbE7Wdyp2uQ=
error: 1 dependencies of derivation
\'/nix/store/sbmwhp3b7h5r5arw2y9b01mzaywsr365-ocamllex-grammar-0.0.0+rev=c5cf996.drv\'
failed to build
error: 1 dependencies of derivation
\'/nix/store/zb1pm9gm8bvs04g2lfzq3ss4zsk0y5x1-vimplugin-treesitter-grammar-ocamllex.drv\'
failed to build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0da71f99580526b4f0004527107b32479a3c4b5e"><pre>vimPlugins.nvim-treesitter: revert ocamllex bump again (#394636)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/519852440f9795edf252c89ef98395ddd679691b"><pre>ocamlPackages.ocaml-version: 3.7.3 -> 4.0.0 (#392833)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d3a750cb7d8e1058a425810c80790a3842ef27b"><pre>bun: 1.2.5 -> 1.2.7 (#393118)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d3a750cb7d8e1058a425810c80790a3842ef27b"><pre>bun: 1.2.5 -> 1.2.7 (#393118)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/c7dbd61d5167a183bfb5a29fb9248cdee6d7ca2e...1d3a750cb7d8e1058a425810c80790a3842ef27b