### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752913666,
-        "narHash": "sha256-t2xlRk7ZQEYWz+VljIq1c5Ad/Xrlb2ZD4fG71evjxrw=",
+        "lastModified": 1753004467,
+        "narHash": "sha256-QznRD2YNqBVT+LjrV36rIuOZO1XKbjm1BgtMTIrTDVg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2df148388c7e6c03f38134b54fab106f095d9b50",
+        "rev": "147633ad35aba48f75af49be7ddc956c71c35acc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2df148388c7e6c03f38134b54fab106f095d9b50",
+        "rev": "147633ad35aba48f75af49be7ddc956c71c35acc",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=2df148388c7e6c03f38134b54fab106f095d9b50";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=147633ad35aba48f75af49be7ddc956c71c35acc";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/cf1333af3b661221edf62befe40340cee8d39878"><pre>vscode-extensions.ocamllabs.ocaml-platform: 1.30.0 -> 1.30.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/568d62da90ce0c157133c01294ebe4a531f15a02"><pre>ocamlPackages.reason-react: improve coding style</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/46a4c640f05eb5f26e7951e11e5e7d9d425dfde1"><pre>ocamlformat_0_26_2: build with OCaml 5.2

Fixes eval, which previously failed with:

\`\`\`
ocamlformat 0.26.2 is not available for OCaml 5.3.0
\`\`\`</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8e22285f4c7c7efbd7f39a7a625df19d4340ae35"><pre>{ocamlformat_0_26_2,elixir_1_{14_15_16}}: fix build (#426643)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7377de7a5b95acd8f7ef30c28e8f38ba60a36cdd"><pre>ocamlPackages.reason-react: improve coding style (#425391)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/727f12e7b16c2efa0f5c91af7405718d53902148"><pre>vscode-extensions.ocamllabs.ocaml-platform: 1.30.0 -> 1.30.1 (#423749)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/147633ad35aba48f75af49be7ddc956c71c35acc"><pre>opencode: 0.3.22 -> 0.3.43 (#426844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/147633ad35aba48f75af49be7ddc956c71c35acc"><pre>opencode: 0.3.22 -> 0.3.43 (#426844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/147633ad35aba48f75af49be7ddc956c71c35acc"><pre>opencode: 0.3.22 -> 0.3.43 (#426844)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/2df148388c7e6c03f38134b54fab106f095d9b50...147633ad35aba48f75af49be7ddc956c71c35acc