### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778491576,
-        "narHash": "sha256-9YOHDS9ANGbRmf3DSQ9UCvas3CyYNIBwBkKGQZTLXGY=",
+        "lastModified": 1778930970,
+        "narHash": "sha256-FqqcYr0c5in/HRL5bkRWykAGp/Q10Vj/zUiSr1P8URE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1174f92bf37f1a5914be77e1b44482d6fbc75ecc",
+        "rev": "5a51fe22e18a6ce886b3cffa4c255378c151323c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1174f92bf37f1a5914be77e1b44482d6fbc75ecc",
+        "rev": "5a51fe22e18a6ce886b3cffa4c255378c151323c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=1174f92bf37f1a5914be77e1b44482d6fbc75ecc";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=5a51fe22e18a6ce886b3cffa4c255378c151323c";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/d887cb9758b6fbc43d2217202be3474933a5921c"><pre>ocamlPackages.reason-native.src: set license

source: https://github.com/reasonml/reason-native/blob/master/LICENSE</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/29314531c4bb0d1ce30443ebd64490ded25280eb"><pre>ocamlPackages.ca-certs: 1.0.1 → 1.0.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3b476d7cdc98db1761bf6b2ee64046a544d32f1e"><pre>ocamlPackages.ca-certs: 1.0.1 → 1.0.3 (#519288)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4ad2218c1be8243046876c1089f4eaa3d963ae47"><pre>ocamlPackages.reason-native.src: set license (#516525)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5bd889b1705207b82d420d46042b12fc8338b2b8"><pre>ocamlPackages.mirage-block-unix: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cf849300e7dfadbee9edaf7e50d8ebf9c8c61949"><pre>ocamlPackages.mirage-block: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ccecc3b826f912d5b5ac08f3b7e12820a6d3e7f9"><pre>ocamlPackages.mirage-bootvar-xen: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/decac3978cc60bdfa8a770156937ab429b4ee83b"><pre>ocamlPackages.mirage-clock: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d98942a1bc7c7d9b43607017176a7ee755b3da20"><pre>ocamlPackages.mirage-console: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/507e857ac3bce6047b3fec2a52926cd7cc1155c8"><pre>ocamlPackages.mirage-kv: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8a8b61403853c6b444a1b600b7bba7af77812837"><pre>ocamlPackages.mirage-logs: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/131e04cb4a319a75e3857c0d3729af49b9859411"><pre>ocamlPackages.mirage-nat: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0d6bba8e3c2b75e5a602fcf0332d0c7354562e9d"><pre>ocamlPackages.mirage-net: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cb7ae8da059cf09b1bac7bf2350d4174364ffcab"><pre>ocamlPackages.mirage-profile: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b35f00d2170102db125ba96d6a0b5086d1b6203e"><pre>ocamlPackages.mirage-protocols: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/618ba6b080231330653c810663348f8efadac9fe"><pre>ocamlPackages.mirage-random-test: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/578945fa2d09db8626085b5e10fcf8ca7cf6b42c"><pre>ocamlPackages.mirage-random: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e0e5a059046f5535445470b4c7d3efb41134963b"><pre>ocamlPackages.mirage-time: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7f27db9e30c1f2f66310c81c060425c9d4cf9737"><pre>ocamlPackages.mirage-unix: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/61c15901fad351b506c1608b89ffc9790635f70c"><pre>ocamlPackages.mirage-vnetif: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dfc0b322b9cfc50a4ee6ac9ef58692e3d1f01837"><pre>ocamlPackages.mirage-xen: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ebb1fb432fca2ceba9761bf01d10d28a9467ddf"><pre>ocamlPackages.mldoc: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/def68ef356680500fb0732d003e2279d9fd5b0d3"><pre>ocamlPackages.mm: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/30cea1a590500db623d62477429a6c0ace3b206a"><pre>ocamlPackages.mmap: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a73560ee5f88bf8621a0bb7ad91aa38899b9c283"><pre>ocamlPackages.mopsa: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/351d4648814501fd36f8dcc2ea5172fc7a97cc27"><pre>ocamlPackages.mrmime: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1dc555d2b388c071f72e7e482b7c3b9700576ce9"><pre>ocamlPackages.msat: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/58af940aa5ff64814a2368dd435b5f4319607808"><pre>ocamlPackages.msgpck: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4d045f4b40545d1eb87208f23c15cc534e8d324a"><pre>ocamlPackages.multicore-bench: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a26ae6280458dd3a67494752e1076b2aa2bdcd28"><pre>ocamlPackages.multicore-magic: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ee8b9bbe5eb26d4a7ca191c29b2ee4d00586e711"><pre>ocamlPackages.multipart-form-data: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5ac4ac91bc4115dba07b62824b05c095a9619661"><pre>ocamlPackages.mustache: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0e85f7e5036bb2eb9e7b05a762afa671f87279a4"><pre>ocamlPackages.netchannel: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e959d709794f8b9d0a8340c40659c3bd6eb9760c"><pre>ocamlPackages.nice_parser: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e4937dd1d408db60c10844eb6d644e76cf3375d2"><pre>ocamlPackages.notty: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/06e78b9b16ea939237b2f317ac04a38cb06cc0d7"><pre>ocamlPackages.npy: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ce0e3a57c005615fa3d2c4c70b5a2a5a024fe623"><pre>ocamlPackages.ocaml-lsp: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0da5b64654aedafe05f2ec3d3cb1f2460601cc0b"><pre>ocamlPackages.ocaml-migrate-parsetree: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/52581b0e377b422d0f6deeb108bf3019896813b7"><pre>ocamlPackages.ocaml-migrate-parsetree: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e25e675a8e984993e50a4ba462ad2d76285d7236"><pre>ocamlPackages.ocaml-monadic: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/24915109713df47428d91ce6ddfff64dc310a1a6"><pre>ocamlPackages.ocaml-protoc-plugin: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d1f41b214171146bd62eefd81ef439ea1aaa7b9d"><pre>ocamlPackages.ocaml-r: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/20d2b7d8f4e5df5cf77e77d3442bf80b195597b1"><pre>ocamlPackages.ocaml-result: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/30803288c98a51729a1ad1a339456e14e6ec053e"><pre>ocamlPackages.ocaml-version: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/01917f3091427773b4c02be62bd98f6e66846935"><pre>ocamlPackages.ocamlfuse: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6b6326ba26e8d342418d329f5363e404a605e303"><pre>ocamlPackages.ocamlgraph: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c32072bf19698555f86c78fb62f0333838f3f01d"><pre>ocamlPackages.ocamline: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0c4d594f3378e296a07a9a9539c3e297eb007502"><pre>ocamlPackages.ocolor: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9821096d9821f02564690132fedde461bb44d56e"><pre>ocamlPackages.ocplib-endian: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6a5c6d5e26501f54c43899f7cf3b30ce0a6afe0f"><pre>ocamlPackages.ocplib-simplex: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bbad9e79e963d363bea853df1596be56f89acfb5"><pre>ocamlPackages.octavius: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/582281c4f46dfa7c4fd89795b2e8c12c6fd8edb6"><pre>ocamlPackages.odate: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a2842ed6526421784c459c0edb4eb5533f5a06e0"><pre>ocamlPackages.odds: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2a09c4ae1828bf8e867f4fa8b35237e2b2f39b70"><pre>ocamlPackages.ogg: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/63d8551747f3d563db0d3a0bf2dc45aec16a073f"><pre>ocamlPackages.ohex: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1cbe36d2b633aacf5de274c21bd938c965a334f0"><pre>ocamlPackages.oidc: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/41c3df1d217ec4df394212dbf1af81f49c0e84c5"><pre>ocamlPackages.omd: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0dd797fd46b278783e8defd8f31f6d6481e61238"><pre>ocamlPackages.optint: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1ac5484e563101784ab29a0416be725d4de36406"><pre>ocamlPackages.oseq: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7cebe6c5c20f32d937a2fc5c776dc2bbe5db8800"><pre>ocamlPackages.otfed: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dd47b8b1d66121ce6e6e285b1be542b72838b9a2"><pre>ocamlPackages.otr: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3bf657dbc0c9eeb5acfab0cd28904e581409984c"><pre>ocamlPackages.ounit2: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/113029d6a5f2f7661bf592f0a5b9742c4c08c189"><pre>ocamlPackages.owee: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4a4e515524e244faf69c00371fb67461c3f9f4ce"><pre>ocamlPackages.paf: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/791cb2da826fa8e5b6392e025ffa115532750294"><pre>ocamlPackages.parany: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/514b59e51034f758de7b091c356e0ec63e071e39"><pre>ocamlPackages.parmap: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/697ce045783f8c74e3a748514de4fcf78c8b0a1b"><pre>ocamlPackages.parse-argv: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d1bb86680b105a7c85ea2f0ea6458d8bc4a4a189"><pre>ocamlPackages.patch: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/05f0e15386edaa1389cd4940dffa211f7c2232b7"><pre>ocamlPackages.patricia-tree: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fe49ab4621d9862573466eb9c4149b25a4b08f95"><pre>ocamlPackages.pbkdf: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/682b92af2f0244d7566c2f6d358714eb0c74a27f"><pre>ocamlPackages.pbrt: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/16c164d9203c07f7b8f0dcaea32783a254d2ce48"><pre>ocamlPackages.pcap-format: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2936fde4b40867805e47ba935d2d17dab85e97b6"><pre>ocamlPackages.pecu: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0c9a9d280bdfd6824ca303c735d5e2339bbca96d"><pre>ocamlPackages.pgocaml: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/374e7c10930996b3bbb1ff166b56c387502fa928"><pre>ocamlPackages.phylogenetics: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4cfc8d97a87b59b9887f7fa86df78a7f0569b687"><pre>ocamlPackages.piaf: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/17a49a4f324ae16a21957679570b4a92254fb23b"><pre>ocamlPackages.polynomial: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d9dbafa875e0958d8bb9d05ba14adb63feabab1"><pre>ocamlPackages.portaudio: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/649014446d5ef75a3d0716142cd2c8b3e6f69c43"><pre>ocamlPackages.postgresql: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4f50e9dda266511ef9a1c92833970e143ce438eb"><pre>ocamlPackages.pp: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/77e4bed685cdd55965cd1eb8f8e4e109d763fc57"><pre>ocamlPackages.pp_loc: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6d3a9bc092e3eb6e7aa15e981f27ab25727dda64"><pre>ocamlPackages.pprint: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0ef77a609757f827a26bf5be20fc3574bf6afa2d"><pre>ocamlPackages.ppx_bap: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/12bd828fac4d3deef53adbfee14675b880470707"><pre>ocamlPackages.ppx_blob: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8933c5072b085839bb9570ce9e5878570e0830f0"><pre>ocamlPackages.ppx_cstubs: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/50de546f145663c2829b1e2ef8a0d4e09c27ea92"><pre>ocamlPackages.ppx_derivers: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3184d53dc86314ba8e87f6cde09d5bbaa50403b7"><pre>ocamlPackages.ppx_deriving: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f21b4740df2d2e64f64a9b1ac62a23ca66332ac1"><pre>ocamlPackages.ppx_deriving_cmdliner: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/49507a566ab195a228ea0075237ae703c7ce31c8"><pre>ocamlPackages.ppx_deriving_protobuf: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a63cd29bae2b82dca1039f6ee137076bc87afa07"><pre>ocamlPackages.ppx_deriving_yaml: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/33d62f030f4b50ac9aeb49588f0ca7d0f9404a83"><pre>ocamlPackages.ppx_deriving_yojson: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f33fc90c85e9fdce3974b0aee918968bce625a60"><pre>ocamlPackages.ppx_gen_rec: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c82f9d289a01b5d1a316e1dae23d867fea782697"><pre>ocamlPackages.ppx_monad: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3e687038c36f46be137dd1979e7190fe17d6cc54"><pre>ocamlPackages.ppx_show: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b290b7eafa6976dfa9cef23870ccac99a6724cf8"><pre>ocamlPackages.ppx_tools_versioned: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7a38bee08268378784deb5e7d08929dc1f7903f1"><pre>ocamlPackages.ppx_yojson_conv_lib: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b138d633516f9d6e36eca476f20453c73a74f40a"><pre>ocamlPackages.ppxlib: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f6e1bb11db6d9d9bb66506a39e8ee76298f92fc2"><pre>ocamlPackages.pratter: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2576582185d62b2ac70fa6df2778f3145cdfa4ec"><pre>ocamlPackages.prelude: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/53fd02e0777f2f62fa5b8346a1318ff7ccd2d2b6"><pre>ocamlPackages.prettym: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/966d0629f3658f87c9811705c68394486b3bfaef"><pre>ocamlPackages.printbox: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7e83fd4711f216fdcf0377fd48fedff9ed33a9e2"><pre>ocamlPackages.processor: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f85052e2d06e6f51c53d06a4bac8ea789a539393"><pre>ocamlPackages.promise_jsoo: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a543758b97ff7830cbe504aaa2bf1e8da9de7f01"><pre>ocamlPackages.psmt2-frontend: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7ba2f554970b0c1d0e2fe4b8fa3734e9e99343d1"><pre>ocamlPackages.psq: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/66426dd225357609a958ecf7d9593436b0c6b88f"><pre>ocamlPackages.pulseaudio: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4eadf9d4e9589084b27ae861b7f132ad18152494"><pre>ocamlPackages.pure-splitmix: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a49f6cc05e82d8a02d741fb0453609ac0e256ab0"><pre>ocamlPackages.pyml: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5947e1c9a62a79c8656cbc6748c469eebfe18caf"><pre>ocamlPackages.qcheck: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a9fe8e7159b5ffbc71577e17a8cecd6ee9f30a33"><pre>ocamlPackages.qtest: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/59a88a37ee04e77595fdae116e3202f30cf3742e"><pre>ocamlPackages.randomconv: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/abfba03d60ed85cb51ef0950ce53a92e5e22b9a3"><pre>ocamlPackages.raylib: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ea93cbd618c45b6e19136b6a5369df5445ff7c06"><pre>ocamlPackages.raylib: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8281d9b8551c341b5a42b5a604e700d4f54ca0f6"><pre>ocamlPackages.rdbg: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/eea3eab2f6776644315abd3d14827a7195c4cbc5"><pre>ocamlPackages.re: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9c02628f2e38cad733fa54948a01b41d9ed61c16"><pre>ocamlPackages.reactivedata: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6bf0fe8df9e08d5f9c573cb41c13bcbb7a5a683e"><pre>ocamlPackages.redis: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d8ca420393c06b872de4b98b4724f98c946746d4"><pre>ocamlPackages.res: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6cb4d850e3decd8acd581f48661a112e11b5ea75"><pre>ocamlPackages.resource-pooling: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a62e2f5503dfd595f07dccba42a81654f8a7e78a"><pre>ocamlPackages.rfc7748: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d87fe9b01447fdd3be9807527139808b8691e775"><pre>ocamlPackages.ringo: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/67db0f2e73d68ede977710fa97c9c1a2e99e9939"><pre>ocamlPackages.rio: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/483eba44cd70f43d0bb9d318243790941b09d4c4"><pre>ocamlPackages.riot: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d7c2fc6f0d816cfd45c498a5847db52d80451227"><pre>ocamlPackages.rock: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7435054aa53f240a374f9213297f23fd962c849c"><pre>ocamlPackages.rosetta: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/519a7c9b879478f69a21a662b84c49a60b427dca"><pre>ocamlPackages.routes: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/42aa0b41a7488525886278ce29ca1f3ed901eed0"><pre>ocamlPackages.rpclib: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7fd84df3e7ebcf33897df02b2037cdbbbc1384e3"><pre>ocamlPackages.rusage: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/eda8a964b98e551c77166ada3cf1c14b6125d59b"><pre>ocamlPackages.saturn: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/40dd883339b8f065ed02c7c6167631d984df8fd9"><pre>ocamlPackages.scfg: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3f666107a79fbceef7407da6a4d0476f77fd5380"><pre>ocamlPackages.secp256k1-internal: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/25278990f0a944bc57f77c0bb5076664fa05d8c2"><pre>ocamlPackages.sedlex: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d8345bb3b61725d3cb010f5076560d59b839f3f4"><pre>ocamlPackages.sel: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/86725bc31573b11703953ff21cfddedb7f1a3225"><pre>ocamlPackages.semver: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1dee60f5a01ebd7ff7da830360e889d22ea48799"><pre>ocamlPackages.genspio: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/46b7a34334f6bd0d97ab517c2eee074517d83077"><pre>ocamlPackages.get-activity: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5f45dcfdb9ba1116eced0f1b259274c7c757090e"><pre>ocamlPackages.get-activity-lib: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/38be5fb1c76b2970217551ec322735f45c2a4824"><pre>ocamlPackages.getopt: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2ff654292a93a30fdf7f1606c8c9e31ced9820ea"><pre>ocamlPackages.git: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/878f36db8e82d962569c0cd56a3264511c50c2e0"><pre>ocamlPackages.github: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d37761e92d2c08b48036120966af8d682e1286ac"><pre>ocamlPackages.gitlab: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a1e2a3b104157e6b5a2fca82c20202d31356119f"><pre>ocamlPackages.gluon: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a06da2fa62082accad29a7c0cba424e942ac055d"><pre>ocamlPackages.gluten: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9240dde9c0e7b63f30f3964f9e31d23246222d1f"><pre>ocamlPackages.gmap: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/894230db30a963d073c1e8332f2f250a60aec757"><pre>ocamlPackages.graphql-cohttp: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dfa9e59dd366bba6655e18713c1d5c8ca19d7a1e"><pre>ocamlPackages.graphql: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/af0617c7b9aacee57050399bd6d258fed535bd72"><pre>ocamlPackages.gsl: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b363f01605540603d4a4279ec5ec83bb9372ee50"><pre>ocamlPackages.gstreamer: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/df88aab50e416a764d21c55f81d7a89289cbe651"><pre>ocamlPackages.hack_parallel: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2b27ea54eabe640c3a25958febf121d6ae6f9f44"><pre>ocamlPackages.happy-eyeballs: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4ec3c9ed2058e7835354f3cdb29a4005ed2ee6ab"><pre>ocamlPackages.hc: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8ff305985bdd4a0da5aca9bccbbc7d4dbf5b17cf"><pre>ocamlPackages.hex: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f65e7c62d7e65f9aa4a22f8a1ca107fba22fdbcc"><pre>ocamlPackages.hidapi: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/272b19374df98c932c31d0d5c464b1b78dca0ecb"><pre>ocamlPackages.higlo: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d40c18f3116f2860be927812cc6acc332f5651fc"><pre>ocamlPackages.hkdf: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/22633701792fe54749ad658a7649d4d07fab8611"><pre>ocamlPackages.hpack: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/208141a6f1d985767c099b070abbe08dfdadc875"><pre>ocamlPackages.httpaf: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a29f846146f5ca7caf280fadb0c74cd0f53311d1"><pre>ocamlPackages.httpun-ws: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/45883af4e880b16297d4dcef6eae8c88accced79"><pre>ocamlPackages.httpun: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/118bd50e6e655a210c66f5d59d0548dea5538dde"><pre>ocamlPackages.hxd: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/607371604eeaae450c4f721f162be94e0903145d"><pre>ocamlPackages.imagelib: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/744484752681a0382a3f7e22f481676518d447bb"><pre>ocamlPackages.index: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5710219cbc63e897e1a23abb158d3529df44767d"><pre>ocamlPackages.inotify: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dc3698d7e2bb3d0c1c09f69e5b081cd456d3f558"><pre>ocamlPackages.integers: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4637d8eafa4d0410a4c9573ada3a1c2271a7bf63"><pre>ocamlPackages.integers_stubs_js: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/755e3b65d04e30b6aa95f98dc5084037461dfdae"><pre>ocamlPackages.io-page: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5669c1de399d6bdc23dfea5a505fad40668e8f69"><pre>ocamlPackages.iomux: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a29c8d9f73fecaed36df0f9c40ff1a30ac33aac1"><pre>ocamlPackages.iri: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dc23a702312837eacb08566649f4a5750e46ece1"><pre>ocamlPackages.irmin: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/856d04eef953da7405623b259248fd092e8d599d"><pre>ocamlPackages.iter: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1b2516b9229a24fead168b275f3a43c56d54086b"><pre>ocamlPackages.jose: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ffdb7651ed420a29c3027ff18c816c76b79d2964"><pre>ocamlPackages.json-data-encoding: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b8e16f46e5838a4d9c929d3909101953fc6d525c"><pre>ocamlPackages.junit: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/07d10aee7878624ea6eb9198d5ca557e8797c7b3"><pre>ocamlPackages.jwto: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c273b87d0d23cfefdc406d4b9e31543291242a02"><pre>ocamlPackages.kafka: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b998e69227c75e5895a3b86880d84dad4f690266"><pre>ocamlPackages.kcas: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/49612f26bb1964dbf1bef9a7f0193c070a10e937"><pre>ocamlPackages.kdf: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f08e44bd8a53c8bd07c18426b49a53078dac7c1c"><pre>ocamlPackages.kdl: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/edf3c80a1a7dc4cb0ab5158bac0a32a58283c1ea"><pre>ocamlPackages.ke: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7b869043f446e887adf40f48648014c1d0ddd419"><pre>ocamlPackages.kicadsch: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7cab79975341d4351a52a51daa533a8ad1c3dafa"><pre>ocamlPackages.kqueue: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a7eeb65fe023d6d7847a6e65dad43cfcd1e46ad8"><pre>ocamlPackages.lablgtk3: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/df0dd0a0983a19d1defb5a75f6b6a247e356ae0f"><pre>ocamlPackages.lambdapi: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bccc889a0f09e48a99396088e642e337aeb183dc"><pre>ocamlPackages.lambdasoup: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c4c08c9931a20d76c84d01582e2259495f2b13c4"><pre>ocamlPackages.lame: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5dd15df9873da25a645c57f1a2ebf120e6e79729"><pre>ocamlPackages.landmarks: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/811e56f6b3c8a595256533ddbc143f8ebc043657"><pre>ocamlPackages.lastfm: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8cbc1fa865b0e6a4085c29167b73bd14b420e5ad"><pre>ocamlPackages.lens: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a5c0f24f161c75d802300172f857aa79f38e8af6"><pre>ocamlPackages.letsencrypt: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f3b04c66743257afe0839ac55783a2de56bab1c3"><pre>ocamlPackages.libc: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fbb1f576d32a9473478dea1332ed2b9e111ddf9f"><pre>ocamlPackages.lilv: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ddbacd27ed3387438cc2411776b1a22b5ca8a227"><pre>ocamlPackages.linenoise: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1d9de6ec2096980f8b7fc20112e73ea1dbcadc2e"><pre>ocamlPackages.lo: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/51bbe94fad853d6ca1764046141a569a1003bac6"><pre>ocamlPackages.lru: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e05f54e36c241d49269259386a7b664482009422"><pre>ocamlPackages.lua-ml: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ec5e4a8503a3a13ab0b6c6fff48ba272f68520f2"><pre>ocamlPackages.lun: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/914064d1bcc110f7001e0994f1efd14ed710ad61"><pre>ocamlPackages.lustre-v6: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f7586a37de5512e34560ce55f6c9d143d7dc24ec"><pre>ocamlPackages.lutils: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f3281bb0aeb963bd418c19bde7cda27c586af521"><pre>ocamlPackages.luv: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3498fdb8b7ef77d7569d664f2638aa6b19aa4287"><pre>ocamlPackages.lwt_eio: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8cffc04b3ecdf7ff30b6b538b3665cd5654e3175"><pre>ocamlPackages.lwt_ssl: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8c854899311d11e1d36d92bdff8a29f19a98833c"><pre>ocamlPackages.macaddr: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d10ee51bd02d7815cf1b2371ca69e2b1b610883c"><pre>ocamlPackages.mad: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f338dfad733732590e13007a45bf4b41c38bfa01"><pre>ocamlPackages.magic-mime: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cc903b8e2a81d526fda376754176b221a080f822"><pre>ocamlPackages.mccs: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cbf5b74112ddad777f7a4a88984f83d3fab7e1a3"><pre>ocamlPackages.mec: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3e3ca38c835b37b17a845941ef9490988fb3d7fb"><pre>ocamlPackages.melange-json: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a4e3a5223be0c13378bf179a42fd053b10fd3c0f"><pre>ocamlPackages.mem_usage: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1ca0bf03f4f6680c44ed25c8166a540ba9f767af"><pre>ocamlPackages.memprof-limits: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/183709c8462acefbff276ad5c1680a8a8279f3f7"><pre>ocamlPackages.memtrace: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4dc830660032c118699a71e128fb76da2b3cd6c2"><pre>ocamlPackages.merlin-extend: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f54d106e6362b7ad9af4740cc88a74e6686dd3a2"><pre>ocamlPackages.metadata: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f8066c3efa1e5f734200c809ffb883350a617fc8"><pre>ocamlPackages.metrics: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a197a460ff8cf5b44191ad3ef3523f0620edd401"><pre>ocamlPackages.middleware: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cab561198facd36aa0326d6b3ca3ab6eb627d3ef"><pre>ocamlPackages.mimic: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/10bf0cd38b56ac2e2472ecca19777bdfe8469bd8"><pre>ocamlPackages.minttea: migrate to finalAttrs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5410170f2c679755196cab23dd652449372f2d92"><pre>various: migrate ocaml packages to finalAttrs #4 (#482768)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/12cb899a954188a2cea2f1eeba07f6ba85d1d008"><pre>various: migrate ocaml packages to finalAttrs #3 (#482737)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/1174f92bf37f1a5914be77e1b44482d6fbc75ecc...5a51fe22e18a6ce886b3cffa4c255378c151323c