### PR TITLE
add mingw support

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -160,3 +160,34 @@ jobs:
       - name: Build nix packages
         run : ./ci.sh x86_64-linux ${{matrix.target}}_${{matrix.setup.ocaml-version}}
         continue-on-error: ${{ matrix.setup.continue-on-error }}
+
+  cross-compilers-mingw:
+    strategy:
+      fail-fast: false
+      matrix:
+        setup:
+          # mingw cross-compilation only supported on OCaml 5.4+
+          - { ocaml-version: 5_4, continue-on-error: false }
+          - { ocaml-version: 5_5, continue-on-error: true }
+    name: mingw packages (OCaml ${{ matrix.setup.ocaml-version }})
+    runs-on: ubuntu-latest
+    env:
+      NIXPKGS_ALLOW_UNFREE: 1
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            system-features = nixos-test benchmark big-parallel kvm
+            extra-substituters = https://anmonteiro.nix-cache.workers.dev
+            extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
+      - uses: nix-ocaml/nix-s3-action@fork
+        with:
+          skipPush: true
+          endpoint: "s3://overlays?endpoint=https://7a53c28e9b7a91239f9ed42da04276bc.r2.cloudflarestorage.com"
+          signingKey: ${{ secrets.R2_SIGNING_KEY }}
+          awsAccessKeyId: ${{ secrets.R2_ACCESS_KEY_ID }}
+          awsSecretAccessKey: ${{ secrets.R2_SECRET_ACESS_KEY }}
+      - name: Build nix packages
+        run : ./ci.sh x86_64-linux mingw_${{matrix.setup.ocaml-version}}
+        continue-on-error: ${{ matrix.setup.continue-on-error }}

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -286,7 +286,6 @@ rec {
         # just build a subset of the static overlay, with the most commonly used
         # packages
         inherit
-          caqti-driver-postgresql
           ppx_deriving
           base
           cohttp-lwt-unix
@@ -296,10 +295,16 @@ rec {
           irmin
           ;
       }
+      // lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isMinGW) {
+        # postgresql can't cross-compile for mingw (needs glibc)
+        inherit caqti-driver-postgresql;
+      }
       // (
         if lib.hasPrefix "5_" ocamlVersion then
           {
             inherit piaf carl;
+          }
+          // lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isMinGW) {
             static-carl = carl.override { static = true; };
           }
         else

--- a/ci/hydra.nix
+++ b/ci/hydra.nix
@@ -129,4 +129,8 @@ with filter;
   );
 
   musl_5_5 = (if system == "x86_64-linux" then crossTarget pkgs.pkgsCross.musl64 "5_5" else { });
+
+  # mingw cross-compilation (Windows) - only OCaml 5.4+ supported
+  mingw_5_4 = (if system == "x86_64-linux" then crossTarget pkgs.pkgsCross.mingwW64 "5_4" else { });
+  mingw_5_5 = (if system == "x86_64-linux" then crossTarget pkgs.pkgsCross.mingwW64 "5_5" else { });
 }

--- a/cross/base_bigstring-memmem.patch
+++ b/cross/base_bigstring-memmem.patch
@@ -1,0 +1,29 @@
+--- a/src/base_bigstring_stubs.c
++++ b/src/base_bigstring_stubs.c
+@@ -64,6 +64,26 @@
+ #define bswap_64 bswap64
+ #endif
+ 
++/* memmem is a GNU extension not available on mingw */
++#ifdef __MINGW32__
++static void *memmem(const void *haystack, size_t haystack_len,
++    const void * const needle, const size_t needle_len)
++{
++    if (haystack == NULL) return NULL;
++    if (haystack_len == 0) return NULL;
++    if (needle == NULL) return NULL;
++    if (needle_len == 0) return NULL;
++    for (const char *h = haystack;
++            haystack_len >= needle_len;
++            ++h, --haystack_len) {
++        if (!memcmp(h, needle, needle_len)) {
++            return (void *)h;
++        }
++    }
++    return NULL;
++}
++#endif
++
+ #include <caml/alloc.h>
+ #include <caml/memory.h>
+ #include <caml/fail.h>

