### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749896453,
-        "narHash": "sha256-6+AmSZBogyr1zbVc2k4IBcmY/Yt39mC4+cfZi0n/AAA=",
+        "lastModified": 1749984698,
+        "narHash": "sha256-y6frNvpXfbFWfzcCXs1WTRb0ynRbov0sWT9XJPBe+gQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba48a1f6ce571455cb631dee840c6cd401ea4adb",
+        "rev": "68eb4789b2a9881bcaad2f88fb3771bc7c7f24fa",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba48a1f6ce571455cb631dee840c6cd401ea4adb",
+        "rev": "68eb4789b2a9881bcaad2f88fb3771bc7c7f24fa",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=ba48a1f6ce571455cb631dee840c6cd401ea4adb";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=68eb4789b2a9881bcaad2f88fb3771bc7c7f24fa";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/42b749a3395a3902e273c5d9d3165170a70a44bd"><pre>z3: build with cmake by default

Currently ocaml bindings do *build* with cmake, but
they don\'t get installed properly. Until that is
fixed, we need to keep the \`py\`+\`make\` based build.

The \`cmake\` build is needed to generate the cmake and
pkg-config output, needed for e.g. prusa-slicer 2.9.2.

python import check and pkg-config passthru testers
have been added for better coverage.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f46f985238e3b1c70138c6f3d8edcacd97710736"><pre>ocamlPackages.hc: init at 0.5

Signed-off-by: Ethan Carter Edwards <ethan@ethancedwards.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/68eb4789b2a9881bcaad2f88fb3771bc7c7f24fa"><pre>vscode-extensions.tabnine.tabnine-vscode: 3.287.0 -> 3.288.0 (#416577)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/ba48a1f6ce571455cb631dee840c6cd401ea4adb...68eb4789b2a9881bcaad2f88fb3771bc7c7f24fa