### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777449270,
-        "narHash": "sha256-ewYYsuUyY4seI1f0hZosz45dp1tXq9h+kPMTqiUYkvM=",
+        "lastModified": 1777554572,
+        "narHash": "sha256-UmFofZDlG7wQuiLGma4TJGLgiGjrjKC3b8T/1GvFrGs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53c960ee92d022291caf984741101b569918759b",
+        "rev": "c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53c960ee92d022291caf984741101b569918759b",
+        "rev": "c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=53c960ee92d022291caf984741101b569918759b";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/6aa17ff4eba50c2f4fa9e3aefa096f065726348c"><pre>ocamlPackages.ocamlnet: don\'t use stringy license

This is mit bsd3 and gpl3 according to https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/blob/master/README.md</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f38184e9e775cbfe0dd7937c50c232f89a4e781c"><pre>ocamlPackages.dns: 10.2.4 → 10.2.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8f0c2c3c13012700fbcf60324349d87df353ab6"><pre>liquidsoap: 2.4.2 → 2.4.4

ocamlPackages.ffmpeg: 1.2.8 → 1.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/340a962145c25d0785ba53305edfd99d23b8f9fe"><pre>ocamlPackages.digestif: drop postCheck</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/070d240eb98688981be614e133b23aadead5f2cd"><pre>ocamlPackages.httpcats: drop (implicit) dependency on rresult</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6c568f32a5db7f18612e2c47b1763340de391702"><pre>ocamlPackages.bos: 0.2.1 → 0.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9ae716ebbbd1b7ac6dad4b554e159d31783ab7a2"><pre>ocamlPackages.postgresql: fix meta.changelog</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0e6d0d7ac7b0fd5c09ff6627a467775765cac66e"><pre>ocamlPackages.postgresql: fix meta.changelog (#514652)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a6e6ff3476bc015c7994e3d1a1b94b48e2dc5371"><pre>ocamlPackages.lwt: 6.1.1 -> 6.1.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a26e265895cd7cc2cef5ed29c8fdbb7dd86a384c"><pre>ocamlPackages.lwt: 6.1.1 -> 6.1.2 (#479413)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9c63777baf2a2a3b7af304596de278cafe24578e"><pre>ocamlPackages.bos: 0.2.1 -> 0.3.0 (#512776)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ff58c396f77a4a524e77dad33640c1ad9872b357"><pre>ocamlPackages.atdgen-codec-runtime: 4.1.0 -> 4.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8d91d90aff9d8a2dbe428989976a1e3e7eba0247"><pre>ocamlPackages.atdgen-codec-runtime: 4.1.0 -> 4.2.0 (#509202)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bf706776dcc246611be32e3a2ae47f27fa5db58e"><pre>ocamlPackages.dns: 10.2.4 → 10.2.5 (#512838)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d1f12a810a3d39ed904a58cf1fd2b0061b4c491c"><pre>ocamlPackages.ocamlnet: don\'t use stringy license (#512727)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/03e4d46144215391fcb915a3637e5f03206b6f6d"><pre>ocamlPackages.elpi: 3.6.2 -> 3.7.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/84a255aa9c9b88d408bdc0c3ce419030be5ad403"><pre>ocamlPackages.elpi: 3.6.2 -> 3.7.1 (#515012)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff"><pre>jaspr_cli: init at 0.23.0 (#491081)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/53c960ee92d022291caf984741101b569918759b...c3d7954dc42e4fa7fffe3def8214cea2a7cbbeff