### PR TITLE
cross: preserve OCaml 5.5 bytecode launchers

### DIFF
--- a/cross/ocaml-compiler.nix
+++ b/cross/ocaml-compiler.nix
@@ -61,6 +61,7 @@ if lib.versionOlder "5.4" osuper.ocaml.version then
         '-lgcc_eh' \
         ""
     '';
+    dontStrip = lib.versionAtLeast o.version "5.5";
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
## What

Disable generic Nix stripping for OCaml cross compiler packages starting with OCaml 5.5.

## Why

OCaml 5.5 installs bytecode tools such as `ocaml.exe`, `ocamlmklib.exe`, and other build-time tools as ELF bytecode launcher executables. In the MinGW cross compiler output, Nix fixup treated those launchers as ordinary ELF binaries and stripped them. That removed the bytecode payload, leaving tools that fail at runtime with:

```
not found or is not a bytecode executable file
```

This breaks OCaml 5.5 MinGW package builds when they invoke build-time tools from the cross compiler, for example while evaluating dune files or running helper build scripts.

OCaml 5.4 was unaffected because its cross `ocaml.exe` was installed as a script/text bytecode executable, so the generic strip phase did not damage it.

## Testing

```
nix build --no-link --print-out-paths .#legacyPackages.x86_64-linux.pkgsCross.mingwW64Static.ocaml-ng.ocamlPackages_5_5.ocaml
/nix/store/87ninyj3m92d57r3bmymskz823vmm01i-ocaml+flambda-x86_64-w64-mingw32-5.5.0/bin/ocaml -version
```

The version check prints:

```
The OCaml toplevel, version 5.5.0
```

The MinGW pthreads phase fix is already merged in #2512, so this PR is now only the launcher preservation fix.