### PR TITLE
avoid rebuilding Xen for mismatched OCaml sets

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -2096,11 +2096,10 @@ with oself;
   });
 
   oxenstored =
-    let
-      xen' = xen.override { ocamlPackages = oself; };
-    in
-    if lib.meta.availableOn stdenv.hostPlatform xen' then
-      osuper.oxenstored.override { xen = xen'; }
+    if
+      lib.meta.availableOn stdenv.hostPlatform xen && lib.elem ocaml (xen.nativeBuildInputs or [ ])
+    then
+      osuper.oxenstored
     else
       null;
 


### PR DESCRIPTION
Expose oxenstored only when Xen was built with the same OCaml compiler, avoiding full Xen/SeaBIOS rebuilds across compiler sets. Follow-up to #2617.