### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758098782,
-        "narHash": "sha256-sX+iNoZkgSQsnsCHO6aI7mYh2GqbYDLWMB0iN41i61k=",
+        "lastModified": 1759422813,
+        "narHash": "sha256-WNkZqscW/dPLK5NMKH/jCkYMaVm/3KWgPmKMq65IXxk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5874893c92e656c85dc729e8b570fc38d3c85853",
+        "rev": "2a7c84e1e740f004e0fe5c2577a63d1e659a496c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5874893c92e656c85dc729e8b570fc38d3c85853",
+        "rev": "2a7c84e1e740f004e0fe5c2577a63d1e659a496c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5874893c92e656c85dc729e8b570fc38d3c85853";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=2a7c84e1e740f004e0fe5c2577a63d1e659a496c";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/cf1b86f4640a434e44f1e5aa965f050b894ff5e1"><pre>ocamlPackages.unionFind: 20220122 -> 20250818</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/abb5c4631098eca5c9ac01f7a2ddb573348d35b5"><pre>ocamlPackages.tls-eio: 2.0.1 -> 2.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b854517ed358f574ffa7e019bca52157421b8a6d"><pre>ocamlPackages.mirage-crypto: 2.0.1 -> 2.0.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b6ea50cbadccb5bc01cd099b0e537ac769e5f9dd"><pre>ocamlPackages.github: 4.4.1 -> 4.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/010cf0010c1a789676ccb19bd7efbe188e220f25"><pre>vscode-extensions.ocamllabs.ocaml-platform: 1.32.0 -> 1.32.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cb965e378b014d0f690415c5dc41859fea3f00b4"><pre>ocamlPackages.utop: 2.15.0 → 2.16.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3b170a009b9d4218538a0aed1f64b82b3a30cb6"><pre>ocamlPackages.ppx_deriving: 6.1.0 → 6.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7f9ad8535b0662a4c9be030d91eaa5151c638ff0"><pre>ocamlPackages.reason: 3.16.0 → 3.17.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2f7398ef44d0b8276746231a9637366dc32e2ae9"><pre>ocamlPackages.odoc: 2.4.4 → 3.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f7fa6b751beb1d306e74aaf83ff509c2b69879c6"><pre>ocamlPackages.lambdapi: 2.6.0 → 3.0.0

