### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755578972,
-        "narHash": "sha256-3VxpGUb5akZOiCSK/uuIRLuELma0a75Xqlf444c1eoA=",
+        "lastModified": 1755716446,
+        "narHash": "sha256-AdVENrXoFws0sENT2Sz9SMavbqVJnATmCODuqJ7GcSs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9512947ff97e22508c33fbf002a5141e1ee8a15d",
+        "rev": "b0eccfbc0168243438e8a6747fcdfb1bb796a3f7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9512947ff97e22508c33fbf002a5141e1ee8a15d",
+        "rev": "b0eccfbc0168243438e8a6747fcdfb1bb796a3f7",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=9512947ff97e22508c33fbf002a5141e1ee8a15d";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=b0eccfbc0168243438e8a6747fcdfb1bb796a3f7";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/70b9b7c6f84d44dc2dbc159d316052012e295edc"><pre>ocamlPackages.ca-certs-nss: 3.114 -> 3.115</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/42b331d9224f00baa024808bd9e665401da29958"><pre>ocamlPackages.ca-certs-nss: 3.114 -> 3.115 (#434050)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0f147d22bb9726c47ca504d639e53a0cad23643b"><pre>ocaml-ng.ocamlPackages_4_14.bap: unpin LLVM</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2318ee749e5361c6ff8b9b194eb4bfbb61b4c1ef"><pre>ocamlPackages.mlx: 0.9 -> 0.10</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/97eb7ee0da337d385ab015a23e15022c865be75c"><pre>ocamlPackages.ppxlib: 0.33.0 → 0.36.0

ocamlPackages.base_quickcheck: 0.17.0 → 0.17.1
ocamlPackages.optcomp: 0.17.0 → 0.17.1
ocamlPackages.ppx_bench: 0.17.0 → 0.17.1
ocamlPackages.ppx_bin_prot: 0.17.0 → 0.17.1
ocamlPackages.ppx_deriving: 6.0.3 → 6.1.0
ocamlPackages.ppx_deriving_qcheck: 0.6 → 0.7
ocamlPackages.ppx_deriving_yaml: 0.3.0 → 0.4.1
ocamlPackages.ppx_deriving_yojson: 3.9.0 → 3.10.0
ocamlPackages.ppx_diff: 0.17.0 → 0.17.1
ocamlPackages.ppx_expect: 0.17.2 → 0.17.3
ocamlPackages.ppx_globalize: 0.17.0 → 0.17.2
ocamlPackages.ppx_inline_test: 0.17.0 → 0.17.1
ocamlPackages.ppx_let: 0.17.0 → 0.17.1
ocamlPackages.ppx_stable: 0.17.0 → 0.17.1
ocamlPackages.ppx_tydi: 0.17.0 → 0.17.1
ocamlPackages.ppx_typeprep_conv: 0.17.0 → 0.17.1
ocamlPackages.ppx_variants_conv: 0.17.0 → 0.17.1
ocamlPackages.sexp_conv: 0.17.0 → 0.17.1
ocamlPackages.sexp_message: 0.17.2 → 0.17.4
reason: 3.15.0 → 3.16.0

ocamlPackages.bisect_ppx: make compatible with ppxlib 0.36
ocamlPackages.config: make compatible with ppxlib 0.36
ocamlPackages.lwt_ppx: make compatible with ppxlib 0.36
ocamlPackages.melange: make compatible with ppxlib 0.36
ocamlPackages.ppx_bitstring: make compatible with ppxlib 0.36
ocamlPackages.ppx_repr: make compatible with ppxlib 0.36

ocamlPackages.bistro: mark as broken
ocamlPackages.dream-html: mark as broken
ocamlPackages.ocsigen-ppx-rpc: mark as broken
ocamlPackages.ppx_deriving_cmdliner: mark as broken
ocamlPackages.reason-react-ppx: mark as broken</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/fbcf476f790d8a217c3eab4e12033dc4a0f6d23c...b0eccfbc0168243438e8a6747fcdfb1bb796a3f7