--- a/cross/iomux-mingw.patch
+++ b/cross/iomux-mingw.patch
@@ -1,0 +1,65 @@
+diff -ruN a/lib/include/discover.ml b/lib/include/discover.ml
+--- a/lib/include/discover.ml	2026-04-19 20:08:32.901410113 +0200
++++ b/lib/include/discover.ml	2026-04-19 20:17:45.013219847 +0200
+@@ -19,17 +19,25 @@
+ }
+ |}
+ 
++let has_poll_h = {|
++#include <poll.h>
++int main(void) { return 0; }
++|}
++
+ let () =
+   C.main ~name:"discover" @@ fun c ->
+ 
+-  (* check for ppoll(2) *)
+-  let has_ppoll = C.c_test c has_ppoll_code in
++  let is_windows = not (C.c_test c ~link_flags:["-c"] has_poll_h) in
++  let poll_header = if is_windows then "winsock2.h" else "poll.h" in
++
++  (* check for ppoll(2) — not available on Windows *)
++  let has_ppoll = (not is_windows) && C.c_test c has_ppoll_code in
+   C.C_define.gen_header_file c ~fname:"config.h" [ "HAS_PPOLL", Switch has_ppoll ];
+   let has_list = [ Printf.sprintf "let has_ppoll = %b" has_ppoll ] in
+ 
+   (* general poll(2) definitions *)
+   let defs =
+-    C.C_define.import c ~includes:["poll.h"]
++    C.C_define.import c ~includes:[poll_header]
+       C.C_define.Type.[
+         "POLLIN", Int;
+         "POLLPRI", Int;
+diff -ruN a/lib/iomux_stubs.c b/lib/iomux_stubs.c
+--- a/lib/iomux_stubs.c	2026-04-19 20:08:32.901569733 +0200
++++ b/lib/iomux_stubs.c	2026-04-19 20:09:12.727744144 +0200
+@@ -1,8 +1,14 @@
+ #define _GNU_SOURCE
+ 
+ #include <errno.h>
++#ifdef __MINGW32__
++#include <winsock2.h>
++#define poll WSAPoll
++typedef ULONG nfds_t;
++#else
+ #include <poll.h>
+ #include <signal.h>
++#endif
+ 
+ #include <caml/bigarray.h>
+ #include <caml/memory.h>
+@@ -154,10 +160,14 @@
+ caml_iomux_poll_max_open_files(value v_unit)
+ {
+         CAMLparam1(v_unit);
++#ifdef __MINGW32__
++        long r = 8192;
++#else
+         long r = sysconf(_SC_OPEN_MAX);
+         if (r == -1) /* this allocs */
+                 uerror("poll_max_open_files", Nothing);
+         else if (r > 524288)
+                 r = 524288;
++#endif
+ 	CAMLreturn (Val_int(r));
+ }

--- a/cross/ocaml-compiler.nix
+++ b/cross/ocaml-compiler.nix
@@ -5,6 +5,7 @@
   natocamlPackages,
   writeScriptBin,
   osuper,
+  windows ? null,
 }:
 
 let
@@ -32,10 +33,35 @@ if lib.versionOlder "5.4" osuper.ocaml.version then
       buildPackages.stdenv.cc
       natocaml
     ];
+
+    # mingw needs pthreads for threading support
+    buildInputs = lib.optionals stdenv.hostPlatform.isMinGW [
+      windows.pthreads
+    ];
+
     configurePlatforms = [ ];
     preConfigure = ''
       configureFlagsArray+=("--host=${stdenv.buildPlatform.config}" "--target=${stdenv.targetPlatform.config}" "PARTIALLD=$LD -r" "ASPP=$CC -c")
     '';
