### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786987418,
-        "narHash": "sha256-YFespwm5tJqJ43M5/sga9dq74SIoOUiZS4qXciA7kcA=",
+        "lastModified": 1787090093,
+        "narHash": "sha256-Qv3TVuOP1/43EjcNVPIX1P/39m1jEcQ7l5b/Kc9BAbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2a747aca22036dce3677fd41877427e3cd33e87a",
+        "rev": "d68cbd890248f6e1c17c681f3c2b21f2436cd3f6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2a747aca22036dce3677fd41877427e3cd33e87a",
+        "rev": "d68cbd890248f6e1c17c681f3c2b21f2436cd3f6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=2a747aca22036dce3677fd41877427e3cd33e87a";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=d68cbd890248f6e1c17c681f3c2b21f2436cd3f6";
   };
 
   outputs =

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1815,13 +1815,6 @@ with oself;
     ];
   };
 
-  mirage-logs = osuper.mirage-logs.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = "https://github.com/mirage/mirage-logs/releases/download/v2.1.0/mirage-logs-2.1.0.tbz";
-      sha256 = "1fww8q0an84wiqfwycqlv9chc52a9apf6swbiqk28h1v1jrc52mf";
-    };
-  });
-
   msat = osuper.msat.overrideAttrs (o: {
     postPatch = (o.postPatch or "") + ''
       substituteInPlace dune \


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/35e8276463bc8bd221d5c123001738ebcc1f414b"><pre>ocamlPackages.pacomb: 1.4.3 -> 1.4.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a4162eb067c758ba34925d291cda29cea05d9a91"><pre>ocamlPackages.pacomb: 1.4.3 -> 1.4.4 (#546508)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dafb1126315db50d176d963f85b1c8f8e824791a"><pre>ocamlPackages.cmdliner-stdlib: init at 1.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/0b1cbc3f587fa980c37c7b06f04aa40293a0a755"><pre>ocamlPackages.cmdliner-stdlib: init at 1.0.1 (#553886)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/3a106f647206ec693c470bb5f3655eea07ec71e0"><pre>ocamlPackages.mirage-bootvar: init at 1.0.1</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8a4404e49b8184ac70098ab8deb6f52700007338"><pre>ocamlPackages.mirage-logs: 2.1.0 -> 3.0.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/5c8ba696a3e8aaa2a2868a81494bbd1a26eccf32"><pre>ocamlPackages.cmdliner-stdlib: drop extraneous minimalOCamlVersion</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/51498c131357689272906a859ce2c77c439f4d6f"><pre>ocamlPackages.mirage-bootvar: init at 1.0.1 (#553889)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8c223b09535a81a78d4e85462f75404cc175a3ca"><pre>ocamlPackages.buildDunePackage: allow multiple dune packages

A single \`dune-project\` file can contain multiple packages that dune can
build. This is a problem, because the default dune build command we use
doesn\'t search through \`dune-project\` for dependencies, it assumes that
will have already been built and can be found with findlib. See
zipperposition for an example of this.

Adds a new \`dunePackages\` argument to allow this, defaulting to \`[ pname ]\`
for backwards compatibility.</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/b6c2725f1208c66437095d28c5b84e6a173d9e3c"><pre>ocamlPackages.buildDunePackage: allow multiple dune packages (#553950)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d68cbd890248f6e1c17c681f3c2b21f2436cd3f6"><pre>terraform-providers.hashicorp_aws: 6.58.0 -> 6.60.0 (#553990)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/d68cbd890248f6e1c17c681f3c2b21f2436cd3f6"><pre>terraform-providers.hashicorp_aws: 6.58.0 -> 6.60.0 (#553990)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/2a747aca22036dce3677fd41877427e3cd33e87a...d68cbd890248f6e1c17c681f3c2b21f2436cd3f6