### PR TITLE
increase CI concurrency

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 args=(
   --flake ".#hydraJobs.${1}.${2}"
-  --http-connections 20
+  --jobs 30
+  --http-connections 50
   --copy-to
   "s3://overlays?endpoint=https://7a53c28e9b7a91239f9ed42da04276bc.r2.cloudflarestorage.com&region=auto&compression=zstd&parallel-compression=true&secret-key=${HOME}/.nix/nix-cache-key.sec"
   # --no-link
-  # --eval-workers 4
   # --skip-cached
   # --no-nom
   # --option allow-import-from-derivation false


### PR DESCRIPTION
Run CI with 30 evaluator/build workers and 50 HTTP connections.

Builds on #2533.