### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777282418,
-        "narHash": "sha256-d9n+0hStOP1OsXshp11saXi6Pj2e+OaDQSJJoT9x66E=",
+        "lastModified": 1777449270,
+        "narHash": "sha256-ewYYsuUyY4seI1f0hZosz45dp1tXq9h+kPMTqiUYkvM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfa1e6982e80e1b6a887a4e8d9f45dc9c98ede4d",
+        "rev": "53c960ee92d022291caf984741101b569918759b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfa1e6982e80e1b6a887a4e8d9f45dc9c98ede4d",
+        "rev": "53c960ee92d022291caf984741101b569918759b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=dfa1e6982e80e1b6a887a4e8d9f45dc9c98ede4d";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=53c960ee92d022291caf984741101b569918759b";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/da2aa63f832c8b89a5087a99d166d8f170ac8f08"><pre>ocamlPackages.earlybird: 1.3.5 -> 1.3.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/41359d74fa2208b32ec74962b99c7ad0db4e8242"><pre>ocamlPackages.earlybird: 1.3.5 -> 1.3.6 (#514311)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/00a033102d2d7116b780df996c347674f9d207cd"><pre>ocamlPackages.duration: 0.2.1 -> 0.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/249b26c9cbb528393c959405412f4823d3fe5e5b"><pre>ocamlPackages.duration: 0.2.1 -> 0.3.1 (#509580)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2d128537b873801952987fa446686299c7c0e943"><pre>ocamlPackages.checkseum: 0.5.2 -> 0.5.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/634cdc8eb3e6b2738065888438cedaff5540d8d8"><pre>ocamlPackages.checkseum: 0.5.2 -> 0.5.3 (#511535)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2fca561ed380a2856993c903aee0eff4ab5c253a"><pre>ocamlPackages.decoders: fix changelog urls

See #514132</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e57916398b98406d9e908e94a6ce39933ed74e0c"><pre>ocamlPackages.smtml: 0.25.0 → 0.26.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c10b9142f0d5f6bc455134a509f4d8f0bad057d9"><pre>ocamlPackages.decoders: fix changelog urls (#514522)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/82adf3f129e5211dd4cafe5d27cda1d415b9e010"><pre>ocamlPackages.smtml: 0.25.0 → 0.26.0 (#514528)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ab29a4e2e42264532edc5ed45a95cfff7a53a19e"><pre>ocamlPackages.yamlx: 0.1.0 → 0.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6f0ab84c6dd690c0de203ef91d52ab2d5a9a88e1"><pre>ocamlPackages.yamlx: 0.1.0 -> 0.3.0 (#512016)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/dfa1e6982e80e1b6a887a4e8d9f45dc9c98ede4d...53c960ee92d022291caf984741101b569918759b