### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751331362,
-        "narHash": "sha256-U4PMIjimk9RQwERsPkd7+84WRoWgaeVGDo/XuydRpns=",
+        "lastModified": 1751529439,
+        "narHash": "sha256-fn4qiux6lOX2MEB5VU/KFUhjc4HuQON2SexwJnC1ibc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08ed4a9c085d54f04207ec4e8c5e0eddbe991229",
+        "rev": "f596e2141c241f5cca21188543cd4dcda32f2c3c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08ed4a9c085d54f04207ec4e8c5e0eddbe991229",
+        "rev": "f596e2141c241f5cca21188543cd4dcda32f2c3c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=08ed4a9c085d54f04207ec4e8c5e0eddbe991229";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=f596e2141c241f5cca21188543cd4dcda32f2c3c";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/1400a718678fe9eb28bae99b3871993478027a4c"><pre>ocamlPackages.ocaml_pcre: 8.0.3 -> 8.0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/268f3732e15850a9f99020bf9e29b34a6409e584"><pre>ocaml-augeas: update download URLs for debian patches

The current set of patches are not available at the old URLs,
because the Debian package revision was updated.

Switched the fetching strategy to pull directly from Salsa

The patch contents have not changed</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/909740f29dcaf4c572627111aa3cfad0bed86acf"><pre>ocamlPackages.ocaml_pcre: 8.0.3 -> 8.0.4 (#419109)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f5f1c7605e4a2e7fb465d124ae0dda9bddfcce10"><pre>ocaml-augeas: update download URLs for debian patches (#421267)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/08ed4a9c085d54f04207ec4e8c5e0eddbe991229...f596e2141c241f5cca21188543cd4dcda32f2c3c