### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775502230,
-        "narHash": "sha256-fAftaS6ehYk0cnokkyCyYU78UMFtOzLpxaaIDFFPwVQ=",
+        "lastModified": 1775814348,
+        "narHash": "sha256-wW/U49vd2vEVwnpSN122BAR0uRFz6U6NaPVeVdA5ghg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "40a78c7b16a0ecd9a8428fa7129246810da242a9",
+        "rev": "3ec049d0d1b13a6bda5232e00f1c6c25c5fa373a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "40a78c7b16a0ecd9a8428fa7129246810da242a9",
+        "rev": "3ec049d0d1b13a6bda5232e00f1c6c25c5fa373a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=40a78c7b16a0ecd9a8428fa7129246810da242a9";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=3ec049d0d1b13a6bda5232e00f1c6c25c5fa373a";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/98d231d9cad3993470e30dc01169bdc2a254537e"><pre>ocamlPackages.miou: 0.4.0 → 0.5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4afb0ec098ae96d0efe2012a89843a29395590fe"><pre>ocamlPackages.miou: 0.4.0 → 0.5.5 (#505903)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2bf39f7b5ab7b836242a800dfc1cfd5814baf1cb"><pre>ocamlPackages.httpcats: 0.2.0 → 0.2.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c7cd205126720a577135a4771e24982991e67dcf"><pre>ocamlPackages.httpcats: 0.2.0 → 0.2.1 (#507694)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/563249454d0a45ece81fb78a2f6f73ea4f7b206b"><pre>ocamlPackages.lwt_eio: 0.5.1 → 0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8d012e30b6a570a6be36867f0f8a0377414435af"><pre>ocamlPackages.linol: 0.10 -> 0.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5328032d5d4bc155c0dc2a574710a9c556d0a3cf"><pre>ocamlPackages.lwt_eio: 0.5.1 → 0.6 (#507797)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/737ed8fef482d0543b92e9a6e0764f86d368ccdd"><pre>ocamlPackages.linol: 0.10 -> 0.11 (#507830)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a9b57c69f314c300161ebcb4409a2642ad244162"><pre>tree-sitter-grammars.tree-sitter-ocamllex: init at 0.25.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/026f737325447137e169d340295b40e261550223"><pre>tree-sitter-grammars.tree-sitter-ocamllex: init (#504295)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4c4626a7c5cc0e81a45adc75a2aaf7485bd3f0be"><pre>ocamlPackages.luv: 0.5.12 -> 0.5.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/41b660719803ab4a584a82ef7e0e3bb0c5ff0157"><pre>ocamlPackages.luv: clean up ocaml version handling

OCaml 4.08 and below has been removed from nix so we can assume we have
at least 4.09.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5d7f24d5155a30f7b60d88f84c31a047887f1504"><pre>ocamlPackages.luv: clean up autotool file patching

Files named configure are already patched automatically:
97c43828fb7e016b4ee8fe434bc4d5e0b8a8b4be. We only need to worry about
ltmain.sh now.

Since we no longer have to worry about the missing substitution in
configure, we can use --replace-fail instead of --replace which avoids
the deprecation warning.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/981817f061b071ca6f4f733cf378bfa5185e11d8"><pre>ocamlPackages.luv: 0.5.12 -> 0.5.14 (#503553)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/40a78c7b16a0ecd9a8428fa7129246810da242a9...3ec049d0d1b13a6bda5232e00f1c6c25c5fa373a