### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780795668,
-        "narHash": "sha256-RAPmF/rximnsPEVkHxGuLAMekHsQWsFou+Dmqw5PjnQ=",
+        "lastModified": 1780981259,
+        "narHash": "sha256-GVdFp/OsVrwtvNe5f/o4PAv31sjxykYH3Kp2zIyJTeg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afdf13dce322e2aec0a57490a45df202367ec2e2",
+        "rev": "58f254b2fae09cec435a9480741ba3c749c4e1b6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afdf13dce322e2aec0a57490a45df202367ec2e2",
+        "rev": "58f254b2fae09cec435a9480741ba3c749c4e1b6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=afdf13dce322e2aec0a57490a45df202367ec2e2";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=58f254b2fae09cec435a9480741ba3c749c4e1b6";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/5319be66952711a42be8ad027e9b0681a122efcd"><pre>coq-lsp: add \`\$OCAMLFIND_DESTDIR\` to wrapper \`OCAMLPATH\`

\`wrapProgram\` in \`installPhase\` prepends propagated build inputs\'
\`\$OCAMLPATH\` but omits \`\$OCAMLFIND_DESTDIR\`, coq-lsp\'s own site-lib
containing the compiled serlib \`.cmxs\` plugins. At runtime Rocq\'s
plugin loader maps plugin names (e.g. \`rocq-runtime.plugins.ltac\`) to
serlib adapters (e.g. \`coq-lsp.serlib.ltac\`) and calls
\`Findlib.package_directory()\` to locate them. Without coq-lsp\'s own
output in \`OCAMLPATH\`, findlib fails and seven \"not available\" warnings
are emitted on every \`.v\` file.

\`\$OCAMLFIND_DESTDIR\` is set by the preceding \`dune install\` invocation.
Prepending it to the wrapper\'s \`OCAMLPATH\` ensures coq-lsp can discover
its own serlib plugins at runtime.

Assisted-by: Syzygy(tnxwqvtl)/OpenCode(1.14.48):zai-coding-plan/glm-5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/55854843924fbf0a590c44efe817c5fee6b16f44"><pre>ocamlPackages.dockerfile: 8.3.9 -> 8.4.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/33c831ec1ee30119f703459d5756e25ad5e70bfc"><pre>ocamlPackages.awa: 0.6.0 -> 0.6.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/191cceeb678273cc5769f5085936b6536c73616a"><pre>ocamlPackages.awa: 0.6.0 -> 0.6.1 (#529126)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f8fc7b191208f70651469fbb5ac1c3d1494589b9"><pre>coq-lsp: add \`\$OCAMLFIND_DESTDIR\` to wrapper \`OCAMLPATH\` (#523243)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1b918f0e7b67d98a6eea7b2858fb4b4892c22dc4"><pre>ocamlPackages.dockerfile: 8.3.9 -> 8.4.0 (#523699)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/afdf13dce322e2aec0a57490a45df202367ec2e2...58f254b2fae09cec435a9480741ba3c749c4e1b6