### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751867001,
-        "narHash": "sha256-3I49W0s3WVEDBO5S1RxYr74E2LLG7X8Wuvj9AmU0RDk=",
+        "lastModified": 1752206449,
+        "narHash": "sha256-NVAbC/s4CupABWGXF8M9mDiVw/n0YCftxwc1KatVjDk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73feb5e20ec7259e280ca6f424ba165059b3bb6b",
+        "rev": "1bd4d0d4a678d48b63eb18f457d74df2fcee6c69",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73feb5e20ec7259e280ca6f424ba165059b3bb6b",
+        "rev": "1bd4d0d4a678d48b63eb18f457d74df2fcee6c69",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=73feb5e20ec7259e280ca6f424ba165059b3bb6b";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=1bd4d0d4a678d48b63eb18f457d74df2fcee6c69";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/430a1e6f49c1e1b98074646f79faa3632173c511"><pre>ocamlPackages.gapi-ocaml: 0.4.5 -> 0.4.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/911e5bf660fadc86972eebea5210dcae10d7fe9d"><pre>ocamlPackages.kdl: init at 0.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7e2b40e0250ae85d35f044dcc4f72aff4e2a8784"><pre>ocamlPackages.js_of_ocaml: 6.0.1 -> 6.1.0

Co-authored-by: Vincent Laporte <vbgl@users.noreply.github.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5c8499934295dd5b0ad89472f9f6b91a773d8643"><pre>ocamlPackages.gen_js_api: 1.1.4 -> 1.1.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/93d0e63a62bf5e870b4ec015535cdcda57ba7c5e"><pre>ocamlPackages.js_of_ocaml: 6.1.0 -> 6.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/43c98b9e4bb46a09aa2122c136500fda2cfcbe99"><pre>ocamlPackages.bytesrw: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/90d1463182d77a8379658da8dcfe4da75a7545c9"><pre>ocamlPackages.jsont: init at 0.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fd9a920f354417246dcf3f2c6062dc8d2f9ebea6"><pre>ocamlPackags.redis: init at 0.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/17a6fa3837787a1b9856d2377a0fe5494a4ab961"><pre>ocamlPackages.redis-lwt: init at 0.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b3cf32038f25ad14dd7a5f3c10845801a2c15126"><pre>ocamlPackages.lua-ml: 0.9.2 -> 0.9.4

Diff: https://github.com/lindig/lua-ml/compare/0.9.2...0.9.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1dcba47ef55717529748876b9eef5b8a9a341c50"><pre>ocamlPackages.kcas: 0.6.1 -> 0.7.0

Diff: https://github.com/ocaml-multicore/kcas/compare/0.6.1...0.7.0
Changelog: https://github.com/ocaml-multicore/kcas/releases/tag/0.7.0

ocamlPackages.kcas: add meta.longDescription and meta.changelog</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e5724bdebe4246c3a5f6eafb225668f0541516b8"><pre>ocamlPackages.mmap: 1.1.0 -> 1.2.0

Changelog: https://github.com/mirage/mmap/releases/tag/v1.2.0
Diff: https://github.com/mirage/mmap/compare/v1.1.0...v1.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e30021f627be31915b394f4349d740ad9c116372"><pre>ocamlPackages.amqp-client: init at 2.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1b405c80b4f3b3a0dacd04082ae5ec85d878012c"><pre>ocamlPackages.gapi-ocaml: 0.4.5 -> 0.4.6 (#409451)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/73feb5e20ec7259e280ca6f424ba165059b3bb6b...1bd4d0d4a678d48b63eb18f457d74df2fcee6c69