+
+    # mingw: add pthreads path to flexlink, remove -lgcc_eh, add -nocygpath
+    postConfigure = lib.optionalString stdenv.hostPlatform.isMinGW ''
+      # Add -nocygpath to prevent flexlink from trying to use cygpath
+      # Add -L path for pthreads to all flexlink invocations
+      substituteInPlace Makefile.config --replace-fail \
+        'MKEXE=flexlink' \
+        'MKEXE=flexlink -nocygpath -L${windows.pthreads}/lib'
+      substituteInPlace Makefile.config --replace-fail \
+        'MKDLL=flexlink' \
+        'MKDLL=flexlink -nocygpath -L${windows.pthreads}/lib'
+      substituteInPlace Makefile.config --replace-fail \
+        'MKMAINDLL=flexlink' \
+        'MKMAINDLL=flexlink -nocygpath -L${windows.pthreads}/lib'
+      substituteInPlace Makefile.config --replace-fail \
+        '-lgcc_eh' \
+        ""
+    '';
+
     buildPhase = ''
       runHook preBuild
       make crossopt ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
@@ -46,6 +72,32 @@ if lib.versionOlder "5.4" osuper.ocaml.version then
       cp ${natocaml}/bin/ocamllex $out/bin/ocamllex
       cp ${natocaml}/bin/ocamlyacc $out/bin/ocamlyacc
       cp ${natocaml}/bin/ocamlrun $out/bin/ocamlrun
