### PR TITLE
build OCaml 5.5 musl packages on ARM Linux

### DIFF
--- a/ci/hydra.nix
+++ b/ci/hydra.nix
@@ -135,7 +135,13 @@ with filter;
       { }
   );
 
-  musl_5_5 = (if system == "x86_64-linux" then crossTarget pkgs.pkgsCross.musl64 "5_5" else { });
+  musl_5_5 =
+    if system == "x86_64-linux" then
+      crossTarget pkgs.pkgsCross.musl64 "5_5"
+    else if system == "aarch64-linux" then
+      crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "5_5"
+    else
+      { };
 
   # mingw cross-compilation (Windows) - only OCaml 5.4+ supported
   mingw_5_4 = (if system == "x86_64-linux" then crossTarget pkgs.pkgsCross.mingwW64 "5_4" else { });

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1638,6 +1638,9 @@ with oself;
   # https://github.com/NixOS/nixpkgs/blob/f6ed1c3c/pkgs/top-level/ocaml-packages.nix#L1035-L1037
   mdx = (osuper.mdx.override { inherit logs; }).overrideAttrs (o: {
     doCheck = false;
+    postInstall = (o.postInstall or "") + ''
+      mkdir -p $bin $lib
+    '';
   });
 
   melange-json-native = buildDunePackage {

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -28,9 +28,14 @@ overlay final prev
     let
       static-overlay = import ../static;
       musl64 = prev.pkgsCross.musl64.extend static-overlay;
+      native-musl =
+        if prev.stdenv.buildPlatform.isAarch64 then
+          prev.pkgsCross.aarch64-multiplatform-musl.extend static-overlay
+        else
+          musl64;
       native-musl-cc =
         let
-          cc = musl64.stdenv.cc;
+          cc = native-musl.stdenv.cc;
         in
         prev.runCommand "native-musl-cc-wrapper" { } ''
           mkdir -p $out/bin
@@ -43,7 +48,7 @@ overlay final prev
       musl-cross-overlay = prev.callPackage ../cross {
         buildPackages = prev.buildPackages;
         nativeCC = native-musl-cc;
-        nativeOCamlPackageSets = musl64.ocaml-ng;
+        nativeOCamlPackageSets = native-musl.ocaml-ng;
       };
     in
     prev.pkgsCross


### PR DESCRIPTION
Run and cache the OCaml 5.5 musl package set on an Ubuntu ARM runner.