### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755061300,
-        "narHash": "sha256-eov82CkCrpiECJa3dyQ2da1sPGnAP3HK0UEra5eupaM=",
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4df8d6cc1ccfd3e4349a1d54e4fb1171e7ec1f5",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4df8d6cc1ccfd3e4349a1d54e4fb1171e7ec1f5",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=d4df8d6cc1ccfd3e4349a1d54e4fb1171e7ec1f5";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=fbcf476f790d8a217c3eab4e12033dc4a0f6d23c";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/ce58e665f1ef2425994878fa0897c1cc89cde2ce"><pre>ocamlPackages.unisim_archisec: 0.0.11 -> 0.0.12</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/92375e4bc96f330075ff5d201fb2f5d70ab57434"><pre>ocamlPackages.colombe: init at 0.12.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8c5b5260ecc17fdfd2c41e816b46ff43af91bf61"><pre>ocamlPackages.sendmail: init at 0.12.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ad911115b254a2f6185c7e5ebd0469dfc4fb9841"><pre>ocamlPackages.letters: init at 0.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/df15cfaf62e8f00d6ae99c475977324c7cada722"><pre>ocamlPackages.unisim_archisec: 0.0.11 -> 0.0.12 (#433179)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0934d9650897f21d297740775c624378c632fb58"><pre>ocamlPackages.lwd: 0.3 → 0.4

ocamlPackages.nottui-unix: init at 0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4ae8242fb8473ea1d68d88814cd0435e499ab9b0"><pre>ocamlPackages.patch: 2.0.0 -> 3.0.0

ocamlPackages.ray{lib,gui}: fix with patch 3.0.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/d4df8d6cc1ccfd3e4349a1d54e4fb1171e7ec1f5...fbcf476f790d8a217c3eab4e12033dc4a0f6d23c