### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745774050,
-        "narHash": "sha256-7t5co9DUcgNX9r0CplMTDIa1lq1CGe+QjLDmnPsdiOE=",
+        "lastModified": 1745818722,
+        "narHash": "sha256-WSWGBO5YIMdwDP4d01093HFqZJO89Jy6iLr6dr7Fzug=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a8cbaf7900c1b5e9becb4e00b22c4044ea12f6bc",
+        "rev": "a80e6503506a17b2443e98686e89a0fa74b02f1c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a8cbaf7900c1b5e9becb4e00b22c4044ea12f6bc",
+        "rev": "a80e6503506a17b2443e98686e89a0fa74b02f1c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=a8cbaf7900c1b5e9becb4e00b22c4044ea12f6bc";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=a80e6503506a17b2443e98686e89a0fa74b02f1c";
   };
 
   outputs = { self, nixpkgs }:

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -637,10 +637,6 @@ with oself;
   };
 
   digestif = osuper.digestif.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = "https://github.com/mirage/digestif/releases/download/v1.2.0/digestif-1.2.0.tbz";
-      sha256 = "0255nb9wjpkdh9v0w9p5y5s79zcqcdg3wsw0cx9nd6i7zv56h0f3";
-    };
     postPatch = ''
       rm -rf fuzz
     '';


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/e169744ac7210b6f65249b2042b81a3d7339635e"><pre>ocamlPackages.qcheck-multicoretests-util: 0.7 -> 0.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3e70e41082788d5f24f5458b343ef41c4c78a267"><pre>ocamlPackages.digestif: 1.2.0 -> 1.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1a9bcf694ee3ca490f02b5197320261d34c2b3cb"><pre>ocamlPackages.tls: 2.0.0 -> 2.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bca2adeb0aba718c602d59ce63d1246ecf83d649"><pre>ocamlPackages.x509: 1.0.5 -> 1.0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/54dd799637adfadc5c3535af56cc241adb319f59"><pre>ocamlPackages.tcpip: 9.0.0 -> 9.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/58c1c3a3e61365f9457933e2b6d95d85f3258b85"><pre>ocamlPackages.ca-certs: 1.0.0 -> 1.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/621aba89c251d99282863c90b6ef7c16aa60d0a8"><pre>ocamlPackages.tls: 2.0.0 -> 2.0.1 (#398577)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d56c597c63af45b34e16a1a2d37e72617e3e45e1"><pre>ocamlPackages.qcheck-multicoretests-util: 0.7 -> 0.8 (#397788)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d423eb0d44aa31d5a8bb3947374b804a67288e36"><pre>ocamlPackages.digestif: 1.2.0 -> 1.3.0 (#398572)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/29bbb194d68e7d3c13018190b429ea4641b911d7"><pre>ocamlPackages.ca-certs: 1.0.0 -> 1.0.1 (#398955)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/efc308bebd8df4174a45c1a92c1283d8a1cd1356"><pre>ocamlPackages.x509: 1.0.5 -> 1.0.6 (#398953)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/67300d3f8eccabb38b7b4ed8f3a25d9583ccf3ea"><pre>ocamlPackages.tcpip: 9.0.0 -> 9.0.1 (#398954)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a80e6503506a17b2443e98686e89a0fa74b02f1c"><pre>confluent-cli: 4.16.0 -> 4.25.0 (#400197)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a80e6503506a17b2443e98686e89a0fa74b02f1c"><pre>confluent-cli: 4.16.0 -> 4.25.0 (#400197)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a80e6503506a17b2443e98686e89a0fa74b02f1c"><pre>confluent-cli: 4.16.0 -> 4.25.0 (#400197)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a80e6503506a17b2443e98686e89a0fa74b02f1c"><pre>confluent-cli: 4.16.0 -> 4.25.0 (#400197)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a80e6503506a17b2443e98686e89a0fa74b02f1c"><pre>confluent-cli: 4.16.0 -> 4.25.0 (#400197)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a80e6503506a17b2443e98686e89a0fa74b02f1c"><pre>confluent-cli: 4.16.0 -> 4.25.0 (#400197)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/a8cbaf7900c1b5e9becb4e00b22c4044ea12f6bc...a80e6503506a17b2443e98686e89a0fa74b02f1c