### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754243818,
-        "narHash": "sha256-sEPw2W01UPf0xNGnMGNZIaE1XHkk7O+lLLetYEXVZHk=",
+        "lastModified": 1754330460,
+        "narHash": "sha256-L5eUA2YptCeQn3IKcJXCKZ8Vb97BCG/SgxnHpNLSEi0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c460617dfb709a67d18bb31e15e455390ee4ee1c",
+        "rev": "23c58a9c308f6652ab64a27595d75861a5f51fa6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c460617dfb709a67d18bb31e15e455390ee4ee1c",
+        "rev": "23c58a9c308f6652ab64a27595d75861a5f51fa6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=c460617dfb709a67d18bb31e15e455390ee4ee1c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=23c58a9c308f6652ab64a27595d75861a5f51fa6";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/4fcfcfd1428690dd80e768034f4a78ddec21516b"><pre>ocamlPackages.fmt: 0.10.0 -> 0.11.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d939ad55b2a02356e341c21d9fa551338ab54267"><pre>ocamlPackages.fmt: 0.10.0 -> 0.11.0 (#429250)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/284d8dacdf642b8c4149a4a1bed76820693fd853"><pre>ocamlPackages.ocsipersist: 1.1.0 → 2.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e2e7d2b3b07e7c2abd14e888b0be0ecaf4ef3353"><pre>ocamlPackages.ocsipersist-sqlite-config: init at 2.0.0

ocamlPackages.ocsipersist-pgsql-config: init at 2.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/77b1e1a66b961da0243d540a22945c079ae38001"><pre>ocamlPackages.js_of_ocaml: 6.1.1 -> 6.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5fadf32beefe590c26d9dc0dd33f8b9c9c213579"><pre>ocamlPackages.ocsigen-start: 6.2.0 → 7.1.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/c460617dfb709a67d18bb31e15e455390ee4ee1c...23c58a9c308f6652ab64a27595d75861a5f51fa6