### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758098782,
-        "narHash": "sha256-sX+iNoZkgSQsnsCHO6aI7mYh2GqbYDLWMB0iN41i61k=",
+        "lastModified": 1759240490,
+        "narHash": "sha256-RPoiXImMd8sEYqOFd71pis08RheOgrd859E+5CIp6Sw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5874893c92e656c85dc729e8b570fc38d3c85853",
+        "rev": "b6f6c613838dd776620c34e8f15fe4d8a9cdf9c0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5874893c92e656c85dc729e8b570fc38d3c85853",
+        "rev": "b6f6c613838dd776620c34e8f15fe4d8a9cdf9c0",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5874893c92e656c85dc729e8b570fc38d3c85853";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=b6f6c613838dd776620c34e8f15fe4d8a9cdf9c0";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/cf1b86f4640a434e44f1e5aa965f050b894ff5e1"><pre>ocamlPackages.unionFind: 20220122 -> 20250818</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/abb5c4631098eca5c9ac01f7a2ddb573348d35b5"><pre>ocamlPackages.tls-eio: 2.0.1 -> 2.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b854517ed358f574ffa7e019bca52157421b8a6d"><pre>ocamlPackages.mirage-crypto: 2.0.1 -> 2.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b6ea50cbadccb5bc01cd099b0e537ac769e5f9dd"><pre>ocamlPackages.github: 4.4.1 -> 4.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/010cf0010c1a789676ccb19bd7efbe188e220f25"><pre>vscode-extensions.ocamllabs.ocaml-platform: 1.32.0 -> 1.32.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cb965e378b014d0f690415c5dc41859fea3f00b4"><pre>ocamlPackages.utop: 2.15.0 → 2.16.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3b170a009b9d4218538a0aed1f64b82b3a30cb6"><pre>ocamlPackages.ppx_deriving: 6.1.0 → 6.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7f9ad8535b0662a4c9be030d91eaa5151c638ff0"><pre>ocamlPackages.reason: 3.16.0 → 3.17.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2f7398ef44d0b8276746231a9637366dc32e2ae9"><pre>ocamlPackages.odoc: 2.4.4 → 3.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f7fa6b751beb1d306e74aaf83ff509c2b69879c6"><pre>ocamlPackages.lambdapi: 2.6.0 → 3.0.0

ocamlPackages.pratter: 3.0.0 → 5.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9eac097f75e7fe8782a0aff0a3ff087c427dd8ce"><pre>ocamlPackages.topkg: 1.0.7 → 1.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/189bb2b717533f1109f9ba48eeaeac201bd5a284"><pre>ocamlPackages.iomux: 0.3 → 0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/42e3b31fadc33f449dccf8a6c81f9f128fc8b188"><pre>ocamlPackages.iomux: 0.3 → 0.4 (#443748)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a118b34a570c96485b8d6cc292651a8610d455da"><pre>ocamlPackages.multipart_form-eio: init at 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a883bf082608738a6346869535636ae9897060a7"><pre>ocamlPackages.multipart_form-miou: init at 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1333a68ece2752ed15e35cfe1b5d3e9d633a89a4"><pre>ocamlPackages.utop: 2.15.0 → 2.16.0 (#442419)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/66ab321a00c88c6b631abf84cb095531599e5250"><pre>ocamlPackages.xtmpl: 0.19.0 → 1.1.0

ocamlPackages.stog: 1.0.0 → 1.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a246280b51a96cad3a8449969d25dade07cf5de4"><pre>coqPackages.autosubst-ocaml: 1.1+8.20 -> 1.1+9.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cd10096566f6ad2ff6746a49655d7b4c3498f863"><pre>coqPackages.autosubst-ocaml: 1.1+8.20 -> 1.1+9.0 (#443607)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ae75f3f0248f02f298dc6fca929d0412bce46029"><pre>ocamlPackages.ppx_deriving: 6.1.0 → 6.1.1 (#442552)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/12bd230118a1901a4a5d393f9f56b6ad7e571d01"><pre>ocamlPackages.topkg: 1.0.7 → 1.1.0 (#443627)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e017ed6fb333f1b81384e8b6065f6adba2476ca4"><pre>ocamlPackages.uucd: 16.0.0 → 17.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2c355fac5bcfc6736543264c739ab56205306b24"><pre>ocamlPackages.tls-eio: 2.0.1 -> 2.0.2 (#435892)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5874893c92e656c85dc729e8b570fc38d3c85853...b6f6c613838dd776620c34e8f15fe4d8a9cdf9c0

#### Error

Error occurred, there could be relevant commits missing