### PR TITLE
[WIP] Add mingw support

### DIFF
--- a/cross/ocaml-compiler.nix
+++ b/cross/ocaml-compiler.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, natocamlPackages, writeScriptBin, osuper }:
+{ stdenv, lib, buildPackages, natocamlPackages, writeScriptBin, osuper, windows }:
 
 let
   natocaml = natocamlPackages.ocaml;
@@ -14,118 +14,72 @@ let
 
   ocamlcTargetWrapper = genWrapper "ocamlcTarget.wrapper" "$BUILD_ROOT/ocamlc.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -I ${natocaml}/lib/ocaml/stublibs -nostdlib ";
   ocamloptTargetWrapper = genWrapper "ocamloptTarget.wrapper" "$BUILD_ROOT/ocamlopt.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
-
 in
+
 osuper.ocaml.overrideAttrs (o:
 let isOCaml5 = lib.versionOlder "5.0" o.version;
 in {
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  depsBuildBuild = [ buildPackages.stdenv.cc natocaml ] ;
+
+  buildInputs = lib.optional stdenv.hostPlatform.isMinGW [
+    windows.mingw_w64_pthreads
+  ];
+
   preConfigure = ''
     configureFlagsArray+=("PARTIALLD=$LD -r" "ASPP=$CC -c")
     installFlagsArray+=("OCAMLRUN=${natocaml}/bin/ocamlrun")
   '';
+  # host is wrong
+  configurePlatforms = ["target"];
   configureFlags = o.configureFlags ++ [ "--disable-ocamldoc" ];
   postConfigure = ''
     cp Makefile.config Makefile.config.bak
     echo 'SAK_CC=${buildPackages.stdenv.cc}/bin/gcc' >> Makefile.config
     echo 'SAK_CFLAGS=$(OC_CFLAGS) $(OC_CPPFLAGS)' >> Makefile.config
     echo 'SAK_LINK=$(SAK_CC) $(SAK_CFLAGS) $(OUTPUTEXE)$(1) $(2)' >> Makefile.config
+    substituteInPlace Makefile.config --replace-fail \
+      -exe \
+      "-exe -L ${windows.mingw_w64_pthreads}/lib"
+    substituteInPlace Makefile.config --replace-fail \
+      -lgcc_eh \
+      ""
   '';
 
-  buildPhase = ''
-    runHook preBuild
-
-    OCAML_HOST=${natocaml}
-    OCAMLRUN="$OCAML_HOST/bin/ocamlrun"
-    OCAMLLEX="$OCAML_HOST/bin/ocamllex"
-    OCAMLYACC="$OCAML_HOST/bin/ocamlyacc"
-    CAMLDEP="$OCAML_HOST/bin/ocamlc"
-    DYNAMIC_LIBS="-I $OCAML_HOST/lib/ocaml/stublibs"
-    HOST_STATIC_LIBS="-I $OCAML_HOST/lib/ocaml"
-    TARGET_STATIC_LIBS="-I $PWD/stdlib -I $PWD/otherlibs/unix"
-
-    HOST_MAKEFILE_CONFIG="$OCAML_HOST/lib/ocaml/Makefile.config"
-    get_host_variable () {
-      cat $HOST_MAKEFILE_CONFIG | grep "$1=" | awk -F '=' '{print $2}'
-    }
-
-    NATDYNLINK=$(get_host_variable "NATDYNLINK")
-    NATDYNLINKOPTS=$(get_host_variable "NATDYNLINKOPTS")
-
-
-    make_caml () {
-      make ''${enableParallelBuilding:+-j $NIX_BUILD_CORES} ''${enableParallelBuilding:+-l $NIX_BUILD_CORES} \
-           CAMLDEP="$CAMLDEP -depend" \
-           OCAMLLEX="$OCAMLLEX" \
-           OCAMLYACC="$OCAMLYACC" CAMLYACC="$OCAMLYACC" \
-           CAMLRUN="$OCAMLRUN" OCAMLRUN="$OCAMLRUN" \
-           NEW_OCAMLRUN="$OCAMLRUN" \
-           CAMLC="$CAMLC" OCAMLC="$CAMLC" \
-           CAMLOPT="$CAMLOPT" OCAMLOPT="$CAMLOPT" \
-           $@
-    }
-
-    make_host () {
-      CAMLC="${ocamlcHostWrapper}/bin/ocamlcHost.wrapper"
-      CAMLOPT="${ocamloptHostWrapper}/bin/ocamloptHost.wrapper"
-
-      make_caml \
-        NATDYNLINK="$NATDYNLINK" NATDYNLINKOPTS="$NATDYNLINKOPTS" \
-        "$@"
-    }
-
-    make_target () {
-      CAMLC="${ocamlcTargetWrapper}/bin/ocamlcTarget.wrapper"
-      CAMLOPT="${ocamloptTargetWrapper}/bin/ocamloptTarget.wrapper"
-
-      make_caml BUILD_ROOT="$PWD" TARGET_OCAMLC="$TARGET_OCAMLC" TARGET_OCAMLOPT="$TARGET_OCAMLOPT" "$@"
-    }
-
-    make_host runtime coreall
-    make_host opt-core
-    make_host ocamlc.opt
-    make_host ocamlopt.opt
-    make_host compilerlibs/ocamltoplevel.cma otherlibraries \
-              ocamldebugger
-    make_host ocamllex.opt ocamltoolsopt \
-              ocamltoolsopt.opt ${if isOCaml5 then "othertools" else ""}
-
-    rm $(find . | grep -E '\.cm.?.$')
-    make_target -C stdlib all allopt
-    make_target ocaml ocamlc
-    make_target ocamlopt
-    make_target otherlibraries otherlibrariesopt ocamltoolsopt \
-                driver/main.cmx driver/optmain.cmx
-
-    # build the compiler shared libraries with the target `zstd.npic.o`
-    cp Makefile.config.bak Makefile.config
-    echo 'SAK_CC=${stdenv.cc.targetPrefix}gcc' >> Makefile.config
-    make_target compilerlibs/ocamlcommon.cmxa \
-                compilerlibs/ocamlbytecomp.cmxa \
-                compilerlibs/ocamloptcomp.cmxa
-    ${if isOCaml5 then "make_target othertools" else ""}
-
-    runHook postBuild
+  buildPhase = "make crossopt";
+  installTargets = [ "installcross" ] ;
+  postInstall = ''
+    ln -s $out/bin/ocaml.exe $out/bin/ocaml
+    ln -s $out/bin/ocamlc.exe $out/bin/ocamlc
+    ln -s $out/bin/ocamlopt.exe $out/bin/ocamlopt
   '';
-  installTargets = o.installTargets ++ [ "installoptopt" ];
-  postInstall = "cp ${natocaml}/bin/ocamlyacc $out/bin/ocamlyacc";
-  patches = [
-    (if lib.versionOlder "5.3" o.version
-    then ./cross_5_3.patch
+  patches =
+    ( if lib.versionOlder "5.4" o.version
+    then []
+    else if lib.versionOlder "5.3" o.version
+    then [./cross_5_3.patch]
     else if lib.versionOlder "5.2" o.version
-    then ./cross_5_2.patch
+    then [./cross_5_2.patch]
     else if lib.versionOlder "5.1" o.version
-    then ./cross_5_1.patch
+    then [./cross_5_1.patch]
     else if isOCaml5
-    then ./cross_5_00.patch
+    then [./cross_5_00.patch]
     else if lib.versionOlder "4.14" o.version
-    then ./cross_4_14.patch
+    then [./cross_4_14.patch]
     else if lib.versionOlder "4.13" o.version
-    then ./cross_4_13.patch
+    then [./cross_4_13.patch]
     else if lib.versionOlder "4.12" o.version
-    then ./cross_4_12.patch
+    then [./cross_4_12.patch]
     else if lib.versionOlder "4.11" o.version
-    then ./cross_4_11.patch
+    then [./cross_4_11.patch]
     else throw "OCaml ${o.version} not supported for cross-compilation")
+  ;
+  postPatch = [
+    ''
+    substituteInPlace \
+    runtime/dynlink.c \
+      --replace-fail \
+      OCAML_STDLIB_DIR \
+      "(char_os *) OCAML_STDLIB_DIR "
+    ''
   ];
 })

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -8,7 +8,7 @@
 # build time (e.g. OMP / ppxlib, etc that are possible to allow in the other
 # overlays).
 
-{ lib, buildPackages, writeText, writeScriptBin, makeWrapper, stdenv }:
+{ lib, buildPackages, writeText, writeScriptBin, makeWrapper, stdenv, fetchpatch, windows }:
 let
   __mergeInputs = acc: names: attrs:
     let
@@ -165,7 +165,7 @@ in
       ocaml = import ./ocaml-compiler.nix {
         inherit
           lib buildPackages writeScriptBin
-          natocamlPackages osuper stdenv;
+          natocamlPackages osuper stdenv windows;
       };
 
       findlib = osuper.findlib.overrideAttrs (o: {

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
             overlays = [ overlay ];
             config = {
               allowUnfree = true;
+              allowUnsupportedSystem = true;
             } // nixpkgs.lib.optionalAttrs (system == "x86_64-darwin") {
               config.replaceStdenv = { pkgs, ... }: pkgs.clang11Stdenv;
             };
@@ -49,5 +50,16 @@
       legacyPackages = nixpkgs.lib.genAttrs
         nixpkgs.lib.systems.flakeExposed
         (system: self.makePkgs { inherit system; });
+
+      packages.x86_64-linux.of =
+        let pkgs =
+        self.makePkgs
+        {
+          system = "x86_64-linux";
+          config.allowUnsupportedSystem = true;
+        };
+        xpkgs = pkgs.pkgsCross.mingwW64;
+        in
+        xpkgs.ocaml-ng.ocamlPackages_5_4.ocamlformat;
     };
 }

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -104,7 +104,8 @@ let
           owner = "ocaml";
           repo = "ocaml";
           rev = "5.3.0";
-          hash = "sha256-OxvfM0OF1XjtAMgAd+4Lm67iMKV7PD1sFmGPYn/yUBY=";
+          hash = "sha256-MJWrcuzJVoHM00ZRgFB5vjnJO0KfYXISPRByQlqFJco=";
+          fetchSubmodules = true;
         };
         postPatch = ''
           substituteInPlace "runtime/caml/camlatomic.h" \
