### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780338866,
-        "narHash": "sha256-GDJZRXBPTssq1uvqVW4GTLIqo8QNheAsSslPnRTsY/Y=",
+        "lastModified": 1780475387,
+        "narHash": "sha256-JsufhU/MyfEEJMNmtmW0DY6LbOVIjjPS0zGQpHvgrBY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "228ae3b72880c28c3782209fb4cd9f3c99fb8dc8",
+        "rev": "c8560a2e8ad260841c482fe30731087b92f2223e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "228ae3b72880c28c3782209fb4cd9f3c99fb8dc8",
+        "rev": "c8560a2e8ad260841c482fe30731087b92f2223e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=228ae3b72880c28c3782209fb4cd9f3c99fb8dc8";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c8560a2e8ad260841c482fe30731087b92f2223e";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/7579aa29421e7fb5d2ed7da97040ed9448d1e10a"><pre>hol_light: unstable-2024-07-07 -> 0-unstable-2026-05-19

Build against the default OCaml (5.4) set instead of the 5.3 pin, using the
module-mode launcher (ocaml-hol). Carries a patch so the pa_j chooser
accepts camlp5 8.05, links findlib into ocaml-hol, and sets up the runtime
OCAMLPATH/CAML_LD_LIBRARY_PATH. Drops the camlp5 8.03.2 downgrade.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/176b638426326e66a2c75a6296ae76972fa3af0e"><pre>ocamlPackages: remove legacy uses of dune_3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2ed4e1df75d024433409dbd1db29096b56fd0c5b"><pre>hol_light: build against the default OCaml (5.4) (#525966)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5f28af7023b04be4852e0984e8628a72192c7f28"><pre>ocamlPackages: remove legacy uses of dune_3 (#526626)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8560a2e8ad260841c482fe30731087b92f2223e"><pre>mattermost: add patches for user limit and free banner removal (#527064)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8560a2e8ad260841c482fe30731087b92f2223e"><pre>mattermost: add patches for user limit and free banner removal (#527064)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/228ae3b72880c28c3782209fb4cd9f3c99fb8dc8...c8560a2e8ad260841c482fe30731087b92f2223e