### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761373498,
-        "narHash": "sha256-Q/uhWNvd7V7k1H1ZPMy/vkx3F8C13ZcdrKjO7Jv7v0c=",
+        "lastModified": 1761544814,
+        "narHash": "sha256-t5f0A+2MtSWTfA6hzMNiotpIMGLlSQF2JnK9m6nkzIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
+        "rev": "e5aa45ed6c45058ec109658b2b7352a9a062cdf3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
+        "rev": "e5aa45ed6c45058ec109658b2b7352a9a062cdf3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=e5aa45ed6c45058ec109658b2b7352a9a062cdf3";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a44ce7d370da14bd5f046546c1654e526704bbfb"><pre>ocamlPackages.terminal: 0.4.0 -> 0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ad5e5a28280d37144509e5c4f228896f0b1475de"><pre>ocamlPackages.monolith: 20250314 -> 20250922</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/954ac426c36fe8079c8411485c2073feea3cdb15"><pre>ocamlPackages.base64: 3.5.1 -> 3.5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/11dfc21f233d30cb08a4709655f35df2c253458f"><pre>ocamlPackages.unisim_archisec: 0.0.12 -> 0.0.13</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cc0affd861598e71ac7cb26ad1e167259dfa3a44"><pre>ocamlPackages.qcheck-multicoretests-util: 0.9 -> 0.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e1e44f9d0f5cff48f72f484609aed0435f85df88"><pre>ocamlPackages.ocaml-version: 4.0.1 -> 4.0.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a0fa22bc6d32af5b4e26bf7a807ed840390df7d2"><pre>ocamlPackages.ocaml-version: 4.0.1 -> 4.0.3 (#449628)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1a572db27830bd5d93dd586dcddcfdb55a6875dc"><pre>ocamlPackages.base64: 3.5.1 -> 3.5.2 (#444358)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c4d51b90e73f2587086894a5265f1fbe66c776fc"><pre>ocamlPackages.monolith: 20250314 -> 20250922 (#446490)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b8a3580f29b20edf308cca172599d84b17070b40"><pre>ocamlPackages.unisim_archisec: 0.0.12 -> 0.0.13 (#447818)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7576f6c8f337ac25f29d1c23751ffed51334f160"><pre>ocamlPackages.terminal: 0.4.0 -> 0.5.0 (#445321)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9aa987d99cd9f0c5c31a44afc40ebc529a2fca91"><pre>ocamlPackages.qcheck-multicoretests-util: 0.9 -> 0.11 (#449619)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce...e5aa45ed6c45058ec109658b2b7352a9a062cdf3