### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759648188,
-        "narHash": "sha256-3MP8PHRchkxNQjunbMBdBmGck8Z7vCs+WVhzCvlFJ7I=",
+        "lastModified": 1759815582,
+        "narHash": "sha256-uQvMq2yTJPsH+tShNlpEbQSIGt3D2P9hh+Y8oyMiUlU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c3fc4d5e33169e331ada119a583581d5de752f0",
+        "rev": "f15bc496e57cdc734e9c4bc2040369e871e46ae6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c3fc4d5e33169e331ada119a583581d5de752f0",
+        "rev": "f15bc496e57cdc734e9c4bc2040369e871e46ae6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=2c3fc4d5e33169e331ada119a583581d5de752f0";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=f15bc496e57cdc734e9c4bc2040369e871e46ae6";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/ebb14544edebcb045907acf527659db710111bb1"><pre>ocamlPackages.mirage: 4.4.2 → 4.10.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c98f2c15716276045a4350441e93a52887e7f2b2"><pre>ocamlPackages.tcs-lib: 0.3 → 0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ff17a22a9e7c3a6b75d54d9993d8ab9788c227f9"><pre>ocamlPackages.tuntap: 2.0.0 → 2.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ba860a2963abaab3dfd36b0cd3f19acfe94f1a2"><pre>ocamlPackages.merlin: 5.5-503 -> 5.6-503</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3273eac6d04ec556381574886288a36147c40175"><pre>ocamlPackages.mirage: 4.4.2 → 4.10.1 (#447277)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/966ed9df873644910c69a557bf574c82bf2e2df9"><pre>ocamlPackages.lsp: 1.23.0 → 1.23.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fce27362e1d5f990b04ae79faecf56e028075c85"><pre>ocamlPackages.tcs-lib: 0.3 → 0.6 (#447295)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0301eaa4b1d40d8cb31534e35720c6328ee08f55"><pre>ocamlPackages.merlin: 5.5-503 -> 5.6-503 (#448313)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6c3c3951fb76343e5f8589db3ab0f82cea1d8f30"><pre>ocamlPackages.synchronizer: init at 0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5fc5466edaf9a07854c4b1f8d0b173937dbfadf4"><pre>ocamlPackages.lsp: 1.23.0 → 1.23.1 (#449001)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aa0ebc256a5b0540e9df53c64ef6930471c98407"><pre>ocamlPackages.synchronizer: init at 0.1 (#448246)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ea839424d592075b11eadde501fd43f843b1664e"><pre>ocamlPackages.tuntap: 2.0.0 → 2.0.1 (#447374)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f15bc496e57cdc734e9c4bc2040369e871e46ae6"><pre>findup: 1.1.3 -> 2.0.0 (#449310)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/2c3fc4d5e33169e331ada119a583581d5de752f0...f15bc496e57cdc734e9c4bc2040369e871e46ae6