+    ''
+    + lib.optionalString stdenv.hostPlatform.isMinGW ''
+            # Remove Windows PE versions of tools that need to run on build machine
+            # The cross-compiler .exe files are actually ELF binaries (run on Linux)
+            # but ocamlyacc.exe and ocamlrun.exe are Windows PE (compiled with mingw gcc)
+            rm -f $out/bin/ocamlyacc.exe $out/bin/ocamlrun.exe $out/bin/ocamlrund.exe
+
+            # Create symlinks for .exe files (mingw adds .exe extension)
+            for f in $out/bin/*.exe; do
+              ln -sf "$(basename "$f")" "''${f%.exe}"
+            done
+
+            # Wrap flexlink to always add -nocygpath and library paths
+            # The compiler has flexlink settings compiled-in that don't include these
+            # Link mcfgthread which is needed by libgcc_eh
+            mv $out/bin/flexlink.opt.exe $out/bin/.flexlink.opt.exe.real
+            cat > $out/bin/flexlink.opt.exe << 'EOF'
+      #!/bin/sh
+      exec "$(dirname "$0")/.flexlink.opt.exe.real" -nocygpath -L${windows.pthreads}/lib -L${windows.mcfgthreads}/lib "$@" -lmcfgthread
+      EOF
+            chmod +x $out/bin/flexlink.opt.exe
+
+            # Update symlinks to point to the wrapper
+            ln -sf flexlink.opt.exe $out/bin/flexlink.exe
+            ln -sf flexlink.opt.exe $out/bin/flexlink.opt
+            ln -sf flexlink.opt.exe $out/bin/flexlink
     '';
   })
 else

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -71,19 +71,23 @@ in
         if p ? pname then
           let
             pname = p.pname or (throw "`p.pname' not found: ${p.name}");
+            prefix1 = "ocaml${osuper.ocaml.version}-";
+            prefix2 = "ocaml-";
+            # For packages like ocaml-lsp-server, try stripping -server suffix
+            withoutServer = lib.removeSuffix "-server" pname;
           in
           natocamlPackages."${pname}" or
           # Some legacy packages are called `ocaml_X`, e.g. extlib and
           # sqlite3
-          natocamlPackages."ocaml_${pname}" or (
-            let
-              prefix1 = "ocaml${osuper.ocaml.version}-";
-              prefix2 = "ocaml-";
-            in
+          natocamlPackages."ocaml_${pname}" or
+          # Try without -server suffix (e.g., ocaml-lsp-server -> ocaml-lsp)
+          natocamlPackages."${withoutServer}" or (
             if lib.hasPrefix prefix1 p.pname then
               natocamlPackages."${(lib.removePrefix prefix1 pname)}"
             else if lib.hasPrefix prefix2 p.pname then
-              natocamlPackages."${(lib.removePrefix prefix2 pname)}"
+              natocamlPackages."${(lib.removePrefix prefix2 pname)}" or
+              # Also try the stripped version without ocaml- prefix
+              natocamlPackages."${(lib.removePrefix prefix2 withoutServer)}"
             else
               throw "Unsupported cross-pkg parsing for `${p.pname}'"
           )

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -16,6 +16,7 @@
   writeScriptBin,
   makeWrapper,
   stdenv,
+  windows ? null,
 }:
 let
   __mergeInputs =
@@ -173,6 +174,7 @@ in
           natocamlPackages
           osuper
           stdenv
+          windows
           ;
       };
 

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -179,6 +179,75 @@ in
       };
 
       findlib = osuper.findlib.overrideAttrs (o: {
+        # For mingw cross-compilation, we need to skip configure entirely
+        # and provide a pre-made Makefile.config, similar to opam-cross-windows
+        dontConfigure = stdenv.hostPlatform.isMinGW;
+
+        # Need native ocamlfind in PATH for OCAMLFIND_TOOLCHAIN to work
+        nativeBuildInputs =
+          (o.nativeBuildInputs or [ ]) ++ lib.optionals stdenv.hostPlatform.isMinGW [ natfindlib ];
+
+        preBuild = lib.optionalString stdenv.hostPlatform.isMinGW ''
+          # Create Makefile.config for mingw cross-compilation
+          # Skip configure which tries to run Windows binaries
+          cat > Makefile.config << EOF
+          OCAML_CORE_STDLIB=$out/lib/ocaml
+          OCAML_CORE_BIN=$out/bin
+          OCAML_CORE_MAN=$out/share/man
+          OCAML_SITELIB=$out/lib/ocaml/${oself.ocaml.version}/site-lib
+          OCAML_THREADS=posix
+          OCAMLFIND_BIN=$out/bin
+          OCAMLFIND_MAN=$out/share/man
+          OCAMLFIND_CONF=$out/etc/findlib.conf
+          OCAML_AUTOLINK=true
+          OCAML_REMOVE_DIRECTORY=1
+          EXEC_SUFFIX=.exe
+          LIB_SUFFIX=.a
+          CUSTOM=-custom
+          PARTS=findlib
+          INSTALL_TOPFIND=0
+          RELATIVE_PATHS=false
+          USE_CYGPATH=0
+          HAVE_NATDYNLINK=1
+          VERSION=${o.version}
+          ENABLE_TOPFIND_PPXOPT=true
+          SYSTEM=mingw64
+          NUMTOP=
+          OPAQUE=-opaque
+          CHECK_BEFORE_INSTALL=0
+          INSTALLFILE=install -c
+          INSTALLDIR=install -d
+          SH=sh
+          CP=cp
+          OCAMLOPT_G=-g
+          EOF
+
+          # Patch Makefile to use ocamlfind (for OCAMLFIND_TOOLCHAIN support)
+          # and to not build/install ocamlfind binary (we use native one)
+          substituteInPlace src/findlib/Makefile \
+            --replace-fail 'OCAMLC = ocamlc' 'OCAMLC = ocamlfind ocamlc' \
+            --replace-fail 'OCAMLOPT = ocamlopt' 'OCAMLOPT = ocamlfind ocamlopt' \
+            --replace-fail 'OCAMLDEP = ocamldep' 'OCAMLDEP = ocamlfind ocamldep' \
+            --replace-fail 'all: ocamlfind$(EXEC_SUFFIX)' 'all:'  \
+            --replace-fail 'opt: ocamlfind_opt$(EXEC_SUFFIX)' 'opt:'
+
+          # Remove the lines that install ocamlfind binary
+          sed -i '/f="ocamlfind/,/ocamlfind\$(EXEC_SUFFIX)"/d' src/findlib/Makefile
+
+          # Generate META files from templates (like opam-cross-windows gen_META.sh)
+          # This is needed so the findlib library can be found by other packages
+          for part in src/*; do
+            if [ -f "$part/META.in" ]; then
+              sed -e "s/@VERSION@/${o.version}/g" \
+                  -e "s/@REQUIRES@//g" \
+                  "$part/META.in" > "$part/META"
+            fi
+          done
+        '';
+
+        # For mingw: use native ocamlfind with OCAMLFIND_TOOLCHAIN
+        OCAMLFIND_TOOLCHAIN = lib.optionalString stdenv.hostPlatform.isMinGW crossName;
+
         postInstall = ''
           rm -rf $out/bin/ocamlfind
           cp ${natfindlib}/bin/ocamlfind $out/bin/ocamlfind
@@ -336,6 +405,7 @@ in
           "LIBDIR=$(OCAMLFIND_DESTDIR)/${o.pname}"
           "DOCDIR=$(out)/share/doc/${o.pname}"
         ];
+
         postInstall = ''
           mv $OCAMLFIND_DESTDIR/${o.pname}/{opam,${o.pname}.opam}
         '';

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -59,7 +59,8 @@ in
   (
     oself: osuper:
     let
-      crossName = lib.head (lib.splitString "-" stdenv.system);
+      crossName =
+        if stdenv.hostPlatform.isMinGW then "windows" else lib.head (lib.splitString "-" stdenv.system);
       natocamlPackages = getNativeOCamlPackages osuper;
       natocaml = natocamlPackages.ocaml;
       natfindlib = natocamlPackages.findlib;
@@ -291,7 +292,8 @@ in
   (
     oself: osuper:
     let
-      crossName = lib.head (lib.splitString "-" stdenv.system);
+      crossName =
+        if stdenv.hostPlatform.isMinGW then "windows" else lib.head (lib.splitString "-" stdenv.system);
       natocamlPackages = getNativeOCamlPackages osuper;
     in
     {

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -502,6 +502,7 @@ in
         configureFlags = [
         ];
         configurePhase = ''
+          ${lib.optionalString stdenv.hostPlatform.isMinGW ''export LDFLAGS="$NIX_LDFLAGS"''}
           ./configure -prefixnonocaml ${stdenv.cc.targetPrefix} -installdir $OCAMLFIND_DESTDIR
         '';
         preBuild = ''

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -398,15 +398,23 @@ in
       natocamlPackages = getNativeOCamlPackages osuper;
     in
     {
-      camlzip = osuper.camlzip.overrideAttrs (_: {
-        OCAMLFIND_TOOLCHAIN = "${crossName}";
-        preInstall = ''
-          mkdir -p $OCAMLFIND_DESTDIR/stublibs
-        '';
-        postInstall = ''
-          ln -sfn $OCAMLFIND_DESTDIR/{,caml}zip
-        '';
-      });
+      camlzip =
+        let
+          zlib = builtins.head osuper.camlzip.propagatedBuildInputs;
+        in
+        osuper.camlzip.overrideAttrs (o: {
+          OCAMLFIND_TOOLCHAIN = "${crossName}";
+          makeFlags = (o.makeFlags or [ ]) ++ [
+            "ZLIB_LIBDIR=${zlib.out}/lib"
+            "ZLIB_INCLUDE=${zlib.dev}/include"
+          ];
+          preInstall = ''
+            mkdir -p $OCAMLFIND_DESTDIR/stublibs
+          '';
+          postInstall = ''
+            ln -sfn $OCAMLFIND_DESTDIR/{,caml}zip
+          '';
+        });
 
       ctypes = osuper.ctypes.overrideAttrs (o: {
         postInstall = ''

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -436,6 +436,14 @@ in
           "DOCDIR=$(out)/share/doc/${o.pname}"
         ];
 
+        # For mingw: the binary is cmdliner.exe but install looks for cmdliner
+        # Create a symlink to fix the install, or just skip the binary
+        preInstall = lib.optionalString stdenv.hostPlatform.isMinGW ''
+          if [ -f _build/src/tool/cmdliner.exe ]; then
+            ln -sf cmdliner.exe _build/src/tool/cmdliner
+          fi
+        '';
+
         postInstall = ''
           mv $OCAMLFIND_DESTDIR/${o.pname}/{opam,${o.pname}.opam}
         '';

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -488,6 +488,14 @@ in
         }
       );
 
+      # memmem is a GNU extension not available on mingw
+      base_bigstring = osuper.base_bigstring.overrideAttrs (
+        o:
+        lib.optionalAttrs stdenv.hostPlatform.isMinGW {
+          patches = (o.patches or [ ]) ++ [ ./base_bigstring-memmem.patch ];
+        }
+      );
+
       carl =
         if lib.versionAtLeast osuper.ocaml.version "5.0" then
           osuper.carl.overrideAttrs (o: {

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -323,6 +323,12 @@ in
         '';
       });
 
+      eio_main =
+        if stdenv.hostPlatform.isMinGW && osuper ? eio_main then
+          fixOCamlPackage (osuper.eio_main.override { eio_posix = oself.eio_windows; })
+        else
+          fixOCamlPackage osuper.eio_main;
+
       cppo = natocamlPackages.cppo;
       dune_2 = natocamlPackages.dune;
       dune_3 = natocamlPackages.dune;

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -159,9 +159,35 @@ in
 
       fixOCamlPackage =
         b:
-        b.overrideAttrs (o: {
-          OCAMLFIND_CONF = makeFindlibConf (findNativePackage b) b;
-        });
+        b.overrideAttrs (
+          o:
+          {
+            OCAMLFIND_CONF = makeFindlibConf (findNativePackage b) b;
+          }
+          // lib.optionalAttrs stdenv.hostPlatform.isMinGW {
+            # Remove makeWrapper - shell wrappers don't work on Windows
+            nativeBuildInputs = lib.filter (p: !(p ? pname && p.pname == "make-shell-wrapper-hook")) (
+              o.nativeBuildInputs or [ ]
+            );
+            # caml/platform.h includes <pthread.h>; on mingw this comes from
+            # windows.pthreads. We need it in buildInputs for the headers, but
+            # its PE libraries in NIX_LDFLAGS break native build-time tools
+            # (nixpkgs#139966). Strip the -L flag; flexlink already has it baked in.
+            # OCaml 5.5+ uses native Windows threads and won't need this.
+            buildInputs =
+              (o.buildInputs or [ ])
+              ++ lib.optionals (lib.versionOlder osuper.ocaml.version "5.5") [ windows.pthreads ];
+            preConfigurePhases = (o.preConfigurePhases or [ ]) ++ [ "removeMingwPthreadsFromLdFlags" ];
+            removeMingwPthreadsFromLdFlags = lib.optionalString (lib.versionOlder osuper.ocaml.version "5.5") ''
+              NIX_LDFLAGS=$(echo "$NIX_LDFLAGS" | sed "s|-L${windows.pthreads}/lib||g")
+              export NIX_LDFLAGS
+            '';
+            # Clear postInstall if it uses wrapProgram (common pattern)
+            postInstall = lib.optionalString (!(lib.hasInfix "wrapProgram" (o.postInstall or ""))) (
+              o.postInstall or ""
+            );
+          }
+        );
     in
 
     (lib.mapAttrs (_: p: if p ? overrideAttrs then fixOCamlPackage p else p) osuper)

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -509,6 +509,17 @@ in
         }
       );
 
+      piaf =
+        if osuper.piaf == null then
+          null
+        else
+          osuper.piaf.overrideAttrs (
+            o:
+            lib.optionalAttrs stdenv.hostPlatform.isMinGW {
+              patches = (o.patches or [ ]) ++ [ ./piaf-mingw.patch ];
+            }
+          );
+
       carl =
         if lib.versionAtLeast osuper.ocaml.version "5.0" then
           osuper.carl.overrideAttrs (o: {

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -496,6 +496,13 @@ in
         }
       );
 
+      iomux = osuper.iomux.overrideAttrs (
+        o:
+        lib.optionalAttrs stdenv.hostPlatform.isMinGW {
+          patches = (o.patches or [ ]) ++ [ ./iomux-mingw.patch ];
+        }
+      );
+
       carl =
         if lib.versionAtLeast osuper.ocaml.version "5.0" then
           osuper.carl.overrideAttrs (o: {

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -471,6 +471,23 @@ in
         '';
       });
 
+      # ptime/mtime use `uname -s` to detect the OS and add -lrt on Linux.
+      # In cross-compilation, uname returns the build machine OS, not the
+      # target. Set the env var so -lrt is skipped — the C stubs already
+      # have native Windows support via _WIN32.
+      ptime = osuper.ptime.overrideAttrs (
+        o:
+        lib.optionalAttrs stdenv.hostPlatform.isMinGW {
+          PTIME_OS = "Win32";
+        }
+      );
+      mtime = osuper.mtime.overrideAttrs (
+        o:
+        lib.optionalAttrs stdenv.hostPlatform.isMinGW {
+          MTIME_OS = "Win32";
+        }
+      );
+
       carl =
         if lib.versionAtLeast osuper.ocaml.version "5.0" then
           osuper.carl.overrideAttrs (o: {

--- a/cross/piaf-mingw.patch
+++ b/cross/piaf-mingw.patch
@@ -1,0 +1,26 @@
+--- a/lib/stubs/piaf_fdutils.c	2026-04-20 11:09:24.478223354 +0200
++++ b/lib/stubs/piaf_fdutils.c	2026-04-20 11:10:05.021371414 +0200
+@@ -30,6 +30,18 @@
+  *---------------------------------------------------------------------------*/
+ 
+ #include <caml/mlvalues.h>
++
++#ifdef __MINGW32__
++#include <io.h>
++#include <windows.h>
++
++CAMLprim value piaf_is_fd_valid(value val_fd) {
++  intptr_t h = _get_osfhandle(Int_val(val_fd));
++  if (h == -1 || h == (intptr_t)INVALID_HANDLE_VALUE)
++    return Val_bool(0);
++  return Val_bool(1);
++}
++#else
+ #include <fcntl.h>
+ 
+ CAMLprim value piaf_is_fd_valid(value val_fd) {
+@@ -39,3 +51,4 @@
+     return Val_bool(0);
+   return Val_bool(1);
+ }
++#endif

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
               overlays = [ overlay ];
               config = {
                 allowUnfree = true;
+                allowUnsupportedSystem = true;
               }
               // nixpkgs.lib.optionalAttrs (system == "x86_64-darwin") {
                 config.replaceStdenv = { pkgs, ... }: pkgs.clang11Stdenv;

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -933,6 +933,20 @@ with oself;
 
   eio-ssl = if lib.versionAtLeast ocaml.version "5.0" then callPackage ./eio-ssl { } else null;
 
