### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755932510,
-        "narHash": "sha256-3VHKh+Lsi5jf1LmfjRjCnEvaYe+1wANj0HtA/6jks2M=",
+        "lastModified": 1756104823,
+        "narHash": "sha256-wRzHREXDOrbCjy+sqo4t3JoInbB2PuhXIUa8NWdh9tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c58ada2eda15d0576e9a2ad74bd8f2318509a40f",
+        "rev": "d7967bed5381e65208f4fb8d5502e3c36bb94759",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c58ada2eda15d0576e9a2ad74bd8f2318509a40f",
+        "rev": "d7967bed5381e65208f4fb8d5502e3c36bb94759",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=c58ada2eda15d0576e9a2ad74bd8f2318509a40f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=d7967bed5381e65208f4fb8d5502e3c36bb94759";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/0b35f8970dfdad4e45c387524cdf55771e44a9f8"><pre>ocamlPackages.macaddr: 5.6.0 -> 5.6.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1a5c67af7553db8873a2f5e15c841acf0c910885"><pre>ocamlPackages.miou: 0.3.1 -> 0.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/af11cb39826d288518e8261aaab465e78a70ac23"><pre>ocamlPackages.smtml: 0.8.0 -> 0.9.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d7d8907aee150e8f57f497e628fc27ad2024bebc"><pre>ocamlPackages.multipart_form: 0.6.0 -> 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/70b9b7c6f84d44dc2dbc159d316052012e295edc"><pre>ocamlPackages.ca-certs-nss: 3.114 -> 3.115</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/42b331d9224f00baa024808bd9e665401da29958"><pre>ocamlPackages.ca-certs-nss: 3.114 -> 3.115 (#434050)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0f147d22bb9726c47ca504d639e53a0cad23643b"><pre>ocaml-ng.ocamlPackages_4_14.bap: unpin LLVM</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2318ee749e5361c6ff8b9b194eb4bfbb61b4c1ef"><pre>ocamlPackages.mlx: 0.9 -> 0.10</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/97eb7ee0da337d385ab015a23e15022c865be75c"><pre>ocamlPackages.ppxlib: 0.33.0 → 0.36.0

ocamlPackages.base_quickcheck: 0.17.0 → 0.17.1
ocamlPackages.optcomp: 0.17.0 → 0.17.1
ocamlPackages.ppx_bench: 0.17.0 → 0.17.1
ocamlPackages.ppx_bin_prot: 0.17.0 → 0.17.1
ocamlPackages.ppx_deriving: 6.0.3 → 6.1.0
ocamlPackages.ppx_deriving_qcheck: 0.6 → 0.7
ocamlPackages.ppx_deriving_yaml: 0.3.0 → 0.4.1
ocamlPackages.ppx_deriving_yojson: 3.9.0 → 3.10.0
ocamlPackages.ppx_diff: 0.17.0 → 0.17.1
ocamlPackages.ppx_expect: 0.17.2 → 0.17.3
ocamlPackages.ppx_globalize: 0.17.0 → 0.17.2
ocamlPackages.ppx_inline_test: 0.17.0 → 0.17.1
ocamlPackages.ppx_let: 0.17.0 → 0.17.1
ocamlPackages.ppx_stable: 0.17.0 → 0.17.1
ocamlPackages.ppx_tydi: 0.17.0 → 0.17.1
ocamlPackages.ppx_typeprep_conv: 0.17.0 → 0.17.1
ocamlPackages.ppx_variants_conv: 0.17.0 → 0.17.1
ocamlPackages.sexp_conv: 0.17.0 → 0.17.1
ocamlPackages.sexp_message: 0.17.2 → 0.17.4
reason: 3.15.0 → 3.16.0

ocamlPackages.bisect_ppx: make compatible with ppxlib 0.36
ocamlPackages.config: make compatible with ppxlib 0.36
ocamlPackages.lwt_ppx: make compatible with ppxlib 0.36
ocamlPackages.melange: make compatible with ppxlib 0.36
ocamlPackages.ppx_bitstring: make compatible with ppxlib 0.36
ocamlPackages.ppx_repr: make compatible with ppxlib 0.36

ocamlPackages.bistro: mark as broken
ocamlPackages.dream-html: mark as broken
ocamlPackages.ocsigen-ppx-rpc: mark as broken
ocamlPackages.ppx_deriving_cmdliner: mark as broken
ocamlPackages.reason-react-ppx: mark as broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f24c0439ea1296e295445e0d8117d282bdacaa9a"><pre>ocamlPackages.multicore-magic: 2.3.0 → 2.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/17ef695a1ebfd1e51d1782651b1578cdabbc2f4d"><pre>ocamlPackages.multicore-bench: 0.1.4 → 0.1.7</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/02470df4afc60cf587d41effab402848ba029819"><pre>ocamlPackages.macaddr: 5.6.0 -> 5.6.1 (#430122)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1db9595838f0b93c7f597c28dce81b8d0fbe7e6a"><pre>ocamlPackages.smtml: 0.8.0 -> 0.9.0 (#433088)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2bb4ea49e54c783e0661f19061cabcac890732d1"><pre>ocamlPackages.miou: 0.3.1 -> 0.4.0 (#431556)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b2ba844c1b7664c8f82cf158b9fe94240da2860d"><pre>ocamlPackages.multipart_form: 0.6.0 -> 0.7.0 (#433433)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/35f1742e4f1470817ff8203185e2ce0359947f12...d7967bed5381e65208f4fb8d5502e3c36bb94759