### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744863809,
-        "narHash": "sha256-ftYNVwqXffcqveMsmXGi7DKxSYzcV8yHfX51d/Sqdq8=",
+        "lastModified": 1745215074,
+        "narHash": "sha256-JjkdlVI9BImDV5RrCiJk17cMSIqbefUXBM9trHRif+c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc0ac3e7c8380b7e12eeebc06dd10bc9cd164862",
+        "rev": "78e2cd1a1590f8c70b329cbc7d13bb2ab5b5a16c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc0ac3e7c8380b7e12eeebc06dd10bc9cd164862",
+        "rev": "78e2cd1a1590f8c70b329cbc7d13bb2ab5b5a16c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=dc0ac3e7c8380b7e12eeebc06dd10bc9cd164862";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=78e2cd1a1590f8c70b329cbc7d13bb2ab5b5a16c";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/ed79c059831b0e87580654c3b0b3be4bb4211ba9"><pre>ocamlPackages.batteries: add missing dependency to ounit</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/064ca4757418b16061a4e4c1c3eee75296f6ad35"><pre>ocamlPackages.qcheck: 0.24 → 0.25

ocamlPackages.ppx_deriving_qcheck: keep at 0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/99c389ef8855f451a8fea2555546ad3b9b0d20dc"><pre>ocamlPackages.cohttp-async: require OCaml ≥ 4.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/862ab26729e2f4ff76120a5c8631249a9bd0c33e"><pre>ocamlPackages.virtual_dom: mark as broken with OCaml 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e1b463d1227cef2fc7f7110501afd56045e61040"><pre>ocamlPackages.reanalyze: disable for OCaml ≥ 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1b08952db083467a9bc9f06d71e60e0d1c742e8c"><pre>ocamlPackages.reanalyze: add indentation</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/68f3ac366e7ce8419238483c7d3e3b73b0b5f9d9"><pre>ocamlPackages.eliom: disable for OCaml ≥ 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f19a5a36105300580c4e6d961422677cc917bf2c"><pre>ocamlPackages.eliom: add indentation</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ef7d361ee0184b76c6177ac761dc29389e5491cf"><pre>ocamlPackages.ocamlformat_0_26_2: disable for OCaml ≥ 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1e875f02041bcfee2e3801eaf7e6fdb6561dfdfa"><pre>ocamlPackages.kafka: disable for OCaml ≥ 5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f46ecca1db025b72f5ca0b6a14356c719e7e4cfb"><pre>ocamlPackages.kafka: add indentation</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6ee239aaa87fa055b06028db1b7d82b42060b242"><pre>ocaml: default to version 5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a5cfa5f3af6965f7139bacb03c29b5c5a19b58e1"><pre>vscode-extensions.ocamllabs.ocaml-platform: 1.28.2 -> 1.29.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/89dc517577cfc237b0c55a640b15294f0ab9900e"><pre>ocamlPackages.eigen: get libc++ headers on Darwin from stdenv.cc.libcxx</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c444dfac5c171540b472b6039b5364303357f9f0"><pre>OCaml: default to version 5.3 (#397478)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/78e2cd1a1590f8c70b329cbc7d13bb2ab5b5a16c"><pre>notmuch: 0.38.3 -> 0.39 (#400017)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/dc0ac3e7c8380b7e12eeebc06dd10bc9cd164862...78e2cd1a1590f8c70b329cbc7d13bb2ab5b5a16c