### PR TITLE
cohttp: alias 5.3 compatibility packages

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -636,6 +636,7 @@ with oself;
     ];
     doCheck = false;
   });
+  cohttp_5_3 = cohttp;
   cohttp-async = osuper.cohttp-async.overrideAttrs (_: {
     postPatch =
       if lib.versionOlder "5.0" ocaml.version then
@@ -645,6 +646,7 @@ with oself;
           substituteInPlace "cohttp-async/src/client.ml" --replace-fail Ivar.fill_exn Ivar.fill
         '';
   });
+  cohttp-async_5_3 = cohttp-async;
   cohttp-server-lwt-unix = disableTests osuper.cohttp-server-lwt-unix;
   cohttp-lwt-jsoo = disableTests osuper.cohttp-lwt-jsoo;
   cohttp-top = disableTests osuper.cohttp-top;

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -647,6 +647,7 @@ with oself;
         '';
   });
   cohttp-async_5_3 = cohttp-async;
+  cohttp-lwt_5_3 = cohttp-lwt;
   cohttp-server-lwt-unix = disableTests osuper.cohttp-server-lwt-unix;
   cohttp-lwt-jsoo = disableTests osuper.cohttp-lwt-jsoo;
   cohttp-top = disableTests osuper.cohttp-top;


### PR DESCRIPTION
Alias the Cohttp 5.3 compatibility attributes to the patched Cohttp packages, avoiding duplicate builds and macOS test port conflicts.

Related to the macOS failure in https://github.com/nix-ocaml/nix-overlays/actions/runs/30180269576/job/89737663030.