### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785825000,
-        "narHash": "sha256-8IX3ITYddN29r/lENhPnUBVGfSDP7JILfzzh5DPPit4=",
+        "lastModified": 1786111980,
+        "narHash": "sha256-pBV6CU1fOHWZFgeG2TRFzlG/MjjcTgnOTz5G3o95cH4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b6ce8cca68dd4ced6695be995b5dfb02383c39b",
+        "rev": "d7d1cfd03c6c2e4919d2ddac4a4e9acd6a3f2462",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b6ce8cca68dd4ced6695be995b5dfb02383c39b",
+        "rev": "d7d1cfd03c6c2e4919d2ddac4a4e9acd6a3f2462",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=8b6ce8cca68dd4ced6695be995b5dfb02383c39b";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=d7d1cfd03c6c2e4919d2ddac4a4e9acd6a3f2462";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/5ae00f6dc7c803d607e5da5e554e572a7fae0865"><pre>ocamlPackages.uring: 2.7.0 → 2.14.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f881e50d1776997409e7b6ffa0fe48078a898655"><pre>ocamlPackages.uring: remove pname usage in strings + fix changelog URL</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9ba1fb868ec05b76a8fb02150b962821284cdfbb"><pre>ocamlPackages.uring: remove rec</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/56c236fc6f67f63beb6e055c08460b2ed0080d4c"><pre>ocamlPackages.uring: 2.14.0 → 2.15.0

2.15.x requires ocaml ≥ 5.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c52cb8ad5790b22713d924db4dbd85c1f85f1fd8"><pre>ocamlPackages.eio: 1.3 → 1.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/44e4eed2ccf8a4b1da1d66557e07cae43c8ea2b6"><pre>ocamlPackages.elpi: fix typo</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/827c1a8ff9070659632ae883c79b3279afef4fe1"><pre>ocamlPackages.miou: 0.5.5 → 0.8.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0508fe02d2320b18e3e0da2d65b182030fcee128"><pre>ocamlPackages.miou: 0.5.5 -> 0.8.0 (#517109)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cded4f5cd4bcf57c7dfcae3b91e349273dcfad90"><pre>ocamlPackages.httpcats: 0.2.1 → 0.3.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8c1063e4097c6180fd6a42b42913c27d19dcf830"><pre>ocamlPackages.ninja_utils: 1.0.0 -> 2.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/eeedd0f66ca320520c56074715947bd4df605010"><pre>ocamlPackages.ninja_utils: 1.0.0 -> 2.0.0 (#549880)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/863c8be5512d915551d866603fb6465fa9a46206"><pre>ocamlPackages.uring: 2.7.0 → 2.15.0; ocamlPackages.eio: 1.3 → 1.4 (#524459)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/87963108030cda5cd8efab2a2ee5093f3fb849fd"><pre>ocamlPackages.httpcats: 0.2.1 → 0.3.1 (#549874)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8319baecf62e9e3bd736c4e7d7bdff5b63f7176"><pre>ocamlPackages.mtime: 2.1.0 → 2.2.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/81cc39b691e058f1aca7d102a337b75ee220d851"><pre>ocamlPackages.odoc: remove \`cmdliner_1\` override for 3.2 and newer

It\'s no longer needed after the test fixes in 3.2:

https://github.com/ocaml/odoc/commit/4fa086b11d14962f41d9717f03a9d8413a8c20dd

This moves the override into the \`default.nix\` so we can conditionally
apply the override for versions below 3.2.0.

Tested:

    nix-build -A ocamlPackages.odoc</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/16de9d44427d6a7db00975af1dc955aafd078f55"><pre>ocamlPackages.mtime: 2.1.0 -> 2.2.0 (#549888)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a4a52519ad33e72797fbb67b960c9a039ee1739"><pre>ocamlPackages.odoc: remove \`cmdliner_1\` override for 3.2 and newer (#550099)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/8b6ce8cca68dd4ced6695be995b5dfb02383c39b...d7d1cfd03c6c2e4919d2ddac4a4e9acd6a3f2462