### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746165930,
-        "narHash": "sha256-MkYNib57sO+nI6KAbpGLseXFmJVZ04QP6Celntnay8E=",
+        "lastModified": 1746208004,
+        "narHash": "sha256-Y8ZPp4ynUgylUrvBZAol5EQH0lO5yUQOXbTEz0Cqe1E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97e6d418edc7a9a85d505f96f1e65ca9d6a5f7a8",
+        "rev": "b5393707178e1a13b6f5fe66b9f966cf3d671951",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97e6d418edc7a9a85d505f96f1e65ca9d6a5f7a8",
+        "rev": "b5393707178e1a13b6f5fe66b9f966cf3d671951",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=97e6d418edc7a9a85d505f96f1e65ca9d6a5f7a8";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=b5393707178e1a13b6f5fe66b9f966cf3d671951";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/8855e5cbdddee60c26da516b85298f5b43ef13d4"><pre>ocaml: use bytecode compiler on loongarch64-linux</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/11fcf324796b9b78f5e2636f7e3ef3e007e35a38"><pre>ocamlPackages.findlib: fix build with bytecode mode</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/15cad86455bdd28944efdca16a29c2d18406c36f"><pre>ocamlPackages.raylib: clean & fix</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6b8d38f99e51c461cf1b5ab3f4b4104d9a4cefd2"><pre>ocamlPackages.raylib: clean & fix (#401338)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8306c6a5916e5e143aa92f94cb6fcff5b65b06a9"><pre>ocaml: add loongarch64-linux support (#402087)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5393707178e1a13b6f5fe66b9f966cf3d671951"><pre>Merge: nixos/oci-containers: stricter dependencies for rootless containers with sdnotify=healthy (#394039)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5393707178e1a13b6f5fe66b9f966cf3d671951"><pre>Merge: nixos/oci-containers: stricter dependencies for rootless containers with sdnotify=healthy (#394039)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5393707178e1a13b6f5fe66b9f966cf3d671951"><pre>Merge: nixos/oci-containers: stricter dependencies for rootless containers with sdnotify=healthy (#394039)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5393707178e1a13b6f5fe66b9f966cf3d671951"><pre>Merge: nixos/oci-containers: stricter dependencies for rootless containers with sdnotify=healthy (#394039)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/97e6d418edc7a9a85d505f96f1e65ca9d6a5f7a8...b5393707178e1a13b6f5fe66b9f966cf3d671951