### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776268487,
+        "narHash": "sha256-oGUKCRR4qQGTgicxkiAHDd7w2YWCLtG9n8IWtNZPxo4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "6b3fb3b76b5c78cc108553d18bc949c7fad671c8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "6b3fb3b76b5c78cc108553d18bc949c7fad671c8",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=6b3fb3b76b5c78cc108553d18bc949c7fad671c8";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/896010e08afb65095ecffbde920e4f9b91155d12"><pre>ocamlPackages.dns: 10.2.3 -> 10.2.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/822792e19fdf1b5d0ecdc5d3ef2cd4b8be76e301"><pre>ocamlPackages.mariadb: 1.1.6 → 1.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5d216b39e999f65685c331a12e449815f63bc476"><pre>ocamlPackages.yamlx: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5f2a6394f0e996bb034b78fe565ca226410f031c"><pre>alt-ergo: 2.6.2 -> 2.6.3

Release: https://github.com/OCamlPro/alt-ergo/releases/tag/v2.6.3
Diff: https://github.com/OCamlPro/alt-ergo/compare/v2.6.2...v2.6.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e1961128cf2e17b3760ee6677cac162a6fe4083f"><pre>ocaml_mysql: 1.2.1 -> deleted

Quoting from https://github.com/ygrek/ocaml-mysql/blob/b9fa2443082f877897a99c0ed1f752d0721eccff/README

> NB the project is not maintained and likely unsafe to use with OCaml 5, see https://github.com/ygrek/ocaml-mysql/issues/18
>   you probably want to use https://github.com/ocaml-community/ocaml-mariadb instead

ocaml_mysql has no nixpkgs that depend on it.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/070445ff85f97e38297b75f01369581f14ca4234"><pre>ocaml_mysql: 1.2.1 -> deleted (#509990)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fae925babe2c54d48110978c72aaaf6763880494"><pre>ocamlPackages.dns: 10.2.3 -> 10.2.4 (#493663)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2234319e750b8452c0f044e7a5b65d1364ede48e"><pre>ocamlPackages.ppx_mikmatch: init at 1.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/be9d1704d9fdb1037600235076cae0c17cfd1195"><pre>ocamlPackages.ppx_mikmatch: init at 1.3 (#474702)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9385ddb6433102b6a2842ff5c89b873352a26410"><pre>ocamlPackages.mariadb: 1.1.6 → 1.3.0 (#509739)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6c20a6f6d9be2b8cbae65fd06899b62c42f9dfa4"><pre>ocamlPackages.yamlx: init at 0.1.0 (#509853)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9...6b3fb3b76b5c78cc108553d18bc949c7fad671c8