### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778930970,
-        "narHash": "sha256-FqqcYr0c5in/HRL5bkRWykAGp/Q10Vj/zUiSr1P8URE=",
+        "lastModified": 1779350018,
+        "narHash": "sha256-fHMrI2uuDNdQy0X6vgDdLoAHEMV4phk8OLtNMra7Vyk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a51fe22e18a6ce886b3cffa4c255378c151323c",
+        "rev": "657e2fa0760e27167cdacb1ec5d84782be312013",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a51fe22e18a6ce886b3cffa4c255378c151323c",
+        "rev": "657e2fa0760e27167cdacb1ec5d84782be312013",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=5a51fe22e18a6ce886b3cffa4c255378c151323c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=657e2fa0760e27167cdacb1ec5d84782be312013";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a62f385df3b74ccb12613001b3f2c95afb089b78"><pre>ber_metaocaml: 114 -> 153</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7c7fa82b6c27c8d9562f7e9d099845b47e91b7ee"><pre>treewide: Don\'t stabilize fetchpatch GitHub compare URLs

The index hash length problem only happens with fetchpatch2, not
fetchpatch. Don\'t cargo cult fixing this when it\'s not a problem.

This reverts most of commit 6388411ec2959f754029160cca7b88c30f935e52,
except:

- Conflicts:
  - pkgs/development/ocaml-modules/mysql/default.nix was deleted
- fetchpatch2 changes were not reverted:
  - pkgs/by-name/gi/gixy/package.nix
  - pkgs/development/python-modules/mohawk/default.nix
  - pkgs/development/python-modules/pyexcel-ods/default.nix</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/04ecfade8a19839595a898ef1ace9394b00fdbdc"><pre>ocamlPackages.elpi: Add update.sh</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c4eaa7e21baaf4f8d02f5286115c8d83d9d6ca8f"><pre>ocamlPackages.cmdliner: 2.1.0 -> 2.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db3549862b447783b39919a337886760f535b5c7"><pre>ocamlPackages.cmdliner: 2.1.0 -> 2.1.1 (#512603)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b88623e40b0f9deed0198360275b158f166f7da0"><pre>ocamlPackages.frama-c-lannotate: 0.2.4 -> 0.2.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6ec5ca36b241798aa2f221acadf5373ff1c73095"><pre>ocamlPackages.camlp5: 8.04.00 -> 8.05.00</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0fb4fec10a437c436031daa0feff3a5670098197"><pre>ocamlPackages.rosetta: 0.3.0 -> 0.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e99630a3499cfcb9a0373da7daef946522b01168"><pre>ocamlPackages.ocb-stubblr: 0.1.0 -> 0.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4f59b7388d1f9bdff13ecb2d5bdca53e037fb0d8"><pre>ocamlPackages.dockerfile: 8.3.4 -> 8.3.9</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bd963c137fdf007d3fa7c92fa21f8708c0f92a0b"><pre>ber_metaocaml: 114 -> 153 (#508161)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aa422e0ecfa5c32f3e985b770bc193d198a8c48e"><pre>ocamlPackages.smtml: 0.26.0 -> 0.27.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db670722fe7747b637438e909096498736f55426"><pre>ocamlPackages.ocb-stubblr: 0.1.0 -> 0.1.1 (#520185)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6da1242d71fb39ad59a1001beade5fbf8adae621"><pre>ocamlPackages.dockerfile: 8.3.4 -> 8.3.9 (#503832)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d5bba66ab2b345144ef6e094078573e0dd4f482f"><pre>ocamlPackages.camlp5: 8.04.00 -> 8.05.00 (#518232)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/93ff109c4c20467489fa6d627e00732bb130915c"><pre>ocamlPackages.rosetta: 0.3.0 -> 0.4.0 (#518468)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5224bdecc09f30c82490d816b5c2cacfa72f7dd1"><pre>ocamlPackages.smtml: 0.26.0 -> 0.27.0 (#520431)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7d2ff9cd16b48e6f6f6ef0e05fcd1b727adb8062"><pre>ocamlPackages.integers: 0.7.0 -> 0.8.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/33b99df1a89e97b4afa071b951e4953e7cbaf3f6"><pre>ocamlPackages.frama-c-luncov: 0.2.4 -> 0.2.4-unstable-2025-11-24</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/61f639d5378b0c6bab073a8fa1fd1e1aca814273"><pre>ocamlPackages.elpi: Add update.sh (#510929)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dd7cd5b559ec3b6b73eceb9f42a3d4ad1a7419ae"><pre>ocamlPackages.integers: 0.7.0 -> 0.8.0 (#522112)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/5a51fe22e18a6ce886b3cffa4c255378c151323c...657e2fa0760e27167cdacb1ec5d84782be312013