@@ -122,7 +123,8 @@ let
           owner = "ocaml";
           repo = "ocaml";
           rev = "1d9d75abb1625a15ba9d6eed706acd6d04661c13";
-          hash = "sha256-0M01h6qaH4kJUzn9VbCkfnjSVilvRWYd8JwoZ9nenAI=";
+          hash = "sha256-P14wrLELunCvuiovOnWPeSUuQNp/VJgIo02Uk4yjl0I=";
+          fetchSubmodules = true;
         };
         postPatch = ''
           substituteInPlace "runtime/caml/camlatomic.h" \

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -62,6 +62,9 @@ in
           [ cross-overlay static-overlay ]);
 
       riscv64 = super.pkgsCross.riscv64.extend cross-overlay;
+
+      #mingw32 = super.pkgsCross.mingw32.extend cross-overlay;
+      mingwW64 = super.pkgsCross.mingwW64.extend cross-overlay;
     };
 
   # Override `pkgs.nix` to the unstable channel


### PR DESCRIPTION
Closes #2018

This is an "in flux" snapshot of my experiments to make cross-compilation to mingw work.

## Status

- this builds a 5.4 compiler that targets 64-bit mingw
- ocamlfind doesn't build
- the branch is very specific to mingw and hasn't been adapted to be generic in term of cross-compilation target

