### PR TITLE
caqti: update to 3.0.1

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -519,10 +519,10 @@ with oself;
   });
 
   caqti = osuper.caqti.overrideAttrs (o: {
-    version = "2.2.4";
+    version = "3.0.1";
     src = builtins.fetchurl {
-      url = "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.2.4/caqti-v2.2.4.tbz";
-      sha256 = "1fzq1brw9na4p22m20xjw19qbk869cj7nkrc2faw0khm40l47smq";
+      url = "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.1/caqti-v3.0.1.tbz";
+      sha256 = "sha256-2jlrKg560pk5U1pUTAg6rK77FKcb+EcZYAS2C+lP2ys=";
     };
     propagatedBuildInputs = o.propagatedBuildInputs ++ [
       ipaddr
@@ -530,6 +530,7 @@ with oself;
       dune-site
       lru
       lwt-dllist
+      x509
     ];
     nativeCheckInputs = [ mdx ];
     checkInputs = [
@@ -1685,10 +1686,10 @@ with oself;
 
   mariadb = buildDunePackage {
     pname = "mariadb";
-    version = "1.2.0";
+    version = "2.0.0";
     src = builtins.fetchurl {
-      url = "https://github.com/ocaml-community/ocaml-mariadb/releases/download/1.2.0/mariadb-1.2.0.tbz";
-      sha256 = "0sgsljalrvm1hcr8gh58hlqqyzbdsldfm19cq53gpr14i6jl6rm0";
+      url = "https://github.com/ocaml-community/ocaml-mariadb/releases/download/2.0.0/mariadb-2.0.0.tbz";
+      sha256 = "sha256-MnsGPH4gAs401Y8/uvrvRx21stQSVrU9RYpC2T8TEcw=";
     };
     buildInputs = [
       dune-configurator

--- a/ocaml/dream/caqti-3.patch
+++ b/ocaml/dream/caqti-3.patch
@@ -1,0 +1,12 @@
+diff --git a/src/sql/dune b/src/sql/dune
+index 7d01018..820991a 100644
+--- a/src/sql/dune
++++ b/src/sql/dune
+@@ -3,6 +3,7 @@
+  (name dream__sql)
+  (libraries
+   caqti
++  caqti.classic
+   caqti-lwt
+   caqti-lwt.unix
+   dream.cipher

--- a/ocaml/dream/default.nix
+++ b/ocaml/dream/default.nix
@@ -40,6 +40,8 @@ buildDunePackage {
   pname = "dream";
   inherit (dream-pure) src version;
 
+  patches = [ ./caqti-3.patch ];
+
   postPatch = ''
     substituteInPlace src/http/adapt.ml \
       --replace-fail \

--- a/ocaml/ppx_rapper/default.nix
+++ b/ocaml/ppx_rapper/default.nix
@@ -10,18 +10,18 @@
 
 buildDunePackage {
   pname = "ppx_rapper";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "roddyyaga";
     repo = "ppx_rapper";
-    rev = "ac71881c7ef1c40c4996c0080365bf2f12d275d1";
-    hash = "sha256-2XTpk1kUakxddcR7ZBiv4hynV6dznDy//G7914azJKU=";
+    rev = "764f71a3b6b6f0416896efec5ef5bca352e5c81b";
+    hash = "sha256-N+x620aYGPn3aXnDXuZURD6GpuPh/K1TvXCS+cicVXU=";
   };
 
   postPatch = lib.optionalString (lib.versionOlder ppxlib.version "0.36") ''
     substituteInPlace ppx/ppx_rapper.ml \
-      --replace-fail "       ~constraint_:drop" ""
+      --replace-fail "          ~constraint_:drop" ""
   '';
 
   buildInputs = [ ppxlib ];


### PR DESCRIPTION
Updates Caqti to 3.0.1, ppx_rapper to 3.1.0 with Caqti 3 support, and required dependents.