### PR TITLE
reduce CI worker concurrency

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 args=(
   --flake ".#hydraJobs.${1}.${2}"
-  --jobs 30
+  --jobs 8
   --http-connections 50
   --copy-to
   "s3://overlays?endpoint=https://7a53c28e9b7a91239f9ed42da04276bc.r2.cloudflarestorage.com&region=auto&compression=zstd&parallel-compression=true&secret-key=${HOME}/.nix/nix-cache-key.sec"


### PR DESCRIPTION
Run CI with 8 evaluator/build workers.

Follow-up to #2535.