### PR TITLE
OCaml 5.5: use ppxlib 0.38.0 release

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2745,7 +2745,7 @@ with oself;
     version = "0.38.0";
     name = "ocaml${ocaml.version}-ppxlib-0.38.0";
     src =
-      if lib.versionOlder "5.5" ocaml.version then
+      if lib.versionOlder "5.6" ocaml.version then
         fetchFromGitHub {
           owner = "ocaml-ppx";
           repo = "ppxlib";


### PR DESCRIPTION
Use the ppxlib 0.38.0 release source for OCaml 5.5 while retaining the development snapshot for OCaml 5.6.

This lets the Dune Nix test closure use the nix-overlays cache (ocaml/dune#15643).