### PR TITLE
ci: build OCaml 5.6 packages

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,9 +37,9 @@ jobs:
           - { ocaml-version: 5_4_fp, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5_fp, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
-          - { ocaml-version: 5_6, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
+          - { ocaml-version: 5_6, continue-on-error: true, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5, continue-on-error: false, os: ubuntu-26.04-arm, platform: aarch64-linux }
-          - { ocaml-version: 5_6, continue-on-error: false, os: ubuntu-26.04-arm, platform: aarch64-linux }
+          - { ocaml-version: 5_6, continue-on-error: true, os: ubuntu-26.04-arm, platform: aarch64-linux }
     name: Native packages (${{ matrix.setup.os }}, OCaml ${{ matrix.setup.ocaml-version }})
     runs-on: ${{ matrix.setup.os }}
     env:
@@ -104,7 +104,7 @@ jobs:
           - { os: macos-latest, target: aarch64-darwin, ocaml-version: 5_4_fp, continue-on-error: false }
           - { os: macos-latest, target: aarch64-darwin, ocaml-version: 5_5, continue-on-error: false }
           - { os: macos-latest, target: aarch64-darwin, ocaml-version: 5_5_fp, continue-on-error: false }
-          - { os: macos-latest, target: aarch64-darwin, ocaml-version: 5_6, continue-on-error: false }
+          - { os: macos-latest, target: aarch64-darwin, ocaml-version: 5_6, continue-on-error: true }
     name: Native packages (macOS (${{ matrix.setup.os }}), OCaml ${{ matrix.setup.ocaml-version }})
     runs-on: ${{ matrix.setup.os }}
     env:
@@ -141,9 +141,9 @@ jobs:
           - { ocaml-version: 5_3, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_4, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
-          - { ocaml-version: 5_6, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
+          - { ocaml-version: 5_6, continue-on-error: true, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5, continue-on-error: false, os: ubuntu-24.04-arm, platform: aarch64-linux }
-          - { ocaml-version: 5_6, continue-on-error: false, os: ubuntu-24.04-arm, platform: aarch64-linux }
+          - { ocaml-version: 5_6, continue-on-error: true, os: ubuntu-24.04-arm, platform: aarch64-linux }
         target:
           - arm64
           - musl

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,7 +37,9 @@ jobs:
           - { ocaml-version: 5_4_fp, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5_fp, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
+          - { ocaml-version: 5_6, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5, continue-on-error: false, os: ubuntu-26.04-arm, platform: aarch64-linux }
+          - { ocaml-version: 5_6, continue-on-error: false, os: ubuntu-26.04-arm, platform: aarch64-linux }
     name: Native packages (${{ matrix.setup.os }}, OCaml ${{ matrix.setup.ocaml-version }})
     runs-on: ${{ matrix.setup.os }}
     env:
@@ -102,6 +104,7 @@ jobs:
           - { os: macos-latest, target: aarch64-darwin, ocaml-version: 5_4_fp, continue-on-error: false }
           - { os: macos-latest, target: aarch64-darwin, ocaml-version: 5_5, continue-on-error: false }
           - { os: macos-latest, target: aarch64-darwin, ocaml-version: 5_5_fp, continue-on-error: false }
+          - { os: macos-latest, target: aarch64-darwin, ocaml-version: 5_6, continue-on-error: false }
     name: Native packages (macOS (${{ matrix.setup.os }}), OCaml ${{ matrix.setup.ocaml-version }})
     runs-on: ${{ matrix.setup.os }}
     env:
@@ -138,7 +141,9 @@ jobs:
           - { ocaml-version: 5_3, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_4, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
+          - { ocaml-version: 5_6, continue-on-error: false, os: ubuntu-latest, platform: x86_64-linux }
           - { ocaml-version: 5_5, continue-on-error: false, os: ubuntu-24.04-arm, platform: aarch64-linux }
+          - { ocaml-version: 5_6, continue-on-error: false, os: ubuntu-24.04-arm, platform: aarch64-linux }
         target:
           - arm64
           - musl

--- a/ci/hydra.nix
+++ b/ci/hydra.nix
@@ -71,6 +71,11 @@ with filter;
     ocamlVersion = "5_5";
     extraIgnores = extraIgnores ++ ocaml5Ignores;
   };
+  build_5_6 = ocamlCandidates {
+    inherit pkgs;
+    ocamlVersion = "5_6";
+    extraIgnores = extraIgnores ++ ocaml5Ignores;
+  };
 
   build_5_4_fp = ocamlCandidates {
     pkgs = framePointerPkgs "5_4";
@@ -156,6 +161,21 @@ with filter;
       crossTarget pkgs.pkgsCross.musl64 "5_5"
     else if system == "aarch64-linux" then
       crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "5_5"
+    else
+      { };
+
+  arm64_5_6 = (
+    if system == "x86_64-linux" then
+      crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "5_6"
+    else
+      { }
+  );
+
+  musl_5_6 =
+    if system == "x86_64-linux" then
+      crossTarget pkgs.pkgsCross.musl64 "5_6"
+    else if system == "aarch64-linux" then
+      crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "5_6"
     else
       { };
 


### PR DESCRIPTION
Build the OCaml 5.6 package set on Linux and macOS with failures enforced to surface compatibility issues.

Separate from #2555.