### PR TITLE
Reuse native packages in musl cross overlays

### DIFF
--- a/cross/default.nix
+++ b/cross/default.nix
@@ -1,11 +1,15 @@
-{ buildPackages }:
+{
+  buildPackages,
+  nativeCC ? buildPackages.stdenv.cc,
+  nativeOCamlPackageSets ? null,
+}:
 
 self: super:
 
 super.lib.overlayOCamlPackages {
   inherit self super;
   overlays = super.callPackage ./ocaml.nix {
-    inherit buildPackages;
+    inherit buildPackages nativeCC nativeOCamlPackageSets;
   };
   updateOCamlPackages = true;
 }

--- a/cross/ocaml-compiler.nix
+++ b/cross/ocaml-compiler.nix
@@ -19,35 +19,55 @@ let
       null
     else
       builtins.removeAttrs nativeOCamlRuntime [ "__spliced" ];
-  hostOCaml =
+  mkLegacyHostOCaml =
+    {
+      tools,
+      runtime,
+    }:
+    runCommand "${tools.name}-with-musl-runtime" { } ''
+      mkdir -p $out
+      cp -rs ${tools}/* $out/
+      chmod u+w $out/lib/ocaml
+
+      replace_runtime_family() {
+        family="$1"
+        shift
+
+        for runtime_library in "$@"; do
+          if [ ! -e "$runtime_library" ]; then
+            echo "missing $family runtime libraries in ${runtime}/lib/ocaml" >&2
+            exit 1
+          fi
+
+          name="''${runtime_library##*/}"
+          rm -f "$out/lib/ocaml/$name"
+          ln -s "$runtime_library" "$out/lib/ocaml/$name"
+        done
+      }
+
+      replace_runtime_family libasmrun ${runtime}/lib/ocaml/libasmrun*
+      replace_runtime_family libcamlrun ${runtime}/lib/ocaml/libcamlrun*
+    '';
+  buildOCaml =
     if unsplicedNativeOCamlRuntime == null then
       natocaml
     else if usesUpstreamCross then
       unsplicedNativeOCamlRuntime
     else
-      runCommand "${natocaml.name}-with-musl-runtime" { } ''
-        mkdir -p $out
-        cp -rs ${natocaml}/* $out/
-        chmod u+w $out/lib/ocaml
-        for runtime in ${nativeOCamlRuntime}/lib/ocaml/libasmrun* ${nativeOCamlRuntime}/lib/ocaml/libcamlrun*; do
-          name="''${runtime##*/}"
-          rm -f "$out/lib/ocaml/$name"
-          ln -s "$runtime" "$out/lib/ocaml/$name"
-        done
-      '';
+      mkLegacyHostOCaml {
+        tools = natocaml;
+        runtime = unsplicedNativeOCamlRuntime;
+      };
   genWrapper =
     name: camlBin:
     writeScriptBin name ''
       #!${buildPackages.stdenv.shell}
-      NEW_ARGS=""
-
-      for ARG in "$@"; do NEW_ARGS="$NEW_ARGS \"$ARG\""; done
-      eval "${camlBin} $NEW_ARGS"
+      exec ${camlBin} "$@"
     '';
-  ocamlcHostWrapper = genWrapper "ocamlcHost.wrapper" "${hostOCaml}/bin/ocamlc.opt -I ${hostOCaml}/lib/ocaml -I ${hostOCaml}/lib/ocaml/stublibs -I +unix -nostdlib ";
-  ocamloptHostWrapper = genWrapper "ocamloptHost.wrapper" "${hostOCaml}/bin/ocamlopt.opt -I ${hostOCaml}/lib/ocaml -I +unix -nostdlib ";
+  ocamlcHostWrapper = genWrapper "ocamlcHost.wrapper" "${buildOCaml}/bin/ocamlc.opt -I ${buildOCaml}/lib/ocaml -I ${buildOCaml}/lib/ocaml/stublibs -I +unix -nostdlib ";
+  ocamloptHostWrapper = genWrapper "ocamloptHost.wrapper" "${buildOCaml}/bin/ocamlopt.opt -I ${buildOCaml}/lib/ocaml -I +unix -nostdlib ";
 
-  ocamlcTargetWrapper = genWrapper "ocamlcTarget.wrapper" "$BUILD_ROOT/ocamlc.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -I ${hostOCaml}/lib/ocaml/stublibs -nostdlib ";
+  ocamlcTargetWrapper = genWrapper "ocamlcTarget.wrapper" "$BUILD_ROOT/ocamlc.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -I ${buildOCaml}/lib/ocaml/stublibs -nostdlib ";
   ocamloptTargetWrapper = genWrapper "ocamloptTarget.wrapper" "$BUILD_ROOT/ocamlopt.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
 
 in
