### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775545155,
-        "narHash": "sha256-hTjWyj6wz9Iw6IjfrP+rZj1V1DjbVRCd1WjcpxH8Fqs=",
+        "lastModified": 1775903243,
+        "narHash": "sha256-T+a2qaFJw6/qOj/iB9l4p0E+qB04JTgyCJF1IIPJ8/w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f97e195236002ce34b91d43ffe68557ac7d007fc",
+        "rev": "3a9ff420afd6a6c19316093f014aa4eda7eb4f42",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f97e195236002ce34b91d43ffe68557ac7d007fc",
+        "rev": "3a9ff420afd6a6c19316093f014aa4eda7eb4f42",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=f97e195236002ce34b91d43ffe68557ac7d007fc";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=3a9ff420afd6a6c19316093f014aa4eda7eb4f42";
   };
 
   outputs =

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1467,18 +1467,6 @@ with oself;
     '';
   };
 
-  luv = osuper.luv.overrideAttrs (_: {
-    src = fetchFromGitHub {
-      owner = "aantron";
-      repo = "luv";
-      rev = "0.5.14";
-      hash = "sha256-N0rtBuxoHg45BqTf+aR8f6SfCEtiFVAspDgWfSkjH6w=";
-      fetchSubmodules = true;
-    };
-    patches = [ ];
-    doCheck = false;
-  });
-
   luv_unix = buildDunePackage {
     pname = "luv_unix";
     inherit (luv) version src;


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/2bf39f7b5ab7b836242a800dfc1cfd5814baf1cb"><pre>ocamlPackages.httpcats: 0.2.0 → 0.2.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c7cd205126720a577135a4771e24982991e67dcf"><pre>ocamlPackages.httpcats: 0.2.0 → 0.2.1 (#507694)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/563249454d0a45ece81fb78a2f6f73ea4f7b206b"><pre>ocamlPackages.lwt_eio: 0.5.1 → 0.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8d012e30b6a570a6be36867f0f8a0377414435af"><pre>ocamlPackages.linol: 0.10 -> 0.11</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5328032d5d4bc155c0dc2a574710a9c556d0a3cf"><pre>ocamlPackages.lwt_eio: 0.5.1 → 0.6 (#507797)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/737ed8fef482d0543b92e9a6e0764f86d368ccdd"><pre>ocamlPackages.linol: 0.10 -> 0.11 (#507830)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a9b57c69f314c300161ebcb4409a2642ad244162"><pre>tree-sitter-grammars.tree-sitter-ocamllex: init at 0.25.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/026f737325447137e169d340295b40e261550223"><pre>tree-sitter-grammars.tree-sitter-ocamllex: init (#504295)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4c4626a7c5cc0e81a45adc75a2aaf7485bd3f0be"><pre>ocamlPackages.luv: 0.5.12 -> 0.5.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/41b660719803ab4a584a82ef7e0e3bb0c5ff0157"><pre>ocamlPackages.luv: clean up ocaml version handling

OCaml 4.08 and below has been removed from nix so we can assume we have
at least 4.09.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5d7f24d5155a30f7b60d88f84c31a047887f1504"><pre>ocamlPackages.luv: clean up autotool file patching

Files named configure are already patched automatically:
97c43828fb7e016b4ee8fe434bc4d5e0b8a8b4be. We only need to worry about
ltmain.sh now.

Since we no longer have to worry about the missing substitution in
configure, we can use --replace-fail instead of --replace which avoids
the deprecation warning.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/981817f061b071ca6f4f733cf378bfa5185e11d8"><pre>ocamlPackages.luv: 0.5.12 -> 0.5.14 (#503553)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/f97e195236002ce34b91d43ffe68557ac7d007fc...3a9ff420afd6a6c19316093f014aa4eda7eb4f42