### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750317888,
-        "narHash": "sha256-gSy/wRFGYk10WtIyWjefLB1uyZo3U3hCuk87FXVZ2Us=",
+        "lastModified": 1750490923,
+        "narHash": "sha256-nFyooZtroT1pb5Y2G1nsfu+FDNSouMePSgmr1Eb6qcs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a269ce3952843c88718f4ae6046f6ac3aa944e9f",
+        "rev": "86c02c145a0b6ae0fab47564e0a003a967203f46",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a269ce3952843c88718f4ae6046f6ac3aa944e9f",
+        "rev": "86c02c145a0b6ae0fab47564e0a003a967203f46",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=a269ce3952843c88718f4ae6046f6ac3aa944e9f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=86c02c145a0b6ae0fab47564e0a003a967203f46";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/4868c12f4002e4bea45ca255677b86cddf4cf744"><pre>ocamlPackages.encore: 0.8 -> 0.8.1 (#414532)

* ocamlPackages.encore: 0.8 -> 0.8.1
Diff: https://github.com/mirage/encore/compare/v0.8...v0.8.1
Changelog: https://github.com/mirage/encore/releases/tag/v0.8.1

* ocamlPackages.encore: modernized derivation
- Removed duneVersion
- Added longDescription and changelog</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c0b96fce53b6d93ec90e01e3df927941a6f02fd7"><pre>ocamlPackages.directories: 0.5 -> 0.6 (#414677)

* ocamlPackages.directories: 0.5 -> 0.6
Changelog: https://github.com/OCamlPro/directories/releases/tag/0.6
Diff: https://github.com/OCamlPro/directories/compare/0.5...0.6

* ocamlPackages.directories: modernized derivation
- Rename: ocamlpro -> OCamlPro
- Added: meta.changelog
- Change: rev -> tag and sha256 -> hash
- Fix: minimalOCamlVersion</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/23328d1c2378b99b1a82b8a6c5e84d640904e0aa"><pre>ocamlPackages.janeStreet_0_15: remove</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/451f48f244841d744c1cdc3b1ce6002eaa08fbc0"><pre>ocamlPackages.eigen: 0.2.0 -> 0.3.3 (#414921)

* ocamlPackages.eigen: 0.2.0 -> 0.3.3
Diff: https://github.com/owlbarn/eigen/compare/0.2.0...0.3.3
Changelog: https://github.com/owlbarn/eigen/releases/tag/0.3.3

* ocamlPackages.eigen: modernized derivation
- Removed with lib;
- Changed rev to tag and sha256 to hash</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/92e2572f9be7adf8af48a98e8544058fef182ae6"><pre>ocamlPackages.scfg: init at 0.5

Co-authored-by: Vincent Laporte <Vincent.Laporte@gmail.com>
Signed-off-by: Ethan Carter Edwards <ethan@ethancedwards.com></pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/a269ce3952843c88718f4ae6046f6ac3aa944e9f...86c02c145a0b6ae0fab47564e0a003a967203f46