### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761373498,
-        "narHash": "sha256-Q/uhWNvd7V7k1H1ZPMy/vkx3F8C13ZcdrKjO7Jv7v0c=",
+        "lastModified": 1761895999,
+        "narHash": "sha256-nwDpLSvoDmeA38JYYRjDPwJRYAyNY/gc/G/s8vWG09E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
+        "rev": "27bdcabd74757daccba0ba1ffeabe5ffee9eb616",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
+        "rev": "27bdcabd74757daccba0ba1ffeabe5ffee9eb616",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=27bdcabd74757daccba0ba1ffeabe5ffee9eb616";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a44ce7d370da14bd5f046546c1654e526704bbfb"><pre>ocamlPackages.terminal: 0.4.0 -> 0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ad5e5a28280d37144509e5c4f228896f0b1475de"><pre>ocamlPackages.monolith: 20250314 -> 20250922</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/954ac426c36fe8079c8411485c2073feea3cdb15"><pre>ocamlPackages.base64: 3.5.1 -> 3.5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/11dfc21f233d30cb08a4709655f35df2c253458f"><pre>ocamlPackages.unisim_archisec: 0.0.12 -> 0.0.13</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cc0affd861598e71ac7cb26ad1e167259dfa3a44"><pre>ocamlPackages.qcheck-multicoretests-util: 0.9 -> 0.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e1e44f9d0f5cff48f72f484609aed0435f85df88"><pre>ocamlPackages.ocaml-version: 4.0.1 -> 4.0.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b8bf170aa9119754a9e284e50644dde8cccc5390"><pre>ocamlPackages.dockerfile: 8.3.2 -> 8.3.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/19b93bd09ea2221f7b4893e5ac857634add7f129"><pre>ocamlPackages.mirage-ptime: 5.1.0 -> 5.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/78b661a8004ec1c2bcc23c1a0adef413edc7af0e"><pre>ocamlPackages.ninja_utils: 0.9.0 -> 1.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/27413a10fe147777f250d34c50080c88d5777061"><pre>ocamlPackages.http-mirage-client: fix test on darwin, migrate source</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/da39deb6731eb17a04388c06156c78c791236e06"><pre>ocamlPackages.dns: 10.2.1 -> 10.2.2

Diff: https://github.com/mirage/ocaml-dns/compare/v10.2.1...v10.2.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a0fa22bc6d32af5b4e26bf7a807ed840390df7d2"><pre>ocamlPackages.ocaml-version: 4.0.1 -> 4.0.3 (#449628)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1a572db27830bd5d93dd586dcddcfdb55a6875dc"><pre>ocamlPackages.base64: 3.5.1 -> 3.5.2 (#444358)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c4d51b90e73f2587086894a5265f1fbe66c776fc"><pre>ocamlPackages.monolith: 20250314 -> 20250922 (#446490)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b8a3580f29b20edf308cca172599d84b17070b40"><pre>ocamlPackages.unisim_archisec: 0.0.12 -> 0.0.13 (#447818)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7576f6c8f337ac25f29d1c23751ffed51334f160"><pre>ocamlPackages.terminal: 0.4.0 -> 0.5.0 (#445321)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9aa987d99cd9f0c5c31a44afc40ebc529a2fca91"><pre>ocamlPackages.qcheck-multicoretests-util: 0.9 -> 0.11 (#449619)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7a4ca294421375340af642fa6e5367c5a99d9819"><pre>ocamlPackages.dns: 10.2.1 -> 10.2.2 (#455624)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/043dc9c8872c858dce419a1ea4684771c777f210"><pre>ocamlPackages.mirage-ptime: 5.1.0 -> 5.2.0 (#455179)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6d89dcd57701a839654f78afc62466b94e55a3b2"><pre>maintainers/github-teams.json: Manual adjustment of necessary changes

