### PR TITLE
Update sources

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -125,6 +125,10 @@ let
     "tsdl-ttf"
     "miou"
     "mirage-crypto-rng-miou-unix"
+
+    "virtual_dom_toplayer"
+    "ppx_css"
+    "bonsai"
   ];
 
   ocaml5Ignores = [

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -129,6 +129,7 @@ let
     "virtual_dom_toplayer"
     "ppx_css"
     "bonsai"
+    "memtrace_viewer"
   ];
 
   ocaml5Ignores = [

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749632365,
-        "narHash": "sha256-52jhP+dVqi7oWaYZqWZp+KNqmCmEdSsN870yhG6FxYQ=",
+        "lastModified": 1749896453,
+        "narHash": "sha256-6+AmSZBogyr1zbVc2k4IBcmY/Yt39mC4+cfZi0n/AAA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3156024cc8366b3aa79210364db0005c16c0e2ae",
+        "rev": "ba48a1f6ce571455cb631dee840c6cd401ea4adb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3156024cc8366b3aa79210364db0005c16c0e2ae",
+        "rev": "ba48a1f6ce571455cb631dee840c6cd401ea4adb",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=3156024cc8366b3aa79210364db0005c16c0e2ae";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=ba48a1f6ce571455cb631dee840c6cd401ea4adb";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/377b6ec37b2cd005c492daea43746df03148c1d5"><pre>ocamlPackages.sedlex: 3.4 → 3.6

ocamlPackages.ppx_css: mark as broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3cbaba6d9d51880029561a71ad69a155eb55d5d6"><pre>ocamlPackages.bap: update to janestreet 0.17

libbap: mark as broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/77215bbae4a3847d2aa39d9a164ca1c0a84d7be7"><pre>ocamlformat: do not depend on janeStreet_0_15</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8560e13e04a860c319404c8d53f9d4c30815ca33"><pre>ocamlPackages.dream-html: init at 3.10.1 (#415700)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e1c74a4bfe477554d0601f7aa6000ec0cbc6c2fa"><pre>ocamlPackages.ocaml_intrinsics: propagate its “kernel” dependency</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3c12d02b760d63efdc155200d9c47b5b39d48c83"><pre>ocamlPackages.bap: update to janestreet 0.17 (#415751)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8a2b5b8472c0ec083d2cd6e6464f4d4abb693c0"><pre>ocamlPackages.sedlex: 3.4 → 3.6 (#415489)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5f6b24a36af63f25ad9c3c09b46cecf8b51ed48f"><pre>ocamlPackages.dum: 1.0.1 -> 1.0.3 (#414913)

* ocamlPackages.dum: 1.0.1 -> 1.0.3
Changelog: https://github.com/mjambon/dum/releases/tag/1.0.3
Diff: https://github.com/mjambon/dum/compare/v1.0.1...1.0.3

* ocamlPackages.dum: modernized derivation
- Removed with lib;
- Added meta.longDescription
- Changed --replace to --replace-fail</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fc788257acc99e4e77a70290419519f24219e4af"><pre>ocamlPackages.ocaml_intrinsics: propagate its “kernel” dependency (#416339)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/3156024cc8366b3aa79210364db0005c16c0e2ae...ba48a1f6ce571455cb631dee840c6cd401ea4adb