### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782903989,
-        "narHash": "sha256-1JLeRqAiyWO+uqkN3jg+QVBld9z2TNMRy0CNTLXsKII=",
+        "lastModified": 1783176197,
+        "narHash": "sha256-pCpbAkZsk6IYSeYUPyDRdkF1y0wSn9fxKyQxhUxt5nQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01db7d0addb897329193d09423fed99f8ff26c51",
+        "rev": "c148c8dc4d8befea368b3ce7b5fb5cf71dfba198",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01db7d0addb897329193d09423fed99f8ff26c51",
+        "rev": "c148c8dc4d8befea368b3ce7b5fb5cf71dfba198",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=01db7d0addb897329193d09423fed99f8ff26c51";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c148c8dc4d8befea368b3ce7b5fb5cf71dfba198";
   };
 
   outputs =

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -153,7 +153,7 @@ in
   # Stripped down postgres without the `bin` part, to allow static linking
   # with musl.
   libpq =
-    ((
+    (
       (super.callPackage "${nixpkgs}/pkgs/servers/sql/postgresql/18.nix" {
         inherit self;
       }).override
@@ -173,7 +173,6 @@ in
         zstd = self.zstd-oc;
         zlib = self.zlib-oc;
       }
-    ).withoutJIT
     ).overrideAttrs
       (
         finalAttrs: o:


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a986951c3a719c6ae468524d9710fa8397f72328"><pre>coqPackages.autosubst-ocaml: modernize mkCoqDerivation release hash format</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/acf7edcb2d111dd3de6a44a38bac1b0bb3fbdf05"><pre>ocamlPackages.charon: 2026.06.22 -> 2026.07.01</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e8fd6e43df180c83168010bd631d9d227fb4bd5"><pre>ocamlPackages.aeneas: sync version on charon</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/966d849dfc98635f19aff76f537fe99124bcfb38"><pre>ocamlPackages.charon: 2026.06.22 -> 2026.07.01 (#537535)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a4a2a9aa8ccc7ca9cd1fb5fdc338e2b66fc17dab"><pre>ocamlPackages.x509: 1.1.0 -> 1.1.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e9f9e224613e699aa566f7baa0c01d9d88d4c80c"><pre>ocamlPackages.x509: 1.1.0 -> 1.1.1 (#538135)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/01db7d0addb897329193d09423fed99f8ff26c51...c148c8dc4d8befea368b3ce7b5fb5cf71dfba198