### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -35,7 +35,6 @@ let
     "pgsolver"
     "tcslib"
 
-    "biocaml"
     "pythonlib"
     "magic-trace"
 

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -124,6 +124,8 @@ let
     "tsdl-mixer"
     "tsdl-image"
     "tsdl-ttf"
+    "miou"
+    "mirage-crypto-rng-miou-unix"
   ];
 
   ocaml5Ignores = [

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749411262,
-        "narHash": "sha256-gRBkeW9l5lb/90lv1waQFNT+18OhITs11HENarh6vNo=",
+        "lastModified": 1749632365,
+        "narHash": "sha256-52jhP+dVqi7oWaYZqWZp+KNqmCmEdSsN870yhG6FxYQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fc422d6c394191338c9d6a05786c63fc52a0f29",
+        "rev": "3156024cc8366b3aa79210364db0005c16c0e2ae",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fc422d6c394191338c9d6a05786c63fc52a0f29",
+        "rev": "3156024cc8366b3aa79210364db0005c16c0e2ae",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=0fc422d6c394191338c9d6a05786c63fc52a0f29";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=3156024cc8366b3aa79210364db0005c16c0e2ae";
   };
 
   outputs = { self, nixpkgs }:

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2338,6 +2338,7 @@ with oself;
   # };
   # };
 
+  sedlex = disableTests osuper.sedlex;
   # sedlex = osuper.sedlex.overrideAttrs (_: {
   # src = fetchFromGitHub {
   # owner = "ocaml-community";
@@ -2656,6 +2657,14 @@ with oself;
       js_of_ocaml
       js_of_ocaml-ppx
     ];
+  });
+  js_of_ocaml = osuper.js_of_ocaml-compiler.overrideAttrs (_: {
+    src = fetchFromGitHub {
+      owner = "ocsigen";
+      repo = "js_of_ocaml";
+      rev = "ae754850c7c79ebed2349d24347967a1e3233a4f";
+      hash = "sha256-gV5H/ghjT5ot9p1WAx+Tlecq+/h8fNcu9cPGkgm7iYw=";
+    };
   });
 
   visitors = osuper.visitors.overrideAttrs (o: {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2658,14 +2658,6 @@ with oself;
       js_of_ocaml-ppx
     ];
   });
-  js_of_ocaml-compiler = osuper.js_of_ocaml-compiler.overrideAttrs (_: {
-    src = fetchFromGitHub {
-      owner = "ocsigen";
-      repo = "js_of_ocaml";
-      rev = "ae754850c7c79ebed2349d24347967a1e3233a4f";
-      hash = "sha256-gV5H/ghjT5ot9p1WAx+Tlecq+/h8fNcu9cPGkgm7iYw=";
-    };
-  });
 
   visitors = osuper.visitors.overrideAttrs (o: {
     src =

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2658,7 +2658,7 @@ with oself;
       js_of_ocaml-ppx
     ];
   });
