### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783441933,
-        "narHash": "sha256-AvS+udZTlBUUzzz4+Ru8GP3MKjmlF9p+eyfjjmFEvOM=",
+        "lastModified": 1783760736,
+        "narHash": "sha256-PEXS6z/zIvH+O7J3Ua3N2OUE7IvMhhghwtKxZhVfm5U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "409298523758f00a3d7b36c90499011a9f180494",
+        "rev": "bbb4df715cb62e53cd329090c2b69eb07f2bddac",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "409298523758f00a3d7b36c90499011a9f180494",
+        "rev": "bbb4df715cb62e53cd329090c2b69eb07f2bddac",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=409298523758f00a3d7b36c90499011a9f180494";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=bbb4df715cb62e53cd329090c2b69eb07f2bddac";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/f69f2fb4f5cc041546425ee565b054f1b702dc70"><pre>ocamlPackages.lsp: 1.25.0 → 1.26.0

dune: 3.21.1 -> 3.22.2

ocamlPackages.merlin: 5.6-504 → 5.7.1-504

ocaml-lsp-server: mark old versions as broken</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9eea37174f30b4fa6632099b312e7a376aaeefd9"><pre>ocamlPackages.lsp: 1.25.0 → 1.26.0 (#527279)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3d7e253bfdf5ce05f35bd8f4e8d2933ee977301"><pre>ocamlPackages.merlin: init at 5.8-505 for OCaml 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3a9a3fcc5aa7f43eba75da66cb17567323a6bba9"><pre>ocamlPackages.lsp: init at 1.27.0 for OCaml 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/eaa1851d424fd344072bf62cce4fd9abc2f12390"><pre>ocamlPackages.batteries: update for OCaml ≥ 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/61ae2648aa9c5a8afa131e115c6257c25522ac80"><pre>ocamlPackages.accessor_core: mark as broken with OCaml ≥ 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/463b1ae1c65ee7436eee40f4bfdd69b1d34bca21"><pre>ocamlPackages.ppx_import: mark as broken with OCaml ≥ 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9fc9431347481b81764e019d6ab4b93130a17c76"><pre>frama-c: mark as broken with OCaml ≥ 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5103b5b35b10b44256ac6398ea7a4f5b2e4f32fd"><pre>ocamlPackages.camlp4: fix eval for unsupported OCaml versions</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/844b1a9267f1994ea1a11ee99f7bb62e630f6850"><pre>ocamlPackages_5_5.ocaml: init at 5.5.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6eb243853e0700bf5d4df5f69ea4f3edd735544f"><pre>ocamlPackages.camlp4: init at 5.5+1 for OCaml 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/237b54f2e28fc6096ccb732001e77265be93154b"><pre>ocamlPackages_5_5.ocaml: init at 5.5.0 (#535150)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/659fb24b00f542d9d26312fa4f78eb139149208d"><pre>ocamlPackages.js_of_ocaml: 6.4.0 → 6.4.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3ce316d2f9df655b41b064f582cdf9e173948f04"><pre>vscode-extensions.ocamllabs.ocaml-platform: 2.0.1 -> 2.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6732caab8038606d54d8b8afa305b67752066fe5"><pre>vscode-extensions.ocamllabs.ocaml-platform: 2.0.1 -> 2.3.0 (#539032)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e31461c02c110bea33623f80802ed2909af54d9c"><pre>ocamlPackages.fuse3: init at 3.10.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/64f4a892cf01d1f967c1ddc6e0f09e69a16ac55e"><pre>ocamlPackages.gapi-ocaml: 0.4.8 → 0.4.9</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ddf679831790e97ce14e01496c4af5eef8203511"><pre>google-drive-ocamlfuse: 0.7.32 → 0.9.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5fe5356f613270189baf66b918f603bdb52604f1"><pre>google-drive-ocamlfuse: 0.7.32 → 0.9.0 (#538880)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c1bf7c6571f0bb9b8184710e9ca5031a101889c2"><pre>ocamlPackages.js_of_ocaml: 6.4.0 → 6.4.1 (#537652)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/caeb363b1c4886d7a18d711ac7c14c52c9e3da11"><pre>megam: migrate to ocaml-ng 4.14 and modernize build

- Switch from \`ocaml\` to \`ocaml-ng.ocamlPackages_4_14\` and inherit \`ocaml\`
  directly inside the derivation.
- Update \`src\` to use \`hash\` instead of deprecated \`sha256\`.
- Replace deprecated OCaml APIs using \`--replace-fail\` to ensure failures
  surface during patching.
- Enable \`__structuredAttrs\` for consistency with current package style.
- Remove redundant override in all-packages.nix now that the derivation
  selects the OCaml version internally.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f195e8d0daf72fddcdfebab829ad78e2d04adc15"><pre>megam: migrate to by-name; switch to ocaml-ng 4.14; modernize derivation (#539761)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bbb4df715cb62e53cd329090c2b69eb07f2bddac"><pre>lintspec: 0.17.0 -> 0.18.0 (#540500)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/409298523758f00a3d7b36c90499011a9f180494...bbb4df715cb62e53cd329090c2b69eb07f2bddac