### PR TITLE
ci: filter unavailable packages

### DIFF
--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -284,7 +284,7 @@ rec {
               v = eval_result.value;
               broken = (v ? meta && v.meta ? broken && v.meta.broken);
             in
-            (lib.isDerivation v) && !broken
+            (lib.isDerivation v) && !broken && lib.meta.availableOn stdenv.hostPlatform v
           )
     ) ocamlPackages;
 


### PR DESCRIPTION
Filter platform-incompatible derivations from CI package candidates. Split from #2632.