### PR TITLE
ocaml: update 5.5 to 5.5.1

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -3011,8 +3011,8 @@ with oself;
     src = fetchFromGitHub {
       owner = "anmonteiro";
       repo = "stdcompat";
-      rev = "2a2f6ecee24b3f97acc6be4f23050f98506f08dd";
-      hash = "sha256-Dwjq+bMg1wBvbsJOXtTAQbX0COvx3vChNRLRHYjLRUc=";
+      rev = "23058cc632c4fcd3aaa6f7fe75fb47f71e684e37";
+      hash = "sha256-0MFceuHJo0kPRHpSbiSZfIDt9RAzpjoD/mUeA/Gd6IU=";
     };
 
     dontConfigure = true;

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -172,15 +172,15 @@ let
           ocamlPackages_5_5 = newOCamlScope {
             major_version = "5";
             minor_version = "5";
-            patch_version = "0";
+            patch_version = "1";
             hardeningDisable = [ "strictoverflow" ];
             postPatch = "";
-            patches = [ ./ocaml-14933.patch ];
+            patches = [ ];
             src = super.fetchFromGitHub {
               owner = "ocaml";
               repo = "ocaml";
-              rev = "5.5.0";
-              hash = "sha256-1ZaY+u3SM66pg7aJi1viLyDjCcXoJBHm3oBzYqjJVmY=";
+              rev = "5.5.1";
+              hash = "sha256-/3JzqLaUHstjCKuWV0JEfBMdYlr2R+kH6tzf5DcLYTY=";
               fetchSubmodules = true;
             };
           };


### PR DESCRIPTION
Update OCaml 5.5 to 5.5.1, drop the included musl patch, and track stdcompat with 5.5.1 support. Related to ocaml/opam-repository#30637.