ocamlPackages.pratter: 3.0.0 → 5.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9eac097f75e7fe8782a0aff0a3ff087c427dd8ce"><pre>ocamlPackages.topkg: 1.0.7 → 1.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/189bb2b717533f1109f9ba48eeaeac201bd5a284"><pre>ocamlPackages.iomux: 0.3 → 0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/42e3b31fadc33f449dccf8a6c81f9f128fc8b188"><pre>ocamlPackages.iomux: 0.3 → 0.4 (#443748)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a118b34a570c96485b8d6cc292651a8610d455da"><pre>ocamlPackages.multipart_form-eio: init at 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a883bf082608738a6346869535636ae9897060a7"><pre>ocamlPackages.multipart_form-miou: init at 0.7.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1333a68ece2752ed15e35cfe1b5d3e9d633a89a4"><pre>ocamlPackages.utop: 2.15.0 → 2.16.0 (#442419)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/66ab321a00c88c6b631abf84cb095531599e5250"><pre>ocamlPackages.xtmpl: 0.19.0 → 1.1.0

ocamlPackages.stog: 1.0.0 → 1.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a246280b51a96cad3a8449969d25dade07cf5de4"><pre>coqPackages.autosubst-ocaml: 1.1+8.20 -> 1.1+9.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cd10096566f6ad2ff6746a49655d7b4c3498f863"><pre>coqPackages.autosubst-ocaml: 1.1+8.20 -> 1.1+9.0 (#443607)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ae75f3f0248f02f298dc6fca929d0412bce46029"><pre>ocamlPackages.ppx_deriving: 6.1.0 → 6.1.1 (#442552)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/12bd230118a1901a4a5d393f9f56b6ad7e571d01"><pre>ocamlPackages.topkg: 1.0.7 → 1.1.0 (#443627)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e017ed6fb333f1b81384e8b6065f6adba2476ca4"><pre>ocamlPackages.uucd: 16.0.0 → 17.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2c355fac5bcfc6736543264c739ab56205306b24"><pre>ocamlPackages.tls-eio: 2.0.1 -> 2.0.2 (#435892)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5c4ece24bcf8bb70248aec7c5a18bdafcd006363"><pre>ocamlPackages.reason: 3.16.0 → 3.17.0 (#443074)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b44a5519de81929679bd30aea424851cac77e217"><pre>ocamlPackages.odoc: 2.4.4 → 3.1.0 (#443077)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cb156b915f383a35087b036cfb7b83c87215e3af"><pre>ocamlPackages.earlybird: 1.3.3 → 1.3.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ac5215a85c82c0d5656a0761e1c274158534a566"><pre>ocamlPackages.bdd: unstable-2022-07-14 -> 0.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cf31694264abd8c9f016622fdbfba3f4d24d9f1b"><pre>ocamlPackages.bdd: unstable-2022-07-14 -> 0.5 (#444764)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4f7570281efb4b2811ccb5a8b89948247157dc5f"><pre>ocamlPackages.fix: 20250428 -> 20250919</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a2edb11ea62c50caa4c2f10f4b95af897cee2859"><pre>ocamlPackages.fix: 20250428 -> 20250919 (#444955)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fab18ae547816e0293f4ae6d45bbfdd445c4d0f2"><pre>ocamlPackages.lambdapi: 2.6.0 → 3.0.0 (#443331)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ffc8511fa4dc699c392e600084b017dff6b4300c"><pre>ocamlPackages.unionFind: 20220122 -> 20250818 (#435451)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1b01444c921204a682e1aef995c1bbf5f0640044"><pre>ocamlPackages.mirage-crypto: 2.0.1 -> 2.0.2 (#435901)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cad44a4a1930d4274d21e3273c88659618f02563"><pre>ocamlPackages.github: 4.4.1 -> 4.5.0 (#436194)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b1c9ead94fb6bb092d836847ce7d7be90363cd40"><pre>vscode-extensions.ocamllabs.ocaml-platform: 1.32.0 -> 1.32.3 (#439050)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9065f12169d257765a22b427ac1b4b0407500c11"><pre>ocamlPackages.multipart_form-{eio,miou}: init at 0.7.0 (#443949)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/73432f59e109ca737abe6cbfbfe8a0a39fa37589"><pre>ocamlPackages.buildDunePackage: support fixed point args with \`lib.extendMkDerivation\`</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cb98bc068d7fe308e4c3bd17a74517e4935552b6"><pre>ocamlPackages.linol: use \`finalAttrs\` pattern</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/69d2b0d7ef5a8cc37684a8a6c81d9277edc9bd5a"><pre>ocamlPackages.buildDunePackage: support fixed point args with \`lib.extendMkDerivation\` (#446007)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a96787cf89ad7c930961e06d04ef19fdc1b35681"><pre>ocamlPackages.xtmpl: 0.19.0 → 1.1.0 (#444213)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8d16f813f69d4d12da076ff5bcc0f6fb5820f06e"><pre>ocamlPackages.uucd: 16.0.0 → 17.0.0 (#444236)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3f0813969dbe7c07589d11412126107d5a011202"><pre>ocamlPackages.ocaml-sat-solvers: 0.4 → 0.8</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b7a0343fe9307ec142b85e2089614436b4a7213a"><pre>ocamlPackages.ocaml-sat-solvers: 0.4 → 0.8 (#446112)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9c16f42f073ce09d17bb0efa21f7e4d8ab761da3"><pre>ocamlPackages.ocamlify: 0.0.2 -> 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f434b99f35fadc8d6d874dbfe95c5eb331e62447"><pre>ocamlPackages.ocamlify: 0.0.2 -> 0.1.0 (#446289)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5874893c92e656c85dc729e8b570fc38d3c85853...2a7c84e1e740f004e0fe5c2577a63d1e659a496c

#### Error

Error occurred, there could be relevant commits missing