### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747554148,
-        "narHash": "sha256-aeAOz1/fSKEjEJG6eVjLC4RmxzTe2RkUERPD9yUQIGc=",
+        "lastModified": 1747644487,
+        "narHash": "sha256-0Ub4ws2UGgXAQ7qJ6JEhYOjrrf2Ky/7iEWkyEDkKa/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0afebfe3e464cf20f0952275f8220a9502af465",
+        "rev": "949fb7f3087b8d086fd8c92acfa8412c43cfc116",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0afebfe3e464cf20f0952275f8220a9502af465",
+        "rev": "949fb7f3087b8d086fd8c92acfa8412c43cfc116",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=d0afebfe3e464cf20f0952275f8220a9502af465";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=949fb7f3087b8d086fd8c92acfa8412c43cfc116";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/762dbcc9109855e34d810caf1761d6ca032d4abe"><pre>ocamlPackages.fix: 20230505 -> 20250428</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4eb57ebe920958e2482a9fdfcdd5dd2bdf40c0fe"><pre>ocamlPackages.ocaml_intrinsics: fix ARM CRC32 intrinsics

This patch is needed because of an issue with the aarch64 CRC32 intrinsics that was introduced with ocaml_intrinsics v0.17. It should be removed as soon as https://github.com/janestreet/ocaml_intrinsics/pull/11 is merged.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c2881051c39b8fb86bde4bca317ce09452708295"><pre>ocamlPackages.ocaml_intrinsics: fix ARM CRC32 intrinsics (#408405)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fff45c6f6a2050993c4f045b074a665f13cb0c34"><pre>ocamlPackages.fix: 20230505 -> 20250428 (#402945)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/949fb7f3087b8d086fd8c92acfa8412c43cfc116"><pre>home-assistant-custom-lovelace-modules.universal-remote-card: 4.5.0 -> 4.5.1 (#408607)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/949fb7f3087b8d086fd8c92acfa8412c43cfc116"><pre>home-assistant-custom-lovelace-modules.universal-remote-card: 4.5.0 -> 4.5.1 (#408607)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/949fb7f3087b8d086fd8c92acfa8412c43cfc116"><pre>home-assistant-custom-lovelace-modules.universal-remote-card: 4.5.0 -> 4.5.1 (#408607)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/d0afebfe3e464cf20f0952275f8220a9502af465...949fb7f3087b8d086fd8c92acfa8412c43cfc116