### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760334914,
-        "narHash": "sha256-+eKK1TjjjYoJ7uNAf64nistrdf7K1qAxYpid+RNWssI=",
+        "lastModified": 1760435515,
+        "narHash": "sha256-E9D5sWHmPCmWsrCB3Jogvr/7ODiVaKynDrOpG4ba2tI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "662e2ea08d7caacdfacdb92512a13b3f336f6e56",
+        "rev": "db25466bd95abdbe3012be2900a5562fcfb95d51",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "662e2ea08d7caacdfacdb92512a13b3f336f6e56",
+        "rev": "db25466bd95abdbe3012be2900a5562fcfb95d51",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=662e2ea08d7caacdfacdb92512a13b3f336f6e56";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=db25466bd95abdbe3012be2900a5562fcfb95d51";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/2167711d5ef63b43388b45250a2f70ef94b724bf"><pre>ocamlPackages.notty: fix for OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1e55f8db32136bc8c286245bf5aeecacc8d1e741"><pre>ocamlPackages.xtmpl_ppx: fix for OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6f67b4d54dc614cd10d76dadde302120691bf155"><pre>ocamlPackages.ocf_ppx: fix for OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/904eda08ed23151982e9cec29b0bd5255a967ed9"><pre>ocamlPackages.bistro: fix meta.broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/94f636550b55c81b8126468763cb131a48fde7df"><pre>ocamlPackages.morbig: disable for OCaml ≥ 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/65f869a0e6486479d6a94e9d6a32df0093e2456c"><pre>ocamlPackages.kcas: disable tests with OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e07221e4da4f3ee10b668b6a999c2e1707d4469"><pre>ocaml-ng.ocamlPackages_5_4: init at 5.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/24d7d726c41fe82f68a163dac95aa6d67e99fdf3"><pre>ocamlPackages.ocamlnat: drop

This package only support OCaml < 4. We only package OCaml >= 4, though.
OCaml 4.00.1 is from 2012 already, so this.. has not been supported
literally forever?

I don\'t think we need to add an alias for something that only fails an
assert all the time anyway.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cd1a062362a72a120ce5adf9f86c21e7303f590f"><pre>ocamlPackages.ca-certs-nss: 3.115 -> 3.117</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9b2025ae332b673527d421e0e59d017fc49219ce"><pre>ocaml-ng.ocamlPackages_5_4: init at 5.4.0 (#449330)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b692ac3877104534238eca8b5c6ddd561ad1a807"><pre>ocamlPackages.dockerfile: init at 8.3.2

Homepage: https://www.ocurrent.org/ocaml-dockerfile/dockerfile/Dockerfile/index.html
Source: https://github.com/ocurrent/ocaml-dockerfile

Ocaml library for creating a Dockerfile

Signed-off-by: Ethan Carter Edwards <ethan@ethancedwards.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/550b891d85a480fe759df9126c95f41331b9a75b"><pre>ocamlPackages.ocamlnat: drop (#451765)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aecc6f199e6754925b756e43d97c79b8818d58ba"><pre>ocamlPackages.dockerfile: init at 8.3.2 (#451875)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/60145c9e74d1209922a746af9fa8e1b993093baa"><pre>ocamlPackages.ca-certs-nss: 3.115 -> 3.117 (#451779)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db25466bd95abdbe3012be2900a5562fcfb95d51"><pre>vacuum-tube: 1.3.19 -> 1.3.20 (#451844)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/662e2ea08d7caacdfacdb92512a13b3f336f6e56...db25466bd95abdbe3012be2900a5562fcfb95d51