I've based this work on 5.4 because so many cross-compilation fixes have landed in this release cycle. As a consequence, I haven't imported any cross-compilation patch to the compiler. Instead, it relies on just the following sequence of commands to work:

    ./configure;
    make crossopt
    make installopt

(I used the [upstream instructions](https://github.com/ocaml/ocaml/blob/5.4.0-alpha1/INSTALL.adoc))

## Remarks

I'd like to list the quirks I faced while doing this:

### `host` vs `target` confusion

By default, nix was trying to build a compiler with `build=linux`, `host=mingw`, `target=mingw` (a compiler that would run on windows) instead of `build=linux`, `host=linux`, `target=mingw` (a compiler that runs on linux, whose resulting programs run on windows). I thought that this was an issue with the nix environment, but in the end, just passing `--target` to `./configure` fixes the issue.

### Bootstrapping `flexdll`

On Windows, it's necessary to build `flexdll` to get `flexlink` working. This can now be bootstrapped directly but it's necessary to fetch submodules for this to work.

Also, nix packages the pthreads implementation separately so it's necessary to alter the default link command to add a `-L` flag. I haven't found a way to do this with `./configure` flags (`LD_FLAGS=` sets `-link -L` which passes arguments to the linker and not to `flexlink` itself) so I patched `Makefile.config` instead.

### `.exe` extension

For a reason I haven't understood, this produces binaries with the `.exe` extension. I believe that this extension should be determined by `host` rather than `target`, but I'm not sure. I added symlinks.

## Next steps

The next failing step is to get `findlib` / `ocamlfind` to work. It doesn't seem to find libraries.
