### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760921481,
-        "narHash": "sha256-5aDRQrm4gUCIicnpKi2jo7K8M33i7C56uAmNmaiJQFs=",
+        "lastModified": 1761207842,
+        "narHash": "sha256-LnHXQ9DJ1lFS0ySJilHJy8cxwmdKM/pAo/Uigif2dWU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "773d463d37341ffc8bd05a704156e87b195173be",
+        "rev": "de79463aa9128bf3e4a2c0ad377a63239e3f1543",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "773d463d37341ffc8bd05a704156e87b195173be",
+        "rev": "de79463aa9128bf3e4a2c0ad377a63239e3f1543",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=773d463d37341ffc8bd05a704156e87b195173be";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=de79463aa9128bf3e4a2c0ad377a63239e3f1543";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/164a91150cd63a30e88f6a04f9234c5f644914b5"><pre>ocamlPackages.sail: 0.19.1 -> 0.20</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0708f349688ab88d89897e7ce91efb20aec6202c"><pre>ocamlPackages.ppx_derive_at_runtime: 0.17.0 → 0.17.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4b255a27d300e766e07a853a421b08ce537acf24"><pre>ocamlPackages.ppx_jsonaf_conv: 0.17.0 → 0.17.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1e1c10488f5987c8b02677f3bbc8c0419b186e0f"><pre>ocamlPackages.ppx_pattern_bind: 0.17.0 → 0.17.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f2c975bca02b6e751d961a9aba2abf63431096a2"><pre>ocamlPackages.ppx_quick_test: 0.17.0 → 0.17.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/80e35e85394cb6dab6cb6ee964e3567b107ddbf7"><pre>ocamlPackages.ppx_typed_fields: 0.17.0 → 0.17.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e1d816b18a12d4efbf7b0f8d0efc8f9d6d7e9f53"><pre>ocamlPackages.streamable: 0.17.0 → 0.17.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/72618038521eb9a97f44261443b4f006a917fc36"><pre>ocamlPackages.dolmen_model: init at 0.10</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/79fef7e3b56b4aa2946a46f0c3b1adc81e53cf56"><pre>ocamlPackages.smtml: 0.10.0 → 0.12.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aba5cb3d22fd6a77210e0a02798d50b42dd4a928"><pre>ocamlPackages.sail: 0.19.1 -> 0.20 (#451775)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/470d48fc2db23e93cd5161bb5758b318a99fdd7a"><pre>team/ocaml: add redianthus</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cfe4f564bd1dca12975c505e7499c84ec7d2587c"><pre>ocamlPackages.ocaml_gettext: fix for OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8c3752488b08d3dda144d56965ff470764be3161"><pre>ocamlPackages.{…}: 0.17.0 → 0.17.1 (#453656)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f1786086b6a66f30f43897188e9d9003830790d5"><pre>ocamlPackages.ocaml_gettext: fix for OCaml 5.4 (#454095)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2630bb4c60e684e204cda2f79526b8cbb25ddf6c"><pre>team/ocaml: add redianthus (#449676)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dcbc71d290bfaf56c18d2563ccd11e6e5f9ad0bc"><pre>ocamlPackages.smtml: 0.10.0 → 0.12.0 (#453714)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/13b4ef935774807551d5c8fe546f77f5b8386d0d"><pre>ocamlPackages.graphql_ppx: 1.2.2 → 1.2.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/eb040ed772793f1e5dfd7432487c4fac0cda591c"><pre>ocamlPackages.graphql_ppx: 1.2.2 → 1.2.3 (#454291)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/773d463d37341ffc8bd05a704156e87b195173be...de79463aa9128bf3e4a2c0ad377a63239e3f1543