+  eio_windows =
+    if lib.versionAtLeast ocaml.version "5.0" then
+      buildDunePackage {
+        pname = "eio_windows";
+        inherit (eio) src version;
+        buildInputs = [ dune-configurator ];
+        propagatedBuildInputs = [
+          eio
+          fmt
+        ];
+      }
+    else
+      null;
+
   extlib-1-7-9 = osuper.extlib-1-7-9.overrideAttrs (_: {
     src = fetchFromGitHub {
       owner = "ygrek";

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -153,7 +153,8 @@ let
                   owner = "ocaml";
                   repo = "ocaml";
                   rev = "5.4.1";
-                  hash = "sha256-I7NuUvZMzm1B6krINX9nEyogW7dmZXXKgqPIw1zj7i4=";
+                  hash = "sha256-AGvdzJyn//Q7pc1SfoKQjX68EROSUE84bfkLCtMxq1k=";
+                  fetchSubmodules = true;
                 };
                 postPatch = ''
                   substituteInPlace "runtime/caml/camlatomic.h" \
@@ -174,7 +175,8 @@ let
               owner = "ocaml";
               repo = "ocaml";
               rev = "5.5.0-beta1";
-              hash = "sha256-sdO5UhltZUCll/6m3HwUIpudXj/SccdfEMRTuIpeMs0=";
+              hash = "sha256-1kVLOJVCgrw+vmTzag7T0oZWbNFrRelLQZ4cgP0VXZI=";
+              fetchSubmodules = true;
             };
           };
 

