### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758098782,
-        "narHash": "sha256-sX+iNoZkgSQsnsCHO6aI7mYh2GqbYDLWMB0iN41i61k=",
+        "lastModified": 1758395428,
+        "narHash": "sha256-VPLAH58pBb+6qHXKy/RbJi0jedJ14atDh3r5VNB1uNk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5874893c92e656c85dc729e8b570fc38d3c85853",
+        "rev": "2e894638a7716cb1161a1084e04af88d98684855",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5874893c92e656c85dc729e8b570fc38d3c85853",
+        "rev": "2e894638a7716cb1161a1084e04af88d98684855",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5874893c92e656c85dc729e8b570fc38d3c85853";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=2e894638a7716cb1161a1084e04af88d98684855";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/cb965e378b014d0f690415c5dc41859fea3f00b4"><pre>ocamlPackages.utop: 2.15.0 → 2.16.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3b170a009b9d4218538a0aed1f64b82b3a30cb6"><pre>ocamlPackages.ppx_deriving: 6.1.0 → 6.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9eac097f75e7fe8782a0aff0a3ff087c427dd8ce"><pre>ocamlPackages.topkg: 1.0.7 → 1.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/189bb2b717533f1109f9ba48eeaeac201bd5a284"><pre>ocamlPackages.iomux: 0.3 → 0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/42e3b31fadc33f449dccf8a6c81f9f128fc8b188"><pre>ocamlPackages.iomux: 0.3 → 0.4 (#443748)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1333a68ece2752ed15e35cfe1b5d3e9d633a89a4"><pre>ocamlPackages.utop: 2.15.0 → 2.16.0 (#442419)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a246280b51a96cad3a8449969d25dade07cf5de4"><pre>coqPackages.autosubst-ocaml: 1.1+8.20 -> 1.1+9.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cd10096566f6ad2ff6746a49655d7b4c3498f863"><pre>coqPackages.autosubst-ocaml: 1.1+8.20 -> 1.1+9.0 (#443607)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ae75f3f0248f02f298dc6fca929d0412bce46029"><pre>ocamlPackages.ppx_deriving: 6.1.0 → 6.1.1 (#442552)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/12bd230118a1901a4a5d393f9f56b6ad7e571d01"><pre>ocamlPackages.topkg: 1.0.7 → 1.1.0 (#443627)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5874893c92e656c85dc729e8b570fc38d3c85853...2e894638a7716cb1161a1084e04af88d98684855