### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784087100,
-        "narHash": "sha256-4jFMNTCCFYP7BfYanzw31ESHRDiOfShYEd/kI+T0ks8=",
+        "lastModified": 1784280447,
+        "narHash": "sha256-uNupmWBGix4Eak5wmEsA8K8p7tesH1tEy3HnbANF9DM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c552e6d492ac42d6039dc92a4dd7d608aced167a",
+        "rev": "a53c7797377b2ee8b019920ab4f183937b9dfab5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c552e6d492ac42d6039dc92a4dd7d608aced167a",
+        "rev": "a53c7797377b2ee8b019920ab4f183937b9dfab5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=c552e6d492ac42d6039dc92a4dd7d608aced167a";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=a53c7797377b2ee8b019920ab4f183937b9dfab5";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/a625efad9c10dee4a5f857c562b5e41626d17cf1"><pre>ocamlPackages.ansi: init at 0.7.0

Assisted-by: Claude Sonnet 4.6 (Anthropic)
Co-authored-by: Léo <16472988+redianthus@users.noreply.github.com></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5bae6f2287726944fa167d79bb2c681d43a99aeb"><pre>ocaml: Update license

OCaml has switched away from QPL to LGPL2.1 around 10 years ago:
https://github.com/ocaml/ocaml/commit/7fc2d214c4ee8853615fc3e5649f45e11d85378d
at the 4.04 release.

Nixpkgs does not have such old versions so might as well set the version
for all of them to \`lgpl21\`.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/67e4b85d40ba2809dd1bb293658c5414095f39e9"><pre>ocamlPackages.ocsigen-toolkit: 4.2.0 → 4.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/40fd09d2bafc4baa4d14afcbd2c8f872da588c94"><pre>ocamlPackages.apron: fix propagated inputs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5637900bd83807bc2647c2d817183850cff119b4"><pre>ocamlPackages.apronext: init at 1.0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ef4335d4017c0f1dae2837456d6f205bb1c12504"><pre>ocamlPackages.picasso: init at 0.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/335ff4070b2d7100f238e4433539b1ff3b4142f6"><pre>ocamlPackages.libabsolute: init at 0.3</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/120b31dcc754f889a38c02601ea10be96a5681c4"><pre>ocamlPackages.ocsigen-toolkit: 4.2.0 → 4.3.0 (#539961)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f6604e18a99f690e2e6142937609a2c7d6c53fdd"><pre>ocamlPackages.ansi: init at 0.7.0 (#535547)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/243a3c1790e4d1aef145724b25c2ddd9674f122e"><pre>Update license of OCaml (#537796)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5349cbc9bb06a6e7fdf11a93daed79d58a22b5a2"><pre>ocamlPackages.charon: 2026.07.01 -> 2026.07.16</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8eba732ecaa51ffb4c9d935809dfcce144d908d7"><pre>ocamlPackages.aeneas: 2026.07.01 -> 2026.07.16-bc2eb6f</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c3e871972508a567336241e5c0d97b9a0d65ea06"><pre>ocamlPackages.charon: 2026.07.01 -> 2026.07.10 (#540526)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/c552e6d492ac42d6039dc92a4dd7d608aced167a...a53c7797377b2ee8b019920ab4f183937b9dfab5