### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784800284,
-        "narHash": "sha256-aegW1E+2ZJbIWTi6lRGfUD77qclmKARWJvRolEWmY9s=",
+        "lastModified": 1784941835,
+        "narHash": "sha256-ORuYUG6vcNf6Hsb2FGtQW34bmtzoA3oxi8J/YicbrrQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e77b9866887df0d9759099cef8e2de0845e70451",
+        "rev": "701b3fd657f582f3464354b24baf93e1ee579b03",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e77b9866887df0d9759099cef8e2de0845e70451",
+        "rev": "701b3fd657f582f3464354b24baf93e1ee579b03",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=e77b9866887df0d9759099cef8e2de0845e70451";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=701b3fd657f582f3464354b24baf93e1ee579b03";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/60b2653a8116c9cfcd91b0161444cb227920b9a2"><pre>ocamlPackages.digestif: 1.3.0 -> 1.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8a1dc046f19705bb3bf4d10c387f62d8696d05a0"><pre>ocamlPackages.mimic: 0.0.9 -> 0.0.10</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/def7d4d5df94552f684f4a656f1453204ca590ab"><pre>ocaml: fix cross-compile by adding bootstrapping ocaml

Fixes cross compilation looking for ocamlc:

checking if the installed OCaml compiler can build the cross compiler... ./configure: line 4348: ocamlc: command not found
no (5.4.1 vs )
configure: error: exiting

Assisted-by: DeepSeek V4 Flash</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a2ecb16d6f65a0ccfcee87a9f3c4e22756103aa8"><pre>ocamlPackages.ocamlfuse: drop</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f63f67e72dc374fc72465b148c44de2ef2ebb7ea"><pre>ocamlPackages.ocamlfuse: drop (#544403)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/363e06dfb5ba5c37d119f65185b6919c7ab60ed7"><pre>rocq-core: ocaml 5.4 -> 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5c3ee9cd8c348731ffb0a79349cdfb9d62492c05"><pre>ocamlPackages.mimic: 0.0.9 -> 0.0.10 (#541805)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e857b0dcbf314e4850d10c6fbb8f75e53db73196"><pre>ocamlPackages.digestif: 1.3.0 -> 1.3.1 (#541803)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/16611dafa6bd3de60c6ec430cf0e89205faadedb"><pre>ocaml: fix cross-compile by adding bootstrapping ocaml (#542468)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/e77b9866887df0d9759099cef8e2de0845e70451...701b3fd657f582f3464354b24baf93e1ee579b03