### PR TITLE
upgrade nix-eval-jobs to 2.35.1 and update nix-ci-build

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 args=(
   --flake ".#hydraJobs.${1}.${2}"
   --jobs 4
-  --http-connections 50
   --copy-to
   "s3://overlays?endpoint=https://7a53c28e9b7a91239f9ed42da04276bc.r2.cloudflarestorage.com&region=auto&compression=zstd&parallel-compression=true&secret-key=${HOME}/.nix/nix-cache-key.sec"
+  # --http-connections 50
   # --no-link
   # --skip-cached
   # --no-nom

--- a/ocaml/ocaml5.nix
+++ b/ocaml/ocaml5.nix
@@ -149,8 +149,8 @@ with oself;
     src = fetchFromGitHub {
       owner = "nix-ocaml";
       repo = "nix-ci-build";
-      rev = "328a9485d3da222a92ddd26a865e06a8c30305df";
-      hash = "sha256-fHTnFRXW18dTNh5yTSwgVj031XbKv8ZvzA4nn7vi8cs=";
+      rev = "6bd1c9e76938c9379d6f1fb35aec694a8577c271";
+      hash = "sha256-EylUmE15IgC8xvW4mahCu0qPQfbmEG/scgBJAFrZHHI=";
     };
 
     nativeBuildInputs = [ makeWrapper ];

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -152,12 +152,12 @@ in
       nixComponents = super.nixVersions.nixComponents_2_35;
     }).overrideAttrs
       (_: {
-        version = "2.35.0";
+        version = "2.35.1";
         src = fetchFromGitHub {
-          owner = "anmonteiro";
+          owner = "NixOS";
           repo = "nix-eval-jobs";
-          rev = "ff3b82d0895b68e2a802aa0ab6f726f269c785d8";
-          hash = "sha256-Qt9DoSrIeqhLddUuTT9B9doANM2kKrCRPVsO8PX+SR0=";
+          rev = "5f1fe8040163c58a4a975dbe42e6624f6c948aa4";
+          hash = "sha256-EFJnN35L7UieL8zV8qPrpqfdfzztWksY8JYuXF+mr9o=";
         };
       });
 


### PR DESCRIPTION
Upgrades nix-eval-jobs to 2.35.1 and updates nix-ci-build to its Nix 2.35-compatible revision.