### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748762463,
-        "narHash": "sha256-rb8vudY2u0SgdWh83SAhM5QZT91ZOnvjOLGTO4pdGTc=",
+        "lastModified": 1749397806,
+        "narHash": "sha256-PjSGVrOHH+2DABRJzgIt/y+zxofyfZO71pI33y0t4F4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d0bc640d371e9e8c9914c42951b3d6522bc5dda",
+        "rev": "ae91003958555b8b73c17e6536a302ff492c9d04",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d0bc640d371e9e8c9914c42951b3d6522bc5dda",
+        "rev": "ae91003958555b8b73c17e6536a302ff492c9d04",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=0d0bc640d371e9e8c9914c42951b3d6522bc5dda";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=ae91003958555b8b73c17e6536a302ff492c9d04";
   };
 
   outputs = { self, nixpkgs }:

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -602,22 +602,6 @@ with oself;
 
   decimal = callPackage ./decimal { };
 
-  decoders = buildDunePackage {
-    pname = "decoders";
-    version = "n/a";
-    src = fetchFromGitHub {
-      owner = "mattjbray";
-      repo = "ocaml-decoders";
-      rev = "00d930";
-      sha256 = "sha256-LK2CZHvs9itx51EVi/MonrvnGOlPtLDXdMhAFX9O8Uc=";
-    };
-  };
-  decoders-yojson = buildDunePackage {
-    pname = "decoders-yojson";
-    inherit (oself.decoders) src version;
-    propagatedBuildInputs = [ decoders yojson ];
-  };
-
   domain-local-await = disableTests osuper.domain-local-await;
   thread-table = disableTests osuper.thread-table;
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/4ff415437167fc7c88dc6abe9b34eed67f02bca9"><pre>ocamlPackages.ocamlfuse: 2.7.1_cvs12 -> 2.7.1_cvs13</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e879f79ea1a74b2acae000d5e779636dddac4590"><pre>ocamlPackages.ocamlfuse: 2.7.1_cvs12 -> 2.7.1_cvs13 (#410410)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a4f7e10e678b3e3d8da091a4c497ae210f2677eb"><pre>ocamlPackages.mdx: fix Darwin build

The unix set perm test fails on Darwin, so disable tests as I do not
believe there is a way to disable specific tests in OCaml.

Signed-off-by: Ethan Carter Edwards <ethan@ethancedwards.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1da7506394c1087504dda1d338c2523410188691"><pre>ocamlPackages.ffmpeg: 1.2.1 -> 1.2.5
Diff: https://github.com/savonet/ocaml-ffmpeg/compare/v1.2.1...v1.2.5
Changelog: https://github.com/savonet/ocaml-ffmpeg/releases/tag/v1.2.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9019cc426ef42d9a3013ab8b6031bfbeaaaa5148"><pre>ocamlPackages.ffmpeg: modernized derivation
- Remove \`with lib;\`
- Changed rev to tag, and sha256 to hash
- Added meta.changelog

Co-authored-by: Vincent Laporte <vbgl@users.noreply.github.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/86394421cd328db8782ef50db3210f40aa28e217"><pre>ocamlPackages.ffmpeg: add @momeemt to maintainers</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a02164e094dd05326b6d4e8a36256f37595d23f7"><pre>ocamlPackages.mdx: fix Darwin build (#414279)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d2afc0e998abe2a1bb2c6b803ae9154717c3e24"><pre>ocamlPackages.wasm: 2.0.1 -> 2.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7baddbc4fdabc865e2c875b36614269e107c10ea"><pre>ocamlPackages.cbor: init at 0.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e016599ff52c42f9f853f345be4b2d50f9738c31"><pre>ocamlPackages.bencode: init at 2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5416aaae9d88f3676ea17f67e6b10b5bfcf434db"><pre>ocamlPackages.decoders: init at 1.0.0

Since all decoders-* packages are part of the base decoders package
source, and the versions are all tied together, they are added as a
single commit</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/0d0bc640d371e9e8c9914c42951b3d6522bc5dda...ae91003958555b8b73c17e6536a302ff492c9d04