### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753004467,
-        "narHash": "sha256-QznRD2YNqBVT+LjrV36rIuOZO1XKbjm1BgtMTIrTDVg=",
+        "lastModified": 1753088943,
+        "narHash": "sha256-cIyYVyDTSR6K3+xUGvEO3GAtBsdBhBcDALqHK50QEIQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "147633ad35aba48f75af49be7ddc956c71c35acc",
+        "rev": "91b279d8c68718659084298ea287c73b5bf6df2c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "147633ad35aba48f75af49be7ddc956c71c35acc",
+        "rev": "91b279d8c68718659084298ea287c73b5bf6df2c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=147633ad35aba48f75af49be7ddc956c71c35acc";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=91b279d8c68718659084298ea287c73b5bf6df2c";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/965c224275f14d7b0dcb1f49ad04cbb2e40c2da2"><pre>ocamlPackages.eio: 1.2 → 1.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2aa386b7818fdb2db67ddb1867d55edebc09ca6a"><pre>ocamlPackages.wayland: 2.1 -> 2.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1920e6c40417f0c6a002d88b475a369751d75563"><pre>ocamlPackages.processor: fix darwin build by updating

Signed-off-by: Ethan Carter Edwards <ethan@ethancedwards.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3291bd4e2923621174595b8d4544af7bd3f841ad"><pre>ocamlPackages.processor: fix darwin build by updating (#427038)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/91b279d8c68718659084298ea287c73b5bf6df2c"><pre>libfive: 0-unstable-2025-05-22 -> 0-unstable-2025-07-07 (#425743)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/91b279d8c68718659084298ea287c73b5bf6df2c"><pre>libfive: 0-unstable-2025-05-22 -> 0-unstable-2025-07-07 (#425743)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/91b279d8c68718659084298ea287c73b5bf6df2c"><pre>libfive: 0-unstable-2025-05-22 -> 0-unstable-2025-07-07 (#425743)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/147633ad35aba48f75af49be7ddc956c71c35acc...91b279d8c68718659084298ea287c73b5bf6df2c