### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786935457,
-        "narHash": "sha256-kraAoy5+byR1VkJdQk2FTPSUAN6Pta4fyN3ywHcPAcc=",
+        "lastModified": 1786987418,
+        "narHash": "sha256-YFespwm5tJqJ43M5/sga9dq74SIoOUiZS4qXciA7kcA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4df4976d944e0057c4c9f99919c6cda2c623563a",
+        "rev": "2a747aca22036dce3677fd41877427e3cd33e87a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4df4976d944e0057c4c9f99919c6cda2c623563a",
+        "rev": "2a747aca22036dce3677fd41877427e3cd33e87a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=4df4976d944e0057c4c9f99919c6cda2c623563a";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=2a747aca22036dce3677fd41877427e3cd33e87a";
   };
 
   outputs =

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2099,13 +2099,10 @@ with oself;
     let
       xen' = xen.override { ocamlPackages = oself; };
     in
-    (osuper.oxenstored.override { xen = xen'; }).overrideAttrs (o: {
-      meta = (o.meta or { }) // {
-        platforms = lib.filter (
-          system: lib.meta.availableOn (lib.systems.elaborate system) xen'
-        ) lib.systems.flakeExposed;
-      };
-    });
+    if lib.meta.availableOn stdenv.hostPlatform xen' then
+      osuper.oxenstored.override { xen = xen'; }
+    else
+      null;
 
   ocsipersist-lib = osuper.ocsipersist-lib.overrideAttrs (o: {
     buildInputs = [ ];

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -44,6 +44,7 @@
   libsodium,
   cairo,
   gtk2,
+  xen,
   rdkafka-oc,
   zlib-oc,
   zstd-oc,
@@ -2093,6 +2094,16 @@ with oself;
       platforms = lib.platforms.all;
     };
   });
+
+  oxenstored =
+    let
+      xen' = xen.override { ocamlPackages = oself; };
+    in
+    (osuper.oxenstored.override { xen = xen'; }).overrideAttrs (o: {
+      meta = (o.meta or { }) // {
+        inherit (xen'.meta) platforms badPlatforms;
+      };
+    });
 
   ocsipersist-lib = osuper.ocsipersist-lib.overrideAttrs (o: {
     buildInputs = [ ];

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2101,7 +2101,9 @@ with oself;
     in
     (osuper.oxenstored.override { xen = xen'; }).overrideAttrs (o: {
       meta = (o.meta or { }) // {
-        inherit (xen'.meta) platforms badPlatforms;
+        platforms = lib.filter (
+          system: lib.meta.availableOn (lib.systems.elaborate system) xen'
+        ) lib.systems.flakeExposed;
       };
     });
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/e138d3aa7503ed4d96629319af07f04a0fc69372"><pre>xen: 4.20.4 -> 4.22.0

- Updates Xen to 4.22, which includes the new json_c requirement inherited from 4.21.
- Wraps ./configure flags in helper Nix functions.
- Fixes the missing \`ocamlbuild\` binary.
- Cleans up a comment left inside the script area of the \`installPhase\`.

Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net>
Co-authored-by: Yaroslav Bolyukin <iam@lach.pw>
Co-authored-by: Rane <rane+git@junkyard.systems></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b59e8eeb82a01eb2f5da7f7d35d8836fb3ba23d2"><pre>xen: split ocaml library into a separate output

This is necessary so an externally built oxenstored can link to the main Xen libraries.

Co-authored-by: Fernando Rodrigues <alpha@sigmasquadron.net>
Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/947098f3570396e8197969e4768383c7cb207926"><pre>ocamlPackages.oxenstored: init at 25.3.0

Co-authored-by: Rane <rane+git@junkyard.systems>
Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c86fab4333c60aac28e5842fac4f766df907c2e4"><pre>nixos/xen: support the separate ocaml store package

This will hopefully allow Xen to use the newer oxenstored instead of
the deprecated one built into the monorepo.

Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2a747aca22036dce3677fd41877427e3cd33e87a"><pre>staging-nixos merge #2 for 2026-08-17 (#553678)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2a747aca22036dce3677fd41877427e3cd33e87a"><pre>staging-nixos merge #2 for 2026-08-17 (#553678)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/2a747aca22036dce3677fd41877427e3cd33e87a"><pre>staging-nixos merge #2 for 2026-08-17 (#553678)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/4df4976d944e0057c4c9f99919c6cda2c623563a...2a747aca22036dce3677fd41877427e3cd33e87a