### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786237299,
-        "narHash": "sha256-TdOIVJTuJ2eGUbjgXWe0X3Kbp6rR98V/2uRVAtKTHqs=",
+        "lastModified": 1786400526,
+        "narHash": "sha256-ABftAecb5leXFwM5EZodr2q4dmwuCH+tmdp8xde4ssA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60c768b1d7043edb84f25e2880ab2bd8327f6cfa",
+        "rev": "265b7e2dbbdbe2e59609fa31ed8be38cdb517d13",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60c768b1d7043edb84f25e2880ab2bd8327f6cfa",
+        "rev": "265b7e2dbbdbe2e59609fa31ed8be38cdb517d13",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=60c768b1d7043edb84f25e2880ab2bd8327f6cfa";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=265b7e2dbbdbe2e59609fa31ed8be38cdb517d13";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/93186429f2bf3339ffa9855888ca841c1f37a8b9"><pre>ocamlPackages.camlimages: drop camlimages.lablgtk2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9a61172a09d5eb87ab5be9ebd36f2f52bdb57f22"><pre>ocamlPackages.lablgtk: remove gtksourceview and libgnomecanvas

both of this libraries are part of the long-deprecated GNOME 2 desktop
and being removed from Nixpkgs. since they are optional dependencies for
lablgtk, we remove them from here as well.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a6f00aea9473f61456d06e6a9b54eb43c194b20c"><pre>ocamlPackages.ocamlgraph_gtk: drop

ocamlgraph_gtk has a hard dependency on libgnomecanvas via lablgtk.
libgnomecanvas is being removed from Nixpkgs. however, all users in-tree
just use \`ocamlPackages.ocamlgraph\`, so we drop
\`ocamlPackages.ocamlgraph_gtk\` entirely.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3d072e88ad52d331ebb74c1d14a0b48f353d7e6b"><pre>ocamlPackages.magic-trace: set to x86_64-linux only</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4d790b7f3fe5d03638b4849d6cb0cf50b1156adc"><pre>ocamlPackages.cohttp-async: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/69411a37a2d24de04b91a131adf2045f9b82084c"><pre>ocamlPackages.cohttp-eio: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ebc7ecf6d0540ae694f64f618f51e67fe240b6f9"><pre>ocamlPackages.cohttp_static_handler: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/daf876f6c4858477c2bda62071be7cbcbd8b6df5"><pre>ocamlPackages.cohttp_async_websocket: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a6ea38cbc8e48a9567e95ba2dfe7c0fbd10b3000"><pre>ocamlPackages.async_rpc_websocket: fix build on darwin</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/22d8bafd8c94f8701c818fa42cb69b7f75708fb1"><pre>ocamlPackages.ctypes-foreign: fix build for darwin ocaml 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/180bb059891edb2ec0fafdc0fc120a2525496267"><pre>ocamlPackages.jingoo: 1.5.2 → 1.5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/6a78bfc5c5e12c491262b67c5d59ac1ff88b6682"><pre>ocamlPackages.jingoo: 1.5.2 -> 1.5.4 (#541454)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/4348e45a8dd0cdc1997524f60e0e988711066d18"><pre>ocamlPackages.ppx_deriving_variant_string: disable tests with OCaml < 4.12</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/36ba106ed356837f964311831fb6098bb0eb0b4c"><pre>ocamlPackages.tls: 2.1.0 → 2.1.2</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/35275e21860f18f7859866767e909d0819d8e0b8"><pre>ocamlPackages.cohttp-async: fix build on darwin (#550596)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3bb67c0392022743dc7c58d044f3439fed8dd00b"><pre>ocamlPackages.magic-trace: set to x86_64-linux only (#550599)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3a0a68e967cc173f4011f778451a99302877a5dc"><pre>ocamlPackages.camlimages: drop camlimages.lablgtk2 (#544866)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/031cd9096bb847028cea26a9d41c86da11beb608"><pre>ocamlPackages.ppx_deriving_variant_string: disable tests with OCaml < 4.12 (#551028)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/91e329f5f857c439c110c76a6774f79fb46d4c85"><pre>ocamlPackages.tls: 2.1.0 → 2.1.2 (#551034)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/60c768b1d7043edb84f25e2880ab2bd8327f6cfa...265b7e2dbbdbe2e59609fa31ed8be38cdb517d13