### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756266583,
-        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
+        "lastModified": 1756892917,
+        "narHash": "sha256-hVsGRW6M3Rd2xSlKowNREyVHXCUbxHoktu1ujgxT4x8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
+        "rev": "3f29c71a26f20c830b3708d02bfa62fb1890354a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
+        "rev": "3f29c71a26f20c830b3708d02bfa62fb1890354a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=8a6d5427d99ec71c64f0b93d45778c889005d9c2";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=3f29c71a26f20c830b3708d02bfa62fb1890354a";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/be67eb0d5c7fcd482b78f0588f344c4b88e83046"><pre>ocamlPackages.resto: remove at 1.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c6bcb7dfb18861ed106239dbf062f027b5e4e862"><pre>ocamlPackages.bstr: init at 0.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a03ce7ebd7f03ea82fb5bf611fe4c8f73d8f3c78"><pre>ocamlPackages.h1: 1.0.0 → 1.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/da8cdb8c9b78011bef9d5920a2acee3f45bd3f47"><pre>ocamlPackages.smtml: 0.9.0 -> 0.10.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f2c822b65f4e8554a7ae7c55f910e3833307dbef"><pre>ocamlPackages.lwt: 5.9.1 → 5.9.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8646483b76ee79c64157944ca8efcc359ba7c290"><pre>liquidsoap: 2.3.0 → 2.3.3

ocamlPackages.ogg: 0.7.4 → 1.0.0
ocamlPackages.flac: 0.5.1 → 1.0.0
ocamlPackages.opus: 0.2.2 → 1.0.0
ocamlPackages.speex: 0.4.1 → 1.0.0
ocamlPackages.theora: 0.4.1 → 1.0.0
ocamlPackages.vorbis: 0.8.0 → 1.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ae722887cbb28282e08d818bf867318e6fc8859e"><pre>ocamlPackages.smtml: 0.9.0 -> 0.10.0 (#438782)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/695187d203bdee681c4c485b5fa60a85f61e8fdf"><pre>ocamlPackages.num: 1.1 → 1.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f8130d1b5524b6c995c2aa684db8d4a0488f0ac5"><pre>ocamlPackages.num: 1.1 → 1.6 (#439295)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/726648b296370c35513f5a7488fe3623f810bf5a"><pre>ocamlPackages.lwt: 5.9.1 → 5.9.2 (#439077)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4e953f18c33339776e8964391532a014fbe5d349"><pre>ocamlPackages.h1: 1.0.0 → 1.1.0 (#437795)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3f29c71a26f20c830b3708d02bfa62fb1890354a"><pre>golangci-lint: Build with go 1.25 (#433687)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/8a6d5427d99ec71c64f0b93d45778c889005d9c2...3f29c71a26f20c830b3708d02bfa62fb1890354a