### PR TITLE
cross: gate MinGW pthreads cleanup phase

### DIFF
--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -181,7 +181,11 @@ in
             buildInputs =
               (o.buildInputs or [ ])
               ++ lib.optionals (lib.versionOlder osuper.ocaml.version "5.5") [ windows.pthreads ];
-            preConfigurePhases = (o.preConfigurePhases or [ ]) ++ [ "removeMingwPthreadsFromLdFlags" ];
+            preConfigurePhases =
+              (o.preConfigurePhases or [ ])
+              ++ lib.optionals (lib.versionOlder osuper.ocaml.version "5.5") [
+                "removeMingwPthreadsFromLdFlags"
+              ];
             removeMingwPthreadsFromLdFlags = lib.optionalString (lib.versionOlder osuper.ocaml.version "5.5") ''
               NIX_LDFLAGS=$(echo "$NIX_LDFLAGS" | sed "s|-L${windows.pthreads}/lib||g")
               export NIX_LDFLAGS


### PR DESCRIPTION
## What

Only register the removeMingwPthreadsFromLdFlags phase for OCaml versions older than 5.5.

## Why

For OCaml 5.5, the phase body is already empty because the pthreads cleanup is guarded by lib.versionOlder osuper.ocaml.version "5.5". The phase name was still unconditionally appended to preConfigurePhases, so cross package builds tried to run a shell function that was never defined:

```
removeMingwPthreadsFromLdFlags: command not found
```

This showed up while building MinGW packages for OCaml 5.5, for example cmdliner/csexp/jane-street-headers in Dune's windows-static build.

## Testing

With this change applied together with the follow-up OCaml 5.5 launcher fix, this succeeds:

```
nix build .#legacyPackages.x86_64-linux.pkgsCross.mingwW64Static.ocaml-ng.ocamlPackages_5_5.cmdliner
```