### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750093821,
-        "narHash": "sha256-rumKjLR6VSoDG8eCiCLmwbuWDI+JnDzxaEWVF7F95OU=",
+        "lastModified": 1750402627,
+        "narHash": "sha256-IFVjyXqsgAf4gg34d9x0lcTj2W4aOpoEdiLCdj3Wjo0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "526945c5798687e32d4a6f8a93660fe2ca152ae2",
+        "rev": "618b6dbfc21097d3101f3fc23e6597a2621eb04e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "526945c5798687e32d4a6f8a93660fe2ca152ae2",
+        "rev": "618b6dbfc21097d3101f3fc23e6597a2621eb04e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=526945c5798687e32d4a6f8a93660fe2ca152ae2";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=618b6dbfc21097d3101f3fc23e6597a2621eb04e";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/b8efae8197c28026248ce2bf708bcaf43e3800cf"><pre>ocamlPackages.ocaml-version: 4.0.0 -> 4.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/685dc6fe146f7e344446f5a5be46a7a0a82c2f4a"><pre>ocamlPackages.ocaml-version: 4.0.0 -> 4.0.1 (#411940)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/26631c3d6121ae9a7c4fc164f2b5ca0dfb0d304b"><pre>ocamlPackages.z3: propagate libz3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5d87995243d2cd08a30b877d79ae64e4e62756ac"><pre>vimPlugins.nvim-treesitter: remove ocamllex override

Was fixed upstream and bumped in
https://github.com/NixOS/nixpkgs/commit/42fa8486dc767cce4bed3b5fb2fdb0f8928ee079

Signed-off-by: Austin Horstman <khaneliman12@gmail.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7318bf44791281bc614149718f46c5878feafd43"><pre>ocamlPackages.dream-html: fix adding ppxlib</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/082648cfc2a4d518f3486d337e18f14f2204ede1"><pre>ocamlPackages.caqti: 2.1.1 -> 2.2.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/eab40fa4f2af2b8214d192d81b8366c5efed20b3"><pre>ocamlPackages.caqti-eio: init at 2.2.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4868c12f4002e4bea45ca255677b86cddf4cf744"><pre>ocamlPackages.encore: 0.8 -> 0.8.1 (#414532)

* ocamlPackages.encore: 0.8 -> 0.8.1
Diff: https://github.com/mirage/encore/compare/v0.8...v0.8.1
Changelog: https://github.com/mirage/encore/releases/tag/v0.8.1

* ocamlPackages.encore: modernized derivation
- Removed duneVersion
- Added longDescription and changelog</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c0b96fce53b6d93ec90e01e3df927941a6f02fd7"><pre>ocamlPackages.directories: 0.5 -> 0.6 (#414677)

* ocamlPackages.directories: 0.5 -> 0.6
Changelog: https://github.com/OCamlPro/directories/releases/tag/0.6
Diff: https://github.com/OCamlPro/directories/compare/0.5...0.6

* ocamlPackages.directories: modernized derivation
- Rename: ocamlpro -> OCamlPro
- Added: meta.changelog
- Change: rev -> tag and sha256 -> hash
- Fix: minimalOCamlVersion</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/23328d1c2378b99b1a82b8a6c5e84d640904e0aa"><pre>ocamlPackages.janeStreet_0_15: remove</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/451f48f244841d744c1cdc3b1ce6002eaa08fbc0"><pre>ocamlPackages.eigen: 0.2.0 -> 0.3.3 (#414921)

* ocamlPackages.eigen: 0.2.0 -> 0.3.3
Diff: https://github.com/owlbarn/eigen/compare/0.2.0...0.3.3
Changelog: https://github.com/owlbarn/eigen/releases/tag/0.3.3

* ocamlPackages.eigen: modernized derivation
- Removed with lib;
- Changed rev to tag and sha256 to hash</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/526945c5798687e32d4a6f8a93660fe2ca152ae2...618b6dbfc21097d3101f3fc23e6597a2621eb04e