### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778930970,
-        "narHash": "sha256-FqqcYr0c5in/HRL5bkRWykAGp/Q10Vj/zUiSr1P8URE=",
+        "lastModified": 1779142197,
+        "narHash": "sha256-Fypu3KtYQ+ZXL91CZIGqS3ZKwrMH6GOSPCtJ07W3ecU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a51fe22e18a6ce886b3cffa4c255378c151323c",
+        "rev": "d4d6b67b138722feb847a75760a430943c33f4ef",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a51fe22e18a6ce886b3cffa4c255378c151323c",
+        "rev": "d4d6b67b138722feb847a75760a430943c33f4ef",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5a51fe22e18a6ce886b3cffa4c255378c151323c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=d4d6b67b138722feb847a75760a430943c33f4ef";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a62f385df3b74ccb12613001b3f2c95afb089b78"><pre>ber_metaocaml: 114 -> 153</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6ec5ca36b241798aa2f221acadf5373ff1c73095"><pre>ocamlPackages.camlp5: 8.04.00 -> 8.05.00</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0fb4fec10a437c436031daa0feff3a5670098197"><pre>ocamlPackages.rosetta: 0.3.0 -> 0.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e99630a3499cfcb9a0373da7daef946522b01168"><pre>ocamlPackages.ocb-stubblr: 0.1.0 -> 0.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4f59b7388d1f9bdff13ecb2d5bdca53e037fb0d8"><pre>ocamlPackages.dockerfile: 8.3.4 -> 8.3.9</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bd963c137fdf007d3fa7c92fa21f8708c0f92a0b"><pre>ber_metaocaml: 114 -> 153 (#508161)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aa422e0ecfa5c32f3e985b770bc193d198a8c48e"><pre>ocamlPackages.smtml: 0.26.0 -> 0.27.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db670722fe7747b637438e909096498736f55426"><pre>ocamlPackages.ocb-stubblr: 0.1.0 -> 0.1.1 (#520185)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6da1242d71fb39ad59a1001beade5fbf8adae621"><pre>ocamlPackages.dockerfile: 8.3.4 -> 8.3.9 (#503832)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d5bba66ab2b345144ef6e094078573e0dd4f482f"><pre>ocamlPackages.camlp5: 8.04.00 -> 8.05.00 (#518232)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/93ff109c4c20467489fa6d627e00732bb130915c"><pre>ocamlPackages.rosetta: 0.3.0 -> 0.4.0 (#518468)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5224bdecc09f30c82490d816b5c2cacfa72f7dd1"><pre>ocamlPackages.smtml: 0.26.0 -> 0.27.0 (#520431)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5a51fe22e18a6ce886b3cffa4c255378c151323c...d4d6b67b138722feb847a75760a430943c33f4ef