### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782058286,
-        "narHash": "sha256-U7bO7gEY2KvrJ+Ha8tKQKJATdPi9Wf1ygrJLdVV6F+M=",
+        "lastModified": 1782378976,
+        "narHash": "sha256-UqQgBlQATXM3aBvzTRE/1wxHrCdKg5/ePlXfG/7Eqd8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1745eb556759f12578e02d8a45e782a7b5924e2b",
+        "rev": "5df71f3d167f0aad71658608361c1301147b9eb6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1745eb556759f12578e02d8a45e782a7b5924e2b",
+        "rev": "5df71f3d167f0aad71658608361c1301147b9eb6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=1745eb556759f12578e02d8a45e782a7b5924e2b";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=5df71f3d167f0aad71658608361c1301147b9eb6";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/fad6c551540c1d85f204504ed423936c3d1e9194"><pre>ocamlPackages.ca-certs-nss: 3.121 -> 3.125</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/67e55530a27eee83e81580c3ec33b82b41ee288e"><pre>ocamlPackages.pbrt: 2.4 → 4.1

ocamlPackages.ocaml-protoc: 2.4 → 4.1

ocamlPackages.pbrt_services: init at 4.1
ocamlPackages.pbrt_yojson: init at 4.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6998697633bff5b4f42d85971a897376d0e8354a"><pre>ocamlPackages.charon: 2026.06.14 -> 2026.06.22</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5c4c814fd00d334ba0a878fdd989f9df19013796"><pre>ocamlPackages.aeneas: 2026.06.14 -> 2026.06.22</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/74596aa065b8a0a8453707acfa3bc7932e9ecd77"><pre>ocamlPackages.charon: 2026.06.14 -> 2026.06.22 (#534471)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2e26e069021941150fb21d4f7b7981dce619d678"><pre>ocamlPackages.ca-certs-nss: 3.121 -> 3.125 (#517589)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/750c39e15073101fdef465eaa762e7ce441f9809"><pre>ocamlPackages.windtrap: init at 0.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4599616e95bd8e9d3806a3ceb5da1cea09030933"><pre>ocamlPackages.windtrap: init at 0.1.0 (#533330)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3c2ca0601c6cbe2e29ddb2fe19edda57a2dd116b"><pre>ocamlPackages.eliom: 12.0.1 -> 12.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2ce1578804eecf27a1492edad47cd0e7a17cede3"><pre>ocamlPackages.melange: 6.0.1 → 7.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f2e6d2ee2e4a3d3e5d47ac2bd0c696e1c8fedffb"><pre>ocamlPackages.eliom: 12.0.1 -> 12.1.0 (#534575)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/79eaf6b459ff707268dda7383bec105aa1044df4"><pre>ocamlPackages.pbrt: 2.4 → 4.1 (#534128)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/efa997b6e882d44fc0081ae0083d5008e0fe1acf"><pre>ocamlPackages.melange: 6.0.1 → 7.0.0 (#534809)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/1745eb556759f12578e02d8a45e782a7b5924e2b...5df71f3d167f0aad71658608361c1301147b9eb6