### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751792365,
-        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
+        "lastModified": 1751867001,
+        "narHash": "sha256-3I49W0s3WVEDBO5S1RxYr74E2LLG7X8Wuvj9AmU0RDk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
+        "rev": "73feb5e20ec7259e280ca6f424ba165059b3bb6b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
+        "rev": "73feb5e20ec7259e280ca6f424ba165059b3bb6b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=1fd8bada0b6117e6c7eb54aad5813023eed37ccb";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=73feb5e20ec7259e280ca6f424ba165059b3bb6b";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/cb70f67e5b7b2a9c68c03a45e1d67dad93ab74f5"><pre>xen: enable strictDeps

Shuffles the input lists to ensure Xen works with \`strictDeps\` enabled.
There are more derivations in \`nativeBuildInputs\` than strictly
necessary for a successful build, but Xen calls for the OCaml and dev86
binaries during certain situations when building certain components.

Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net></pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/1fd8bada0b6117e6c7eb54aad5813023eed37ccb...73feb5e20ec7259e280ca6f424ba165059b3bb6b