### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786400526,
-        "narHash": "sha256-ABftAecb5leXFwM5EZodr2q4dmwuCH+tmdp8xde4ssA=",
+        "lastModified": 1786476143,
+        "narHash": "sha256-bKD012WTTrR0/I6/Ab0Yx1JwO9OvUdhfzllFlfLE9Aw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "265b7e2dbbdbe2e59609fa31ed8be38cdb517d13",
+        "rev": "ef33b28e97233dac04666e34f26027c44f5db08b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "265b7e2dbbdbe2e59609fa31ed8be38cdb517d13",
+        "rev": "ef33b28e97233dac04666e34f26027c44f5db08b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=265b7e2dbbdbe2e59609fa31ed8be38cdb517d13";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=ef33b28e97233dac04666e34f26027c44f5db08b";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/130b523c34f45df258f856f19c1084fce3bf3061"><pre>ocamlPackages.eio: disable tests with OCaml < 5.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/81ca649c114fb5c7cd623b5701c9550745cae724"><pre>ocamlPackages.eio-ssl: fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/9b9ba3931c0c6d808ac39966bfe4755c09f5db71"><pre>ocamlPackages.piaf: fix build</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/92ae09009b6f0fa61bcb08183899a53a8fb5f4f6"><pre>ocamlPackages.mirage-crypto: 2.1.0 → 2.3.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/f6f97152d55c772337e0cc3cb91a14cd316e88f5"><pre>ocamlPackages.lablgtk-extras: remove at 1.6 (broken)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c0d425c553cae6400beebd536ddadf9fe400805c"><pre>ocamlPackages.wasm: clean-up</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/03fd498e84d5b1f8493d6edc82a07742117af26b"><pre>ocamlPackages.wasm: clean-up (#550135)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0a94a5869594733dc81e97d095ae709759b92842"><pre>ocamlPackages.lablgtk-extras: remove at 1.6 (broken) (#551281)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/cdf55c1c05fe8140bf58c2b23b7db45016fb0c9a"><pre>ocamlPackages.mirage-crypto: 2.1.0 → 2.3.0 (#551266)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dab93fc2b47f6554813fb9db5d7273cdfa800b79"><pre>ocamlPackages.{eio-ssl,piaf}: fix build (#550157)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ef33b28e97233dac04666e34f26027c44f5db08b"><pre>python3Packages.azure-keyvault-keys: 4.11.0 -> 4.11.1 (#538850)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ef33b28e97233dac04666e34f26027c44f5db08b"><pre>python3Packages.azure-keyvault-keys: 4.11.0 -> 4.11.1 (#538850)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ef33b28e97233dac04666e34f26027c44f5db08b"><pre>python3Packages.azure-keyvault-keys: 4.11.0 -> 4.11.1 (#538850)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ef33b28e97233dac04666e34f26027c44f5db08b"><pre>python3Packages.azure-keyvault-keys: 4.11.0 -> 4.11.1 (#538850)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ef33b28e97233dac04666e34f26027c44f5db08b"><pre>python3Packages.azure-keyvault-keys: 4.11.0 -> 4.11.1 (#538850)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ef33b28e97233dac04666e34f26027c44f5db08b"><pre>python3Packages.azure-keyvault-keys: 4.11.0 -> 4.11.1 (#538850)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/265b7e2dbbdbe2e59609fa31ed8be38cdb517d13...ef33b28e97233dac04666e34f26027c44f5db08b