### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781836206,
-        "narHash": "sha256-BGjXqZOcLbkjwt8smyUskR8hNl7piTg8ccpQdSTw09s=",
+        "lastModified": 1781971108,
+        "narHash": "sha256-aR+FJrqOdjWWqkd88LdrDalCzKNSSbdZTO92I9LCSzY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4fea6b6bfce7b55c6df36fb973205b89d7fe761",
+        "rev": "c8c0b904d406666a948a59d6f52bb44059bc9c24",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4fea6b6bfce7b55c6df36fb973205b89d7fe761",
+        "rev": "c8c0b904d406666a948a59d6f52bb44059bc9c24",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=d4fea6b6bfce7b55c6df36fb973205b89d7fe761";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c8c0b904d406666a948a59d6f52bb44059bc9c24";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/c8c0b904d406666a948a59d6f52bb44059bc9c24"><pre>cubeb: 0-unstable-2026-06-09 -> 0-unstable-2026-06-15 (#533460)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8c0b904d406666a948a59d6f52bb44059bc9c24"><pre>cubeb: 0-unstable-2026-06-09 -> 0-unstable-2026-06-15 (#533460)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8c0b904d406666a948a59d6f52bb44059bc9c24"><pre>cubeb: 0-unstable-2026-06-09 -> 0-unstable-2026-06-15 (#533460)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8c0b904d406666a948a59d6f52bb44059bc9c24"><pre>cubeb: 0-unstable-2026-06-09 -> 0-unstable-2026-06-15 (#533460)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8c0b904d406666a948a59d6f52bb44059bc9c24"><pre>cubeb: 0-unstable-2026-06-09 -> 0-unstable-2026-06-15 (#533460)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8c0b904d406666a948a59d6f52bb44059bc9c24"><pre>cubeb: 0-unstable-2026-06-09 -> 0-unstable-2026-06-15 (#533460)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/d4fea6b6bfce7b55c6df36fb973205b89d7fe761...c8c0b904d406666a948a59d6f52bb44059bc9c24