--- a/ocaml/piaf/default.nix
+++ b/ocaml/piaf/default.nix
@@ -9,6 +9,7 @@
   h2-eio,
   httpun-eio,
   ipaddr,
+  logs,
   magic-mime,
   pecu,
   prettym,
@@ -39,6 +40,7 @@ buildDunePackage {
     httpun-eio
     h2-eio
     ipaddr
+    logs
     magic-mime
     pecu
     prettym

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -57,5 +57,6 @@ overlay final prev
           static-overlay
         ];
 
+      mingwW64 = prev.pkgsCross.mingwW64.extend (prev.callPackage ../cross { });
     };
 }

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -58,5 +58,14 @@ overlay final prev
         ];
 
       mingwW64 = prev.pkgsCross.mingwW64.extend (prev.callPackage ../cross { });
+
+      mingwW64Static =
+        let
+          cross-overlay = (prev.callPackage ../cross { });
+        in
+        prev.pkgsCross.mingwW64.appendOverlays [
+          cross-overlay
+          static-overlay
+        ];
     };
 }

--- a/static/ocaml.nix
+++ b/static/ocaml.nix
@@ -13,8 +13,30 @@ let
       dontDisableStatic = true;
       preConfigure = ''
         ${o.preConfigure or null}
-        configureFlagsArray+=("PARTIALLD=$LD -r" "ASPP=$CC -c" "LIBS=-static" "STRIP=''${STRIP:strip}")
-      '';
+        configureFlagsArray+=("PARTIALLD=$LD -r" "ASPP=$CC -c" "STRIP=''${STRIP:-strip}")
+      ''
+      + (
+        if stdenv.hostPlatform.isMinGW then
+          ''
+            # For mingw/flexlink, use -static flag
+            configureFlagsArray+=("MKEXE=flexlink -static" "MKDLL=flexlink -static" "MKMAINDLL=flexlink -static")
+          ''
+        else
+          ''
+            configureFlagsArray+=("LIBS=-static")
+          ''
+      );
+
+      # For mingw static builds, modify the flexlink wrapper to use static mcfgthread
+      postInstall =
+        (o.postInstall or "")
+        + lib.optionalString stdenv.hostPlatform.isMinGW ''
+          # Replace dynamic -lmcfgthread with static -l:libmcfgthread.a in flexlink wrapper
+          # Also add -lntdll which mcfgthread needs for NT kernel functions
+          if [ -f $out/bin/flexlink.opt.exe ]; then
+            sed -i 's/-lmcfgthread/-l:libmcfgthread.a -lntdll/g' $out/bin/flexlink.opt.exe
+          fi
+        '';
     });
 
   fixOCamlPackage =


### PR DESCRIPTION
This PR adds mingw cross compilation support for OCaml 5.4 and 5.5. I've tried to keep the commits logical, so the details can be inspected in there. Static compilation is also supported.

My intention with these changes is to add them to the dune flake from which we can provide cross-compiled Windows (and maybe other) binaries in the future.

I've fixed some common packages that I've used for testing and the built binaries do work on Windows.

I'm unsure how much of this we wish to test in the CI so I've done a basic attempt.

- Alternative to #2091 
- Fixes #2018 

This will be followed by a way to cross-compile dune itself.