### PR TITLE
cross/ocaml-compiler: use NIX_BUILD_CORES instead of hardcoded -j500

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh pr view:*)",
+      "Bash(jj commit:*)",
+      "Bash(nix build:*)",
+      "Bash(xxd:*)",
+      "Bash(PATH=\"/tmp/mingw-cc/bin:/tmp/cross-ocaml/bin:$PATH\" )",
+      "Bash(LIBRARY_PATH=\"/tmp/mingw-pthreads/lib:$LIBRARY_PATH\":*)",
+      "Bash(/tmp/cross-ocaml/bin/ocamlopt.opt:*)",
+      "Bash(jj show:*)",
+      "Bash(curl:*)",
+      "Bash(jj log:*)",
+      "Bash(git -C /home/ali/repos/nix-overlays log --oneline --all)"
+    ]
+  }
+}

--- a/cross/ocaml-compiler.nix
+++ b/cross/ocaml-compiler.nix
@@ -38,7 +38,7 @@ if lib.versionOlder "5.4" osuper.ocaml.version then
     '';
     buildPhase = ''
       runHook preBuild
-      make crossopt -j500
+      make crossopt ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
       runHook postBuild
     '';
     installTargets = [ "installcross" ];


### PR DESCRIPTION
Respect the Nix sandbox's core count for the cross build instead of always requesting 500 parallel jobs.