### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757752761,
-        "narHash": "sha256-HBM2YTKSegLZjdamfqH9KADj2zQBQBNQHmwdrYkatpg=",
+        "lastModified": 1757839328,
+        "narHash": "sha256-1pHXwkoGSVVlux+4ryyxsm/D6jmYnqBqekPZlN6mVyg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4b46c744cbd5f9336027dff287e74ead84d80041",
+        "rev": "a870b7409045459d9a4011ddd6a42acbb2faed9c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4b46c744cbd5f9336027dff287e74ead84d80041",
+        "rev": "a870b7409045459d9a4011ddd6a42acbb2faed9c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=4b46c744cbd5f9336027dff287e74ead84d80041";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=a870b7409045459d9a4011ddd6a42acbb2faed9c";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/ff6fc870da9daa16943b2fe7fba73accea49eb52"><pre>ocamlPackages.tdigest: 2.2.0 -> 2.2.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2e2b1aad5c057af23941247e71c0cd385ec82c88"><pre>ocamlPackages.bitwuzla-cxx: 0.8.0 -> 0.8.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c6aaa779e8a6eab6e324b294ff9e14f5d8f79d73"><pre>ocamlPackages.mirage-ptime: 5.0.0 -> 5.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/363f11d416ec5fb6dc2b220a8f5d7b53d245d550"><pre>ocamlPackages.mirage-sleep: 4.0.0 -> 4.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9b20aeaf34d48abf54d0dcdc71372b51660b92d6"><pre>ocamlPackages.mirage-mtime: 5.0.0 -> 5.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fc9aa52b83227d4fe6280848154fb6f04cba7563"><pre>ocamlPackages.mirage-sleep: 4.0.0 -> 4.1.0 (#439191)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/905f0f5f4081abe1695f4fedd7f4679a1e2033bf"><pre>ocamlPackages.mirage-ptime: 5.0.0 -> 5.1.0 (#439190)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/747fceb46f80bf67ca5afbf90cca2a28fdf4184b"><pre>ocamlPackages.bitwuzla-cxx: 0.8.0 -> 0.8.2 (#438865)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7d5533eb17bd2c0ee8156a279b4ade73af12d0bc"><pre>ocamlPackages.mirage-mtime: 5.0.0 -> 5.2.0 (#436474)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b706a834b87a99b0c7e394e0980fae8127716cfc"><pre>ocamlPackages.tdigest: 2.2.0 -> 2.2.1 (#408184)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a870b7409045459d9a4011ddd6a42acbb2faed9c"><pre>cargo-tally: 1.0.69 -> 1.0.70 (#442824)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a870b7409045459d9a4011ddd6a42acbb2faed9c"><pre>cargo-tally: 1.0.69 -> 1.0.70 (#442824)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a870b7409045459d9a4011ddd6a42acbb2faed9c"><pre>cargo-tally: 1.0.69 -> 1.0.70 (#442824)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a870b7409045459d9a4011ddd6a42acbb2faed9c"><pre>cargo-tally: 1.0.69 -> 1.0.70 (#442824)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a870b7409045459d9a4011ddd6a42acbb2faed9c"><pre>cargo-tally: 1.0.69 -> 1.0.70 (#442824)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/4b46c744cbd5f9336027dff287e74ead84d80041...a870b7409045459d9a4011ddd6a42acbb2faed9c