This makes \`lib.teams\` be in sync with the GitHub state.

Add the marketing-team so that all teams in \`lib.teams\` can be requested for reviews.

Add these members to the respective teams:
- beam: minijackson (53e70ab75490df87a165d704a9e98312b3f5137b)
- beam: savtrip (f9ff37cdc3ade4bc45f501af0e7f7520a9543f1c)
- cuda: prusnak (748896a2db6cafb61e6b29dfa71f904293443f6b)
- geospatial: autra (7de303b4518766db2ddca9dfcbdc823430fe3869)
- geospatial: l0b0 (510eb5118acff1546bb0037c6f3168496675e1e8)
- gnome: bobby285271 (066634e509988232b435cf2e64c778ec4508a4b4)
- gnome: dasj19 (c57c9362815e48681e9a52ec86cf81e38fe1ce6c)
- k3s: heywoodlh (2ca18a8b175c961eef8aa3637c490de833fcccef)
- k3s: rorosen (b9f397d445b52316eaf08b9d5072fe194ab482ec)
- php: piotrkwiecinski (148e322192b7a451344fe335cc38b95043ee37d4)
- qt-kde: mjm (f6bb8a922fef75dd6a81af0cfe25daca6e3b9c4b)
- qt-kde: NickCao (f6bb8a922fef75dd6a81af0cfe25daca6e3b9c4b)
- qt-kde: ilya-fedin (f6bb8a922fef75dd6a81af0cfe25daca6e3b9c4b)
- qt-kde: K900 (f6bb8a922fef75dd6a81af0cfe25daca6e3b9c4b)
- qt-kde: SuperSandro2000 (f6bb8a922fef75dd6a81af0cfe25daca6e3b9c4b)
- qt-kde: LunNova (f6bb8a922fef75dd6a81af0cfe25daca6e3b9c4b)

Remove these members from the respective teams:
- geospatial: das-g (b93d987a8441384a6bac336318b1582d52305412)
- haskell: expipiplus1 (e134422465913332a5c9cb3ec9161650f7d459c8)
- haskell: peti (https://github.com/NixOS/nixpkgs/pull/450864#issuecomment-3431029084)
- k3s: yajo (8b238112108d8c366856434a3e617f60cd250758)
- k3s: superherointj (7354bda2081a43cfe13f7df67b09af90b309615a)
- ocaml: superherointj (7354bda2081a43cfe13f7df67b09af90b309615a)
- php: drupol (cabc16dc599da7ca2b320fafe80e256d0dfa5b94)
- php: globin (e5d552f5b94c26e574a6333060d0864760034ee3)
- documentation-team: fricklerhandwerk (https://discourse.nixos.org/t/the-next-chapter-in-nix-documentation/68425)

Copy these team descriptions from \`lib.teams.*.scope\` to the GitHub team description:
- nixpkgs-ci: Maintain Nixpkgs\' in-tree Continuous Integration, including GitHub Actions
- cuda: Maintain CUDA-enabled packages
- darwin: Maintain core platform support and packages for macOS and other Apple platforms
- documentation-team: Maintain nixpkgs/NixOS documentation and tools for building it. https://nixos.org/community/teams/documentation
- enlightenment: Maintain Enlightenment desktop environment and related packages
- flutter: Maintain Flutter and Dart-related packages and build tools
- geospatial: Maintain geospatial, remote sensing and OpenStreetMap software
- golang: Maintain Golang compilers
- haskell: Maintain Haskell packages and infrastructure
- k3s: Maintain K3s package, NixOS module, NixOS tests, update script
- lisp: Maintain the Lisp ecosystem
- lua: Maintain the lua ecosystem
- lumina: Maintain lumina desktop environment and related packages
- lxqt: Maintain LXQt desktop environment and related packages
- neovim: Maintain the vim and neovim text editors and related packages
- ocaml: Maintain the OCaml compiler and package set
- pantheon: Maintain Pantheon desktop environment and platform
- qt-kde: Maintain the Qt framework, KDE application suite, Plasma desktop environment and related projects
- nixos-release-managers: Manage the current nixpkgs/NixOS release
- rocm: Maintain ROCm and related packages
- rust: Maintain the Rust compiler toolchain and nixpkgs integration
- systemd: Maintain systemd for NixOS
- xen-project: Maintain the Xen Project Hypervisor and the related tooling ecosystem</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/87a554621aebca1e574bdb553fc8613c1bb6f558"><pre>ocamlPackages.domain-name: 0.4.1 -> 0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1360493b853d4df2cbddcc5834deebf3bed742be"><pre>ocamlPackages.magic-trace: fix platforms</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a3330d2d6c56cc18f68f961ffd543c0d0a887afa"><pre>ocamlPackages.tls-eio: fix test on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7015408b3cec6ca320f4c7c90262500e1a8ea03c"><pre>ocamlPackages.ocp-browser: init at 1.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1079c21566b1451ce99ab22e07e15569b1cb0c35"><pre>ocamlPackages.smtml: 0.12.0 -> 0.13.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e52bb03cd8997f19c106f94602ecd503784883b0"><pre>ocamlPackages.domain-name: 0.4.1 -> 0.5.0 (#455216)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/34993c0910e0d4c6d396bd382e822eb26f7e0921"><pre>ocamlPackages.ocp-browser: init at 1.4.0 (#447741)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/780198f91a3db1843ad3f40bfc2b7a8aa428aa5c"><pre>ocamlPackages.gapi-ocaml: 0.4.6 -> 0.4.7</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/41c5a95055b244df6341595004e84dc0994c1956"><pre>ocamlPackages.gapi-ocaml: 0.4.6 -> 0.4.7 (#456626)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6646062105cedd6ead9336f10ac49251799433ef"><pre>ocamlPackages.ninja_utils: 0.9.0 -> 1.0.0 (#455211)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/14014e0280f44f8b05bb0e079e1616516a4f574e"><pre>ocamlPackages.dockerfile: 8.3.2 -> 8.3.3 (#455167)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2447b16ed7684c8ab393a150430f939d9eddca41"><pre>ocamlPackages.smtml: 0.12.0 -> 0.13.0 (#456420)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce...27bdcabd74757daccba0ba1ffeabe5ffee9eb616