### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754243818,
-        "narHash": "sha256-sEPw2W01UPf0xNGnMGNZIaE1XHkk7O+lLLetYEXVZHk=",
+        "lastModified": 1754535410,
+        "narHash": "sha256-zAkPxVZ90Yb/qerKzk3gsO3igOTaPE0558jDrqmaaSM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c460617dfb709a67d18bb31e15e455390ee4ee1c",
+        "rev": "ff774a42892b6893e786761060ea3f2d1bf2d7e5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c460617dfb709a67d18bb31e15e455390ee4ee1c",
+        "rev": "ff774a42892b6893e786761060ea3f2d1bf2d7e5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=c460617dfb709a67d18bb31e15e455390ee4ee1c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=ff774a42892b6893e786761060ea3f2d1bf2d7e5";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/4fcfcfd1428690dd80e768034f4a78ddec21516b"><pre>ocamlPackages.fmt: 0.10.0 -> 0.11.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d939ad55b2a02356e341c21d9fa551338ab54267"><pre>ocamlPackages.fmt: 0.10.0 -> 0.11.0 (#429250)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/410780274cb55322cc0dd3b355d60022b01879a1"><pre>vscode-extensions.ocamllabs.ocaml-platform: 1.30.1 -> 1.32.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/284d8dacdf642b8c4149a4a1bed76820693fd853"><pre>ocamlPackages.ocsipersist: 1.1.0 → 2.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e2e7d2b3b07e7c2abd14e888b0be0ecaf4ef3353"><pre>ocamlPackages.ocsipersist-sqlite-config: init at 2.0.0

ocamlPackages.ocsipersist-pgsql-config: init at 2.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/77b1e1a66b961da0243d540a22945c079ae38001"><pre>ocamlPackages.js_of_ocaml: 6.1.1 -> 6.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5fadf32beefe590c26d9dc0dd33f8b9c9c213579"><pre>ocamlPackages.ocsigen-start: 6.2.0 → 7.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b7b012669c65be443c1b0c4feae3db1c68698863"><pre>vscode-extensions.ocamllabs.ocaml-platform: 1.30.1 -> 1.32.0 (#430822)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ec67179301f61cc095578cf9ee822dc1cfc1f4e0"><pre>ocamlPackages.logs-syslog: init at 0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3fc72d286c51962d0a0deffc29d23bcd9fe30bed"><pre>ocamlPackages.elpi: 2.0.7 -> 3.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/22ae0b20d009c3228d863d0c495302e64eabf8e1"><pre>ocamlPackages.jsont: flags to turn off optional dependencies</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8ee7cb99fb78981733c64e2e0c60b957261843f0"><pre>ocamlPackages.ppx_deriving: propagate \`ppxlib\` dependency

this fixes an error when using \`ppx_deriving\` in a downstream project.

\`\`\`
ocaml5.3.0-basil_lsp> File \"/nix/store/x-ocaml5.3.0-ppx_deriving-6.0.3/lib/ocaml/5.3.0/site-lib/ppx_deriving/META\", line 1, characters 0-0:
ocaml5.3.0-basil_lsp> Error: Library \"ppxlib.ast\" not found.
ocaml5.3.0-basil_lsp> -> required by library \"ppx_deriving.show\" in
ocaml5.3.0-basil_lsp>    /nix/store/x-ocaml5.3.0-ppx_deriving-6.0.3/lib/ocaml/5.3.0/site-lib/ppx_deriving/show
\`\`\`</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/c460617dfb709a67d18bb31e15e455390ee4ee1c...ff774a42892b6893e786761060ea3f2d1bf2d7e5