### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781160751,
-        "narHash": "sha256-dBIyf+gg33Fr1jdITRfENTALHUtMtLxBAyMqSq5ZGus=",
+        "lastModified": 1781523379,
+        "narHash": "sha256-KqIK9kkpi7h1Qo1mZFlPwbIJ5SBR7peUKba+5ammuDY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4ade1db48ff481708436f206a377be351a38974",
+        "rev": "352426357cd8843ab221b585a2bf6720d4a9bb74",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4ade1db48ff481708436f206a377be351a38974",
+        "rev": "352426357cd8843ab221b585a2bf6720d4a9bb74",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e4ade1db48ff481708436f206a377be351a38974";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=352426357cd8843ab221b585a2bf6720d4a9bb74";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/28c43f1cb3669e7cde42ca9a6cad97f0dc0cb48e"><pre>ocamlPackages.ocaml-r: 0.6.0 → 0.7.0

Fixes build with R 4.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4809582d2c2096b845f5ad087eb56d73a7c933c9"><pre>ocamlPackages.hxd: 0.4.0 -> 0.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a072f09c3060aae6a14b7012d34203f59d4e85ca"><pre>ocamlPackages.hxd: 0.4.0 -> 0.5.0 (#529742)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5b031c1bffa69631340ad29f5b8f4b1f63d1e5fb"><pre>ocamlPackages.timedesc: 3.1.0 → 3.1.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e3a68d77788bbcdca5cc67a6dca280ad2f0c49f8"><pre>ocamlPackages.timedesc: 3.1.0 -> 3.1.2 (#530714)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5f8241dcd9295d37e314eb977bff9d512efb7159"><pre>ocamlPackages.lun: 0.0.2 → 0.0.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6bbabafa8a2c6a4c1c68adfae9f57833a7722ba9"><pre>ocamlPackages.lun: 0.0.2 -> 0.0.3 (#527715)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/72de2cc871ba5a3b456c9c293cb2a5d677be0363"><pre>ocamlPackages.ocaml-r: 0.6.0 → 0.7.0 (#530217)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/22f4a7a1806d624e5a2cfd072c711fba981632a4"><pre>ocamlPackages.easy_logging: init at 0.8.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/be1266bb43fc41c6faef49607d9a95b959df78bb"><pre>ocamlPackages.charon: init at 2026.06.12</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ce4a299968e0e3586ddcd36fac626b8464e3a2bd"><pre>ocamlPackages.aeneas: init at 2026.06.12</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3f8f997ed361f193e5df315df2f01f094d4978c3"><pre>ocamlPackages.aeneas: init at 2026.06.12 (#530999)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/589c5f0938307135fb0403e5d7ef2336f39dbd7b"><pre>ocamlPackages.charon: 2026.06.12 -> 2026.06.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4f241557fbd005e5bf86c9cb7f4a74d4ef39b4a4"><pre>ocamlPackages.aeneas: 2026.06.12 -> 2026.06.14</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3349b2959e6bfafa221ab0fb2781e1d9d074531c"><pre>ocamlPackages.aeneas: 2026.06.12 -> 2026.06.14 (#531644)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ff1d209d7aa7eb349337e1d1dfe6a3e0943be201"><pre>ocamlPackages.charon: 2026.06.12 -> 2026.06.14 (#531643)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e4ade1db48ff481708436f206a377be351a38974...352426357cd8843ab221b585a2bf6720d4a9bb74