### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743948488,
-        "narHash": "sha256-uKcMmNPvGPb58MhAFru/CMDYl69nZRK3A3SLch9ejgA=",
+        "lastModified": 1744348691,
+        "narHash": "sha256-dIPrBepej1ebT1IaWEFLI5mpQO65+oM+SArkrNI9gjo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da98c5d529f118c82e80a3f9b4fb01fdeba3cf7a",
+        "rev": "6b93024f590b15b1f3888fcc6e56a0866e0c26c2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da98c5d529f118c82e80a3f9b4fb01fdeba3cf7a",
+        "rev": "6b93024f590b15b1f3888fcc6e56a0866e0c26c2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=da98c5d529f118c82e80a3f9b4fb01fdeba3cf7a";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=6b93024f590b15b1f3888fcc6e56a0866e0c26c2";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/8562345e83817140d9ab682f8d0371cdb8500491"><pre>ocamlPackages.metadata: 0.3.0 -> 0.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/235158069dbd9b13757342035a0a29db8ddb9af0"><pre>ocamlPackages.metadata: 0.3.0 -> 0.3.1 (#395353)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/99a517284208850db675a6ebfb3d2f8cca9157b4"><pre>vimPlugins.nvim-treesitter-parsers.ocamllex: fix build on darwin

See https://github.com/314eter/tree-sitter-ocamllex/issues/10
and https://github.com/NixOS/nixpkgs/pull/394636</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a14c1622401726d9b39ad8589f9c4366a74bbec7"><pre>ocamlPackages.bitwuzla-cxx: init at 0.6.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/eaa2033789990f8e7d8be1a6e64b06867add6eb5"><pre>vimPlugins.nvim-treesitter-parsers.ocamllex: fix build on darwin (#397010)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/33a287eb135fa5af141f6f889771917b17465296"><pre>ocamlPackages.gettext: 0.4.2 → 0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6a45d840c86c9a31dcb301668a8d8efe0688e4f8"><pre>ocamlPackages.merlin: add meta.mainProgram (#397595)


Co-authored-by: Arne Keller <arne.keller@posteo.de></pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/da98c5d529f118c82e80a3f9b4fb01fdeba3cf7a...6b93024f590b15b1f3888fcc6e56a0866e0c26c2