### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754372978,
-        "narHash": "sha256-ByII9p9ek0k9UADC/hT+i9ueM2mw0Zxiz+bOlydU6Oo=",
+        "lastModified": 1754535410,
+        "narHash": "sha256-zAkPxVZ90Yb/qerKzk3gsO3igOTaPE0558jDrqmaaSM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ebe222ec7ef9de52478f76cba3f0324c1d1119f",
+        "rev": "ff774a42892b6893e786761060ea3f2d1bf2d7e5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ebe222ec7ef9de52478f76cba3f0324c1d1119f",
+        "rev": "ff774a42892b6893e786761060ea3f2d1bf2d7e5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=9ebe222ec7ef9de52478f76cba3f0324c1d1119f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=ff774a42892b6893e786761060ea3f2d1bf2d7e5";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/ec67179301f61cc095578cf9ee822dc1cfc1f4e0"><pre>ocamlPackages.logs-syslog: init at 0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3fc72d286c51962d0a0deffc29d23bcd9fe30bed"><pre>ocamlPackages.elpi: 2.0.7 -> 3.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/22ae0b20d009c3228d863d0c495302e64eabf8e1"><pre>ocamlPackages.jsont: flags to turn off optional dependencies</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8ee7cb99fb78981733c64e2e0c60b957261843f0"><pre>ocamlPackages.ppx_deriving: propagate \`ppxlib\` dependency

this fixes an error when using \`ppx_deriving\` in a downstream project.

\`\`\`
ocaml5.3.0-basil_lsp> File \"/nix/store/x-ocaml5.3.0-ppx_deriving-6.0.3/lib/ocaml/5.3.0/site-lib/ppx_deriving/META\", line 1, characters 0-0:
ocaml5.3.0-basil_lsp> Error: Library \"ppxlib.ast\" not found.
ocaml5.3.0-basil_lsp> -> required by library \"ppx_deriving.show\" in
ocaml5.3.0-basil_lsp>    /nix/store/x-ocaml5.3.0-ppx_deriving-6.0.3/lib/ocaml/5.3.0/site-lib/ppx_deriving/show
\`\`\`</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/9ebe222ec7ef9de52478f76cba3f0324c1d1119f...ff774a42892b6893e786761060ea3f2d1bf2d7e5