### PR TITLE
ci: require OCaml 5.5 MinGW builds

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -168,7 +168,7 @@ jobs:
         setup:
           # mingw cross-compilation only supported on OCaml 5.4+
           - { ocaml-version: 5_4, continue-on-error: false }
-          - { ocaml-version: 5_5, continue-on-error: true }
+          - { ocaml-version: 5_5, continue-on-error: false }
     name: mingw packages (OCaml ${{ matrix.setup.ocaml-version }})
     runs-on: ubuntu-latest
     env:

--- a/cross/ocaml-compiler.nix
+++ b/cross/ocaml-compiler.nix
@@ -61,6 +61,7 @@ if lib.versionOlder "5.4" osuper.ocaml.version then
         '-lgcc_eh' \
         ""
     '';
+    dontStrip = lib.versionAtLeast o.version "5.5";
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
## What

Make the OCaml 5.5 MinGW CI job required by changing its matrix entry from `continue-on-error: true` to `false`.

## Why

The OCaml 5.5 MinGW job is already exercising the relevant cross package graph, including packages that use the OCaml 5.5 bytecode launchers. Keeping it as an allowed failure masked real regressions, including the stripped launcher failures fixed by #2513.

## Stacking

This PR is stacked on #2513. It should be rebased after #2513 merges so the final diff is only the CI policy change.

## Testing

This PR intentionally relies on CI. The MinGW 5.5 job should become a required signal once #2513 is present.