### PR TITLE
ci: build musl before arm64 cross packages

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -135,10 +135,7 @@ jobs:
           - { ocaml-version: 5_3, continue-on-error: false }
           - { ocaml-version: 5_4, continue-on-error: false }
           - { ocaml-version: 5_5, continue-on-error: false }
-        target:
-          - arm64
-          - musl
-    name: ${{matrix.target}} packages (OCaml ${{ matrix.setup.ocaml-version }})
+    name: Cross packages (OCaml ${{ matrix.setup.ocaml-version }})
     runs-on: ubuntu-latest
     env:
       NIXPKGS_ALLOW_UNFREE: 1
@@ -157,8 +154,15 @@ jobs:
           signingKey: ${{ secrets.R2_SIGNING_KEY }}
           awsAccessKeyId: ${{ secrets.R2_ACCESS_KEY_ID }}
           awsSecretAccessKey: ${{ secrets.R2_SECRET_ACESS_KEY }}
-      - name: Build nix packages
-        run : ./ci.sh x86_64-linux ${{matrix.target}}_${{matrix.setup.ocaml-version}}
+      - name: Build musl packages
+        run: |
+          echo "# musl packages (OCaml ${{ matrix.setup.ocaml-version }})" >> "$GITHUB_STEP_SUMMARY"
+          ./ci.sh x86_64-linux musl_${{matrix.setup.ocaml-version}}
+        continue-on-error: ${{ matrix.setup.continue-on-error }}
+      - name: Build arm64 packages
+        run: |
+          echo "# arm64 packages (OCaml ${{ matrix.setup.ocaml-version }})" >> "$GITHUB_STEP_SUMMARY"
+          ./ci.sh x86_64-linux arm64_${{matrix.setup.ocaml-version}}
         continue-on-error: ${{ matrix.setup.continue-on-error }}
 
   cross-compilers-mingw:


### PR DESCRIPTION
so they share the corresponding native packages.