### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783564090,
-        "narHash": "sha256-ajlPoJbp28hK8Zgua3n+g4LuzGVGlKfs94jA2VVUa3Q=",
+        "lastModified": 1783804422,
+        "narHash": "sha256-QDvePo91u7wLujlzbYT47Q/ZdLWXtWTK/dHvY4fqpq0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ab0784f4b4b98a4f100d4cb2245d791cdccf70a",
+        "rev": "25de74a7cf86e4917018e78eea2311f806efc1d2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ab0784f4b4b98a4f100d4cb2245d791cdccf70a",
+        "rev": "25de74a7cf86e4917018e78eea2311f806efc1d2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=9ab0784f4b4b98a4f100d4cb2245d791cdccf70a";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=25de74a7cf86e4917018e78eea2311f806efc1d2";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/caeb363b1c4886d7a18d711ac7c14c52c9e3da11"><pre>megam: migrate to ocaml-ng 4.14 and modernize build

- Switch from \`ocaml\` to \`ocaml-ng.ocamlPackages_4_14\` and inherit \`ocaml\`
  directly inside the derivation.
- Update \`src\` to use \`hash\` instead of deprecated \`sha256\`.
- Replace deprecated OCaml APIs using \`--replace-fail\` to ensure failures
  surface during patching.
- Enable \`__structuredAttrs\` for consistency with current package style.
- Remove redundant override in all-packages.nix now that the derivation
  selects the OCaml version internally.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f195e8d0daf72fddcdfebab829ad78e2d04adc15"><pre>megam: migrate to by-name; switch to ocaml-ng 4.14; modernize derivation (#539761)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/9ab0784f4b4b98a4f100d4cb2245d791cdccf70a...25de74a7cf86e4917018e78eea2311f806efc1d2