### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755716446,
-        "narHash": "sha256-AdVENrXoFws0sENT2Sz9SMavbqVJnATmCODuqJ7GcSs=",
+        "lastModified": 1755932510,
+        "narHash": "sha256-3VHKh+Lsi5jf1LmfjRjCnEvaYe+1wANj0HtA/6jks2M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0eccfbc0168243438e8a6747fcdfb1bb796a3f7",
+        "rev": "c58ada2eda15d0576e9a2ad74bd8f2318509a40f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0eccfbc0168243438e8a6747fcdfb1bb796a3f7",
+        "rev": "c58ada2eda15d0576e9a2ad74bd8f2318509a40f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=b0eccfbc0168243438e8a6747fcdfb1bb796a3f7";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c58ada2eda15d0576e9a2ad74bd8f2318509a40f";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/0b35f8970dfdad4e45c387524cdf55771e44a9f8"><pre>ocamlPackages.macaddr: 5.6.0 -> 5.6.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/70b9b7c6f84d44dc2dbc159d316052012e295edc"><pre>ocamlPackages.ca-certs-nss: 3.114 -> 3.115</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/42b331d9224f00baa024808bd9e665401da29958"><pre>ocamlPackages.ca-certs-nss: 3.114 -> 3.115 (#434050)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0f147d22bb9726c47ca504d639e53a0cad23643b"><pre>ocaml-ng.ocamlPackages_4_14.bap: unpin LLVM</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2318ee749e5361c6ff8b9b194eb4bfbb61b4c1ef"><pre>ocamlPackages.mlx: 0.9 -> 0.10</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/97eb7ee0da337d385ab015a23e15022c865be75c"><pre>ocamlPackages.ppxlib: 0.33.0 → 0.36.0

ocamlPackages.base_quickcheck: 0.17.0 → 0.17.1
ocamlPackages.optcomp: 0.17.0 → 0.17.1
ocamlPackages.ppx_bench: 0.17.0 → 0.17.1
ocamlPackages.ppx_bin_prot: 0.17.0 → 0.17.1
ocamlPackages.ppx_deriving: 6.0.3 → 6.1.0
ocamlPackages.ppx_deriving_qcheck: 0.6 → 0.7
ocamlPackages.ppx_deriving_yaml: 0.3.0 → 0.4.1
ocamlPackages.ppx_deriving_yojson: 3.9.0 → 3.10.0
ocamlPackages.ppx_diff: 0.17.0 → 0.17.1
ocamlPackages.ppx_expect: 0.17.2 → 0.17.3
ocamlPackages.ppx_globalize: 0.17.0 → 0.17.2
ocamlPackages.ppx_inline_test: 0.17.0 → 0.17.1
ocamlPackages.ppx_let: 0.17.0 → 0.17.1
ocamlPackages.ppx_stable: 0.17.0 → 0.17.1
ocamlPackages.ppx_tydi: 0.17.0 → 0.17.1
ocamlPackages.ppx_typeprep_conv: 0.17.0 → 0.17.1
ocamlPackages.ppx_variants_conv: 0.17.0 → 0.17.1
ocamlPackages.sexp_conv: 0.17.0 → 0.17.1
ocamlPackages.sexp_message: 0.17.2 → 0.17.4
reason: 3.15.0 → 3.16.0

ocamlPackages.bisect_ppx: make compatible with ppxlib 0.36
ocamlPackages.config: make compatible with ppxlib 0.36
ocamlPackages.lwt_ppx: make compatible with ppxlib 0.36
ocamlPackages.melange: make compatible with ppxlib 0.36
ocamlPackages.ppx_bitstring: make compatible with ppxlib 0.36
ocamlPackages.ppx_repr: make compatible with ppxlib 0.36

ocamlPackages.bistro: mark as broken
ocamlPackages.dream-html: mark as broken
ocamlPackages.ocsigen-ppx-rpc: mark as broken
ocamlPackages.ppx_deriving_cmdliner: mark as broken
ocamlPackages.reason-react-ppx: mark as broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f24c0439ea1296e295445e0d8117d282bdacaa9a"><pre>ocamlPackages.multicore-magic: 2.3.0 → 2.3.1</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/fbcf476f790d8a217c3eab4e12033dc4a0f6d23c...c58ada2eda15d0576e9a2ad74bd8f2318509a40f

#### Error

Error occurred, there could be relevant commits missing