### PR TITLE
ci: cache Terraform

### DIFF
--- a/ci/hydra.nix
+++ b/ci/hydra.nix
@@ -90,7 +90,7 @@ with filter;
   };
 
   build_top-level-packages = {
-    inherit (pkgs) melange-relay-compiler;
+    inherit (pkgs) melange-relay-compiler terraform;
   }
   // (
     if stdenv.isLinux then


### PR DESCRIPTION
Cache Terraform builds in the overlays binary cache.