### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776927958,
-        "narHash": "sha256-XOzEtft7E0P6TgQViLUOQeGHlEYiQ0+FY24BPEksj6s=",
+        "lastModified": 1777014002,
+        "narHash": "sha256-x6BrXhfnsM2SG/n00O5o1Azn2txRHxU4cCZXiDZkFxU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fec2c46cca5bf9767486a290abae51200b656d69",
+        "rev": "15ebe06759175c2e98dba23c0b125913589094e7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fec2c46cca5bf9767486a290abae51200b656d69",
+        "rev": "15ebe06759175c2e98dba23c0b125913589094e7",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=fec2c46cca5bf9767486a290abae51200b656d69";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=15ebe06759175c2e98dba23c0b125913589094e7";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a9f0eef3a0eceb92f15324d78634dfe3344f74d0"><pre>ocamlPackages.atd: 4.0.0 → 4.1.0

ocamlPackages.atd-jsonlike: init at 4.1.0
ocamlPackages.atd-yamlx: init at 4.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0ad98ccec10e4a6a9b318dbea500f31bef8a9cb0"><pre>ocamlPackages.ocaml-version: 4.0.4 -> 4.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6f37a0d0b224a680a89e4777940a80b86f7cdadd"><pre>ocamlPackages.atd: 4.0.0 → 4.1.0 (#510483)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a3a5085aa7210b761936aba8e65104717d6e23ab"><pre>ocamlPackages.ocaml-version: 4.0.4 -> 4.1.0 (#511958)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/15ebe06759175c2e98dba23c0b125913589094e7"><pre>kyverno: 1.17.1 -> 1.17.2 (#512890)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/15ebe06759175c2e98dba23c0b125913589094e7"><pre>kyverno: 1.17.1 -> 1.17.2 (#512890)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/15ebe06759175c2e98dba23c0b125913589094e7"><pre>kyverno: 1.17.1 -> 1.17.2 (#512890)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/fec2c46cca5bf9767486a290abae51200b656d69...15ebe06759175c2e98dba23c0b125913589094e7