### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785452004,
-        "narHash": "sha256-k94ksv7XmaLeK5sE1ST/TTdu2aDEO9sfbcgEaNJPTXA=",
+        "lastModified": 1785486925,
+        "narHash": "sha256-pkLRv2U1hO3sW20eRYWmxY073lIcDk+Iii8SQF0pZKA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5e9f2fd9ef6011c6886d6935f3ef678c81385fa",
+        "rev": "6e046a96da8cdd8e784a50f553d7f8357f3e3a47",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5e9f2fd9ef6011c6886d6935f3ef678c81385fa",
+        "rev": "6e046a96da8cdd8e784a50f553d7f8357f3e3a47",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=a5e9f2fd9ef6011c6886d6935f3ef678c81385fa";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=6e046a96da8cdd8e784a50f553d7f8357f3e3a47";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/074f3053d13f6b2f6ce650de9b6e9af78fcd3e0d"><pre>coqPackages.coq-lsp: include \`pet-server\` and wrap all binaries

Adding \`lwt\` and \`logs\` to \`propagatedBuildInputs\` makes the build emit
the \`pet-server\` binary, too.

All binaries are now wrapped to have \`OCAMLPATH\` available.

\`-p \${pname}\` removed as it has no effect.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/fe3d616b77f25956120da77fa3a51f4da5079884"><pre>ocamlPackages.crunch: 4.0.0 → 4.1.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d489a86df8332dc751fa216f774025e2fe920e8f"><pre>ocamlPackages.frama-c-luncov: 0.2.4-unstable-2025-11-24 -> 0.2.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/48081132f50bb8948ab4fa25663fa5469cf9a6e1"><pre>ocamlPackages.frama-c-lannotate: 0.2.5 -> 0.2.6</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/90642c8e489e5b45ea5c26dcdee4002ff8a11be8"><pre>ocamlPackages.crunch: 4.0.0 -> 4.1.0 (#547106)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e046a96da8cdd8e784a50f553d7f8357f3e3a47"><pre>goshs: fix CVE-2026-66063 and CVE-2026-66064 (#547661)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e046a96da8cdd8e784a50f553d7f8357f3e3a47"><pre>goshs: fix CVE-2026-66063 and CVE-2026-66064 (#547661)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6e046a96da8cdd8e784a50f553d7f8357f3e3a47"><pre>goshs: fix CVE-2026-66063 and CVE-2026-66064 (#547661)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/a5e9f2fd9ef6011c6886d6935f3ef678c81385fa...6e046a96da8cdd8e784a50f553d7f8357f3e3a47