### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760435515,
-        "narHash": "sha256-E9D5sWHmPCmWsrCB3Jogvr/7ODiVaKynDrOpG4ba2tI=",
+        "lastModified": 1760623159,
+        "narHash": "sha256-Ps5Z0wb9NuDOZyevjlCNgxRValuLBDLZTp6LO5cEMCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db25466bd95abdbe3012be2900a5562fcfb95d51",
+        "rev": "f7a1994b7d8b0faa4a604790212d2e87fa34b9f9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db25466bd95abdbe3012be2900a5562fcfb95d51",
+        "rev": "f7a1994b7d8b0faa4a604790212d2e87fa34b9f9",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=db25466bd95abdbe3012be2900a5562fcfb95d51";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=f7a1994b7d8b0faa4a604790212d2e87fa34b9f9";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/2167711d5ef63b43388b45250a2f70ef94b724bf"><pre>ocamlPackages.notty: fix for OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1e55f8db32136bc8c286245bf5aeecacc8d1e741"><pre>ocamlPackages.xtmpl_ppx: fix for OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6f67b4d54dc614cd10d76dadde302120691bf155"><pre>ocamlPackages.ocf_ppx: fix for OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/904eda08ed23151982e9cec29b0bd5255a967ed9"><pre>ocamlPackages.bistro: fix meta.broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/94f636550b55c81b8126468763cb131a48fde7df"><pre>ocamlPackages.morbig: disable for OCaml ≥ 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/65f869a0e6486479d6a94e9d6a32df0093e2456c"><pre>ocamlPackages.kcas: disable tests with OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e07221e4da4f3ee10b668b6a999c2e1707d4469"><pre>ocaml-ng.ocamlPackages_5_4: init at 5.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/24d7d726c41fe82f68a163dac95aa6d67e99fdf3"><pre>ocamlPackages.ocamlnat: drop

This package only support OCaml < 4. We only package OCaml >= 4, though.
OCaml 4.00.1 is from 2012 already, so this.. has not been supported
literally forever?

I don\'t think we need to add an alias for something that only fails an
assert all the time anyway.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cd1a062362a72a120ce5adf9f86c21e7303f590f"><pre>ocamlPackages.ca-certs-nss: 3.115 -> 3.117</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9b2025ae332b673527d421e0e59d017fc49219ce"><pre>ocaml-ng.ocamlPackages_5_4: init at 5.4.0 (#449330)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b692ac3877104534238eca8b5c6ddd561ad1a807"><pre>ocamlPackages.dockerfile: init at 8.3.2

Homepage: https://www.ocurrent.org/ocaml-dockerfile/dockerfile/Dockerfile/index.html
Source: https://github.com/ocurrent/ocaml-dockerfile

Ocaml library for creating a Dockerfile

Signed-off-by: Ethan Carter Edwards <ethan@ethancedwards.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/550b891d85a480fe759df9126c95f41331b9a75b"><pre>ocamlPackages.ocamlnat: drop (#451765)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aecc6f199e6754925b756e43d97c79b8818d58ba"><pre>ocamlPackages.dockerfile: init at 8.3.2 (#451875)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/60145c9e74d1209922a746af9fa8e1b993093baa"><pre>ocamlPackages.ca-certs-nss: 3.115 -> 3.117 (#451779)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/36c4abcd839dad2268785a541d6399c3273448e0"><pre>ocaml-ng: drop ocaml <=4.08</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a57dccaf8206a10da5578ac75d85669ead787577"><pre>ocamlPackages.gendarme: init at 0.3

Homepage: https://github.com/bensmrs/gendarme

Signed-off-by: Ethan Carter Edwards <ethan@ethancedwards.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aed6e56f036583ea0934a1106d40a3c77cb12587"><pre>ocaml-ng: drop ocaml <=4.08 (#427222)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/618448e31fffea8836d8ea6152f0b8f18d235e8c"><pre>ocamlPackages.gendarme: init at 0.3 (#451870)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c22b76d760241df91b720207478f11e5739b3c4d"><pre>ocamlPackages.ubase: Init at 0.20</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/02763fc9760a32faa287120d2ec34a71ace070e5"><pre>ocamlPackages.ubase: Init at 0.20 (#451932)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/662e2ea08d7caacdfacdb92512a13b3f336f6e56...f7a1994b7d8b0faa4a604790212d2e87fa34b9f9