### PR TITLE
chore: remove marsam as maintainer in default.nix

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -75,7 +75,6 @@ let
       changelog = "https://github.com/ocaml/opam/raw/2.5.0/CHANGES";
       maintainers = [
         maintainers.henrytill
-        maintainers.marsam
       ];
       license = licenses.lgpl21Only;
       platforms = platforms.all;


### PR DESCRIPTION
`marsam` seems to be no longer on the [nixpkgs maintainer list](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix) which breaks usage of ocaml-overlays with nixos-unstable

```
> nix flake update ocaml-overlays
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at «github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa?narHash=sha256-ar3rofg%2BawPB8QXDaFJhJ2jJhu%2BKqN/PRCXeyuXR76E%3D»/pkgs/stdenv/generic/make-derivation.nix:541:11

       … while evaluating attribute 'buildInputs' of derivation 'nix-shell'
         at «github:NixOS/nixpkgs/4c1018dae018162ec878d42fec712642d214fdfa?narHash=sha256-ar3rofg%2BawPB8QXDaFJhJ2jJhu%2BKqN/PRCXeyuXR76E%3D»/pkgs/stdenv/generic/make-derivation.nix:593:11:
          592|           depsHostHost = elemAt (elemAt dependencies 1) 0;
          593|           buildInputs = elemAt (elemAt dependencies 1) 1;
             |           ^
          594|           depsTargetTarget = elemAt (elemAt dependencies 2) 0;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'marsam' missing
       at «github:nix-ocaml/nix-overlays/f6d03e9f2a94e1ec27cd02bb93204f759c3314fc?narHash=sha256-jPPhMIqU14QCm7XYpiMhmkwcDG6Lvcx%2B7hkvelHlUFQ%3D»/ocaml/default.nix:78:9:
           77|         maintainers.henrytill
           78|         maintainers.marsam
             |         ^
           79|       ];
       Did you mean one of marnas or marnym?
```