### PR TITLE
ci: limit build concurrency

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 args=(
   --flake ".#hydraJobs.${1}.${2}"
-  --jobs 8
+  --jobs 4
   --http-connections 50
   --copy-to
   "s3://overlays?endpoint=https://7a53c28e9b7a91239f9ed42da04276bc.r2.cloudflarestorage.com&region=auto&compression=zstd&parallel-compression=true&secret-key=${HOME}/.nix/nix-cache-key.sec"


### PR DESCRIPTION
Reduce nix-ci-build concurrency to avoid Nix daemon disconnects during cold builds.

Related to #2546.