@@ -56,7 +76,7 @@ if usesUpstreamCross then
   osuper.ocaml.overrideAttrs (o: {
     depsBuildBuild = [
       (builtins.removeAttrs nativeCC [ "__spliced" ])
-      hostOCaml
+      buildOCaml
     ];
 
     # mingw needs pthreads for threading support
@@ -95,9 +115,9 @@ if usesUpstreamCross then
     '';
     installTargets = [ "installcross" ];
     postInstall = ''
-      cp ${hostOCaml}/bin/ocamllex $out/bin/ocamllex
-      cp ${hostOCaml}/bin/ocamlyacc $out/bin/ocamlyacc
-      cp ${hostOCaml}/bin/ocamlrun $out/bin/ocamlrun
+      cp ${buildOCaml}/bin/ocamllex $out/bin/ocamllex
+      cp ${buildOCaml}/bin/ocamlyacc $out/bin/ocamlyacc
+      cp ${buildOCaml}/bin/ocamlrun $out/bin/ocamlrun
     ''
     + lib.optionalString stdenv.hostPlatform.isMinGW ''
             # Remove Windows PE versions of tools that need to run on build machine
@@ -136,7 +156,7 @@ else
       depsBuildBuild = [ nativeCC ];
       preConfigure = ''
         configureFlagsArray+=("PARTIALLD=$LD -r" "ASPP=$CC -c")
-        installFlagsArray+=("OCAMLRUN=${hostOCaml}/bin/ocamlrun")
+        installFlagsArray+=("OCAMLRUN=${buildOCaml}/bin/ocamlrun")
       '';
       configureFlags = o.configureFlags ++ [ "--disable-ocamldoc" ];
       postConfigure = ''
@@ -149,7 +169,7 @@ else
       buildPhase = ''
         runHook preBuild
 
-        OCAML_HOST=${hostOCaml}
+        OCAML_HOST=${buildOCaml}
         OCAMLRUN="$OCAML_HOST/bin/ocamlrun"
         OCAMLLEX="$OCAML_HOST/bin/ocamllex"
         OCAMLYACC="$OCAML_HOST/bin/ocamlyacc"
@@ -222,7 +242,7 @@ else
         runHook postBuild
       '';
       installTargets = o.installTargets ++ [ "installoptopt" ];
-      postInstall = "cp ${hostOCaml}/bin/ocamlyacc $out/bin/ocamlyacc";
+      postInstall = "cp ${buildOCaml}/bin/ocamlyacc $out/bin/ocamlyacc";
       patches = [
         (
           if lib.versionOlder "5.3" o.version then

--- a/cross/ocaml-compiler.nix
+++ b/cross/ocaml-compiler.nix
@@ -2,7 +2,10 @@
   stdenv,
   lib,
   buildPackages,
+  nativeCC ? buildPackages.stdenv.cc,
+  nativeOCamlRuntime ? null,
   natocamlPackages,
+  runCommand,
   writeScriptBin,
   osuper,
   windows ? null,
@@ -10,6 +13,28 @@
 
 let
   natocaml = natocamlPackages.ocaml;
+  usesUpstreamCross = lib.versionAtLeast osuper.ocaml.version "5.4";
+  unsplicedNativeOCamlRuntime =
+    if nativeOCamlRuntime == null then
+      null
+    else
+      builtins.removeAttrs nativeOCamlRuntime [ "__spliced" ];
+  hostOCaml =
+    if unsplicedNativeOCamlRuntime == null then
+      natocaml
+    else if usesUpstreamCross then
+      unsplicedNativeOCamlRuntime
+    else
+      runCommand "${natocaml.name}-with-musl-runtime" { } ''
+        mkdir -p $out
+        cp -rs ${natocaml}/* $out/
+        chmod u+w $out/lib/ocaml
+        for runtime in ${nativeOCamlRuntime}/lib/ocaml/libasmrun* ${nativeOCamlRuntime}/lib/ocaml/libcamlrun*; do
+          name="''${runtime##*/}"
+          rm -f "$out/lib/ocaml/$name"
+          ln -s "$runtime" "$out/lib/ocaml/$name"
+        done
+      '';
   genWrapper =
     name: camlBin:
     writeScriptBin name ''
@@ -19,19 +44,19 @@ let
       for ARG in "$@"; do NEW_ARGS="$NEW_ARGS \"$ARG\""; done
       eval "${camlBin} $NEW_ARGS"
     '';
-  ocamlcHostWrapper = genWrapper "ocamlcHost.wrapper" "${natocaml}/bin/ocamlc.opt -I ${natocaml}/lib/ocaml -I ${natocaml}/lib/ocaml/stublibs -I +unix -nostdlib ";
-  ocamloptHostWrapper = genWrapper "ocamloptHost.wrapper" "${natocaml}/bin/ocamlopt.opt -I ${natocaml}/lib/ocaml -I +unix -nostdlib ";
+  ocamlcHostWrapper = genWrapper "ocamlcHost.wrapper" "${hostOCaml}/bin/ocamlc.opt -I ${hostOCaml}/lib/ocaml -I ${hostOCaml}/lib/ocaml/stublibs -I +unix -nostdlib ";
+  ocamloptHostWrapper = genWrapper "ocamloptHost.wrapper" "${hostOCaml}/bin/ocamlopt.opt -I ${hostOCaml}/lib/ocaml -I +unix -nostdlib ";
 
-  ocamlcTargetWrapper = genWrapper "ocamlcTarget.wrapper" "$BUILD_ROOT/ocamlc.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -I ${natocaml}/lib/ocaml/stublibs -nostdlib ";
+  ocamlcTargetWrapper = genWrapper "ocamlcTarget.wrapper" "$BUILD_ROOT/ocamlc.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -I ${hostOCaml}/lib/ocaml/stublibs -nostdlib ";
   ocamloptTargetWrapper = genWrapper "ocamloptTarget.wrapper" "$BUILD_ROOT/ocamlopt.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
 
 in
 
-if lib.versionOlder "5.4" osuper.ocaml.version then
+if usesUpstreamCross then
   osuper.ocaml.overrideAttrs (o: {
     depsBuildBuild = [
-      buildPackages.stdenv.cc
-      natocaml
+      (builtins.removeAttrs nativeCC [ "__spliced" ])
+      hostOCaml
     ];
 
     # mingw needs pthreads for threading support
@@ -70,9 +95,9 @@ if lib.versionOlder "5.4" osuper.ocaml.version then
     '';
     installTargets = [ "installcross" ];
     postInstall = ''
-      cp ${natocaml}/bin/ocamllex $out/bin/ocamllex
-      cp ${natocaml}/bin/ocamlyacc $out/bin/ocamlyacc
-      cp ${natocaml}/bin/ocamlrun $out/bin/ocamlrun
+      cp ${hostOCaml}/bin/ocamllex $out/bin/ocamllex
+      cp ${hostOCaml}/bin/ocamlyacc $out/bin/ocamlyacc
+      cp ${hostOCaml}/bin/ocamlrun $out/bin/ocamlrun
     ''
     + lib.optionalString stdenv.hostPlatform.isMinGW ''
             # Remove Windows PE versions of tools that need to run on build machine
@@ -108,15 +133,15 @@ else
       isOCaml5 = lib.versionOlder "5.0" o.version;
     in
     {
-      depsBuildBuild = [ buildPackages.stdenv.cc ];
+      depsBuildBuild = [ nativeCC ];
       preConfigure = ''
         configureFlagsArray+=("PARTIALLD=$LD -r" "ASPP=$CC -c")
-        installFlagsArray+=("OCAMLRUN=${natocaml}/bin/ocamlrun")
+        installFlagsArray+=("OCAMLRUN=${hostOCaml}/bin/ocamlrun")
       '';
       configureFlags = o.configureFlags ++ [ "--disable-ocamldoc" ];
       postConfigure = ''
         cp Makefile.config Makefile.config.bak
-        echo 'SAK_CC=${buildPackages.stdenv.cc}/bin/gcc' >> Makefile.config
+        echo 'SAK_CC=${nativeCC}/bin/gcc' >> Makefile.config
         echo 'SAK_CFLAGS=$(OC_CFLAGS) $(OC_CPPFLAGS)' >> Makefile.config
         echo 'SAK_LINK=$(SAK_CC) $(SAK_CFLAGS) $(OUTPUTEXE)$(1) $(2)' >> Makefile.config
       '';
@@ -124,7 +149,7 @@ else
       buildPhase = ''
         runHook preBuild
 
-        OCAML_HOST=${natocaml}
+        OCAML_HOST=${hostOCaml}
         OCAMLRUN="$OCAML_HOST/bin/ocamlrun"
         OCAMLLEX="$OCAML_HOST/bin/ocamllex"
         OCAMLYACC="$OCAML_HOST/bin/ocamlyacc"
@@ -197,7 +222,7 @@ else
         runHook postBuild
       '';
       installTargets = o.installTargets ++ [ "installoptopt" ];
-      postInstall = "cp ${natocaml}/bin/ocamlyacc $out/bin/ocamlyacc";
+      postInstall = "cp ${hostOCaml}/bin/ocamlyacc $out/bin/ocamlyacc";
       patches = [
         (
           if lib.versionOlder "5.3" o.version then

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -12,6 +12,9 @@
   lib,
   replaceVars,
   buildPackages,
+  nativeCC ? buildPackages.stdenv.cc,
+  nativeOCamlPackageSets ? null,
+  runCommand,
   writeText,
   writeScriptBin,
   makeWrapper,
@@ -37,14 +40,15 @@ let
     in
     lib.attrValues acc;
 
-  getNativeOCamlPackages =
-    osuper:
+  getOCamlPackages =
+    packageSets: osuper:
     let
       version = lib.stringAsChars (x: if x == "." then "_" else x) (
         builtins.substring 0 (if lib.hasPrefix "5." osuper.ocaml.version then 3 else 4) osuper.ocaml.version
       );
     in
-    buildPackages.ocaml-ng."ocamlPackages_${version}";
+    packageSets."ocamlPackages_${version}";
+
 in
 [
   # This currently needs to be split into 2 functions, to a) avoid infinite
@@ -62,7 +66,12 @@ in
     let
       crossName =
         if stdenv.hostPlatform.isMinGW then "windows" else lib.head (lib.splitString "-" stdenv.system);
-      natocamlPackages = getNativeOCamlPackages osuper;
+      natocamlPackages = getOCamlPackages buildPackages.ocaml-ng osuper;
+      nativeOCamlRuntime =
+        if nativeOCamlPackageSets == null then
+          null
+        else
+          (getOCamlPackages nativeOCamlPackageSets osuper).ocaml;
       natocaml = natocamlPackages.ocaml;
       natfindlib = natocamlPackages.findlib;
       natdune = natocamlPackages.dune;
@@ -204,6 +213,9 @@ in
         inherit
           lib
           buildPackages
+          nativeCC
+          nativeOCamlRuntime
+          runCommand
           writeScriptBin
           natocamlPackages
           osuper
@@ -405,7 +417,7 @@ in
     let
       crossName =
         if stdenv.hostPlatform.isMinGW then "windows" else lib.head (lib.splitString "-" stdenv.system);
-      natocamlPackages = getNativeOCamlPackages osuper;
+      natocamlPackages = getOCamlPackages buildPackages.ocaml-ng osuper;
     in
     {
       camlzip =

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -27,6 +27,24 @@ overlay final prev
   pkgsCross =
     let
       static-overlay = import ../static;
+      musl64 = prev.pkgsCross.musl64.extend static-overlay;
+      native-musl-cc =
+        let
+          cc = musl64.stdenv.cc;
+        in
+        prev.runCommand "native-musl-cc-wrapper" { } ''
+          mkdir -p $out/bin
+          for tool in ${cc}/bin/${cc.targetPrefix}*; do
+            name="''${tool##*/}"
+            ln -s "$tool" "$out/bin/$name"
+            ln -s "$tool" "$out/bin/''${name#${cc.targetPrefix}}"
+          done
+        '';
+      musl-cross-overlay = prev.callPackage ../cross {
+        buildPackages = prev.buildPackages;
+        nativeCC = native-musl-cc;
+        nativeOCamlPackageSets = musl64.ocaml-ng;
+      };
     in
     prev.pkgsCross
     // {
@@ -36,26 +54,18 @@ overlay final prev
         in
         prev.pkgsCross.aarch64-multiplatform.extend cross-overlay;
 
-      aarch64-multiplatform-musl =
-        let
-          cross-overlay = (prev.pkgsMusl.callPackage ../cross { });
-        in
-        prev.pkgsCross.aarch64-multiplatform-musl.appendOverlays [
-          cross-overlay
-          static-overlay
-        ];
+      aarch64-multiplatform-musl = prev.pkgsCross.aarch64-multiplatform-musl.appendOverlays [
+        musl-cross-overlay
+        static-overlay
+      ];
 
-      musl64 = prev.pkgsCross.musl64.extend static-overlay;
+      inherit musl64;
 
       riscv64 = prev.pkgsCross.riscv64.extend (prev.callPackage ../cross { });
-      riscv64-musl =
-        let
-          cross-overlay = (prev.pkgsMusl.callPackage ../cross { });
-        in
-        prev.pkgsCross.riscv64-musl.appendOverlays [
-          cross-overlay
-          static-overlay
-        ];
+      riscv64-musl = prev.pkgsCross.riscv64-musl.appendOverlays [
+        musl-cross-overlay
+        static-overlay
+      ];
 
       mingwW64 = prev.pkgsCross.mingwW64.extend (prev.callPackage ../cross { });
 


### PR DESCRIPTION
Use native build packages when constructing musl cross overlays, avoiding uncached musl-flavoured native toolchains.

Follow-up to #2515.