-  js_of_ocaml = osuper.js_of_ocaml-compiler.overrideAttrs (_: {
+  js_of_ocaml-compiler = osuper.js_of_ocaml-compiler.overrideAttrs (_: {
     src = fetchFromGitHub {
       owner = "ocsigen";
       repo = "js_of_ocaml";

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1433,10 +1433,6 @@ with oself;
 
   mirage-crypto-pk = osuper.mirage-crypto-pk.override { gmp = gmp-oc; };
   mirage-crypto-rng = disableTests osuper.mirage-crypto-rng;
-  mirage-crypto-rng-eio =
-    if lib.versionAtLeast ocaml.version "5.0"
-    then disableTests osuper.mirage-crypto-rng-eio
-    else null;
 
   mirage-runtime = osuper.mirage-runtime.overrideAttrs (_: {
     src = builtins.fetchurl {

--- a/ocaml/dream/default.nix
+++ b/ocaml/dream/default.nix
@@ -17,7 +17,6 @@
 , markup
 , mirage-clock
 , mirage-crypto
-, mirage-crypto-rng-lwt
 , multipart_form
 , multipart_form-lwt
 , ptime
@@ -67,7 +66,6 @@ buildDunePackage rec {
     magic-mime
     mirage-clock
     mirage-crypto
-    mirage-crypto-rng-lwt
     multipart_form
     multipart_form-lwt
     ptime

--- a/ocaml/dream/default.nix
+++ b/ocaml/dream/default.nix
@@ -3,6 +3,7 @@
 , caqti
 , caqti-lwt
 , cstruct
+, digestif
 , dream-httpaf
 , dream-pure
 , fmt
@@ -17,6 +18,7 @@
 , markup
 , mirage-clock
 , mirage-crypto
+, mirage-crypto-rng
 , multipart_form
 , multipart_form-lwt
 , ptime
@@ -48,6 +50,10 @@ buildDunePackage rec {
        --replace-fail \
       "H2.Body.Writer.flush body" \
       "fun f -> H2.Body.Writer.flush body (fun _r -> f ())"
+    substituteInPlace src/dune \
+      --replace-fail mirage-crypto-rng-lwt mirage-crypto-rng.unix
+    substituteInPlace src/dream.ml \
+      --replace-fail Mirage_crypto_rng_lwt.initialize Mirage_crypto_rng_unix.initialize
   '';
 
   propagatedBuildInputs = [
@@ -56,6 +62,7 @@ buildDunePackage rec {
     cstruct
     dream-httpaf
     dream-pure
+    digestif
     fmt
     graphql_parser
     graphql-lwt
@@ -66,6 +73,7 @@ buildDunePackage rec {
     magic-mime
     mirage-clock
     mirage-crypto
+    mirage-crypto-rng
     multipart_form
     multipart_form-lwt
     ptime


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a21c18ab26ee1b05d5143d3f2bac6f768cc85442"><pre>ocamlPackages.bigstringaf: 0.9.0 -> 0.10.0
Changelog: https://github.com/inhabitedtype/bigstringaf/releases/tag/0.10.0
Diff: https://github.com/inhabitedtype/bigstringaf/compare/0.9.0...0.10.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a43f6bcdc6e8767c118da82a622e1bbaf0d2e01"><pre>ocamlPackages.bigstringaf: modernize the derivation and add changelog and longDescription</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2e291d0488deec1c35ab5c79c26f12dcb5b4446b"><pre>ocamlPackages.mirage-crypto: 1.2.0 -> 2.0.1 (#414541)

ocamlPackages.mirage-crypto-rng-miou-unit: init at 2.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c18875a3ca658ae37286cf8abad2653fae3fce71"><pre>ocamlPackages.dns: 10.0.0 → 10.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1c59a2d71b9d558b9ebe48f89a1cfe4c506b27c1"><pre>ocamlPackages-ancient: init at 0.10.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8612bc6e3e44008dd235e91f7c7d5e651ec9d57f"><pre>ocamlPackages.benchmark: 1.6 -> 1.7 (#414669)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1e8f3e3f479bf5eac13fa69b8c9f8c98bb7ea1de"><pre>ocamlPackages.biocaml: remove at 0.11.2

This package is broken (does not build with GCC 14) and the library does
not appear to be maintained upstream.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/60a9e7cc580666542f005396b5e2ab310f32339f"><pre>ocamlPackages.{landmarks, landmarks-ppx}: 1.4 -> 1.5
Changelog: https://github.com/LexiFi/landmarks/releases/tag/v1.5
Diff: https://github.com/LexiFi/landmarks/compare/v1.4...v1.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/95612d14de84651a677ebde0708f92550e68557e"><pre>ocamlPackages.{landmarks, landmarks-ppx}: modernized derivation
- Removed with lib;
- Added meta.homepage, meta.longDescription, and meta.changelog</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/ae91003958555b8b73c17e6536a302ff492c9d04...3156024cc8366b3aa79210364db0005c16c0e2ae