### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779142197,
-        "narHash": "sha256-Fypu3KtYQ+ZXL91CZIGqS3ZKwrMH6GOSPCtJ07W3ecU=",
+        "lastModified": 1779522599,
+        "narHash": "sha256-3F5IRy9EUlVYH9PYuBav+VVBSJsFK+XztqQ7AJU/I3M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4d6b67b138722feb847a75760a430943c33f4ef",
+        "rev": "492bd1f77a7ccf2e2858b3935fe209d3b31f9159",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4d6b67b138722feb847a75760a430943c33f4ef",
+        "rev": "492bd1f77a7ccf2e2858b3935fe209d3b31f9159",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=d4d6b67b138722feb847a75760a430943c33f4ef";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=492bd1f77a7ccf2e2858b3935fe209d3b31f9159";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/7c7fa82b6c27c8d9562f7e9d099845b47e91b7ee"><pre>treewide: Don\'t stabilize fetchpatch GitHub compare URLs

The index hash length problem only happens with fetchpatch2, not
fetchpatch. Don\'t cargo cult fixing this when it\'s not a problem.

This reverts most of commit 6388411ec2959f754029160cca7b88c30f935e52,
except:

- Conflicts:
  - pkgs/development/ocaml-modules/mysql/default.nix was deleted
- fetchpatch2 changes were not reverted:
  - pkgs/by-name/gi/gixy/package.nix
  - pkgs/development/python-modules/mohawk/default.nix
  - pkgs/development/python-modules/pyexcel-ods/default.nix</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/04ecfade8a19839595a898ef1ace9394b00fdbdc"><pre>ocamlPackages.elpi: Add update.sh</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c4eaa7e21baaf4f8d02f5286115c8d83d9d6ca8f"><pre>ocamlPackages.cmdliner: 2.1.0 -> 2.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/db3549862b447783b39919a337886760f535b5c7"><pre>ocamlPackages.cmdliner: 2.1.0 -> 2.1.1 (#512603)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b88623e40b0f9deed0198360275b158f166f7da0"><pre>ocamlPackages.frama-c-lannotate: 0.2.4 -> 0.2.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/7d2ff9cd16b48e6f6f6ef0e05fcd1b727adb8062"><pre>ocamlPackages.integers: 0.7.0 -> 0.8.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/33b99df1a89e97b4afa071b951e4953e7cbaf3f6"><pre>ocamlPackages.frama-c-luncov: 0.2.4 -> 0.2.4-unstable-2025-11-24</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/61f639d5378b0c6bab073a8fa1fd1e1aca814273"><pre>ocamlPackages.elpi: Add update.sh (#510929)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dd7cd5b559ec3b6b73eceb9f42a3d4ad1a7419ae"><pre>ocamlPackages.integers: 0.7.0 -> 0.8.0 (#522112)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5fc76386cda92aaef5189aade56a2bc96f84c373"><pre>ocamlPackages.tls: 2.0.2 → 2.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f08b9889908600d73b77f9a364b15ab9b04a35c4"><pre>ocamlPackages.tls: 2.0.2 → 2.1.0 (#522929)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/d4d6b67b138722feb847a75760a430943c33f4ef...492bd1f77a7ccf2e2858b3935fe209d3b31f9159