### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779720184,
-        "narHash": "sha256-dxXvCwkMB2W/ifiKztOJQlj1Q/q913xasNGL0BpNrIc=",
+        "lastModified": 1780011192,
+        "narHash": "sha256-luHrZG6I7Mwdt413XoDOYBpp9z1z6X23/5SNktwjM+k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b401e19c7941a94b2eca2ae650690156b9e8cb2c",
+        "rev": "3242faf14b7611a62ce0f0071619438a08b65c12",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b401e19c7941a94b2eca2ae650690156b9e8cb2c",
+        "rev": "3242faf14b7611a62ce0f0071619438a08b65c12",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=b401e19c7941a94b2eca2ae650690156b9e8cb2c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=3242faf14b7611a62ce0f0071619438a08b65c12";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/242ddaf0de4ca08655037786ec222dcf2fc75038"><pre>ocamlPackages.caqti: 2.2.4 -> 2.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/365964046ef0baebd5a4ce83c6ca303cc82fde8d"><pre>ocamlPackages.iri: 1.1.0 -> 1.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1bcf9b24d8b601c4feafb4ef5e8d2dab34cb85f3"><pre>ocamlPackages.mirage-crypto-rng: fix tests on x86_64-darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dd22c1adeae25589db469cbd0c5cdffadcf960e6"><pre>ocamlPackages.awa: 0.5.2 → 0.6.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1a30bf3037e89f72ca46b9b5a2798d47688950ab"><pre>ocamlPackages.caqti: 2.2.4 -> 2.3.1 (#508354)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/34af8693ae81e3da91c38ed38f9e0481de391874"><pre>ocamlPackages.awa: 0.5.2 -> 0.6.0 (#523429)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a8d1e46e750abb9256955682cd257d2344f9a444"><pre>ocamlPackages.tar: 3.3.0 → 3.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bae78f0861b229e108e2eb445f0c0a7ab46bdd39"><pre>ocamlPackages.iri: 1.1.0 -> 1.2.0 (#498685)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b5143834f645ca1fac975bda754289cf349512ee"><pre>ocamlPackages.camlp5: 8.05.00 → 8.05.01</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c19f0976a36b3b8e7a32839e5f9f695977c8b8e3"><pre>build-support/ocaml: remove throwIf usage</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bcd7a4e4cb5d47d18a192bf507335774f6727e80"><pre>ocamlPackages.lua-ml: 0.9.4 → 0.9.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bd3d39cc67da0e1898c1491c3ed3f68d9b1a7d91"><pre>ocamlPackages.mirage-crypto-rng: fix tests on x86_64-darwin (#521056)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f9afe36287cc86fedd6167cf39dbe8cc67148398"><pre>ocamlPackages.lua-ml: 0.9.4 → 0.9.5 (#524646)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f5453332c71345b43f37df1b953a9d74d1e92e78"><pre>ocamlPackages.tar: 3.3.0 → 3.5.0 (#524321)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b40d9f2d44e36f4f7bb5f49313f73e65a9cfdba3"><pre>ocamlPackages.camlp5: 8.05.00 → 8.05.01 (#522480)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f6045c00022bb1b651e1a524f1250a67f0d53fa6"><pre>ocamlPackages.rpclib: 9.0.0 → 10.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/71af050348310ccde5f2641159ce931b1c18feff"><pre>ocamlPackages.arp: 4.0.0 → 4.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d3773b2d9ead4fc55aff654479e7c55c34095291"><pre>ocamlPackages.rpclib: 9.0.0 → 10.2.0 (#525108)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/056b62a6c432446c8109f2e78c801dd1205529e6"><pre>ocamlPackages.arp: 4.0.0 → 4.1.0 (#525111)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3242faf14b7611a62ce0f0071619438a08b65c12"><pre>pretix: 2026.4.2 -> 2026.5.0 (#525036)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/b401e19c7941a94b2eca2ae650690156b9e8cb2c...3242faf14b7611a62ce0f0071619438a08b65c12