### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788761488,
-        "narHash": "sha256-mu5sizob4fS6ECwiwFMIlLRn5OZt/DlY29E1xK7ArZc=",
+        "lastModified": 1788794787,
+        "narHash": "sha256-kf4mdS6Wrp+0XqtcUqwH9tu4RzomEJMSAFgIn+VtxMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9485e5e151b6bcea0fef6980325ec8fb4194d30c",
+        "rev": "aaea627de08c837efcab44ca1655bfd826109c3a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9485e5e151b6bcea0fef6980325ec8fb4194d30c",
+        "rev": "aaea627de08c837efcab44ca1655bfd826109c3a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=9485e5e151b6bcea0fef6980325ec8fb4194d30c";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=aaea627de08c837efcab44ca1655bfd826109c3a";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/cc76df272916cf7a350f3a5837653104e1ab8ba0"><pre>ocamlPackages.ocamlformat-mlx-lib: remove unused input odoc</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/22efa6dc5fb80bb0718ef0410e3fbc67df046fc5"><pre>ocamlPackages.ocamlformat-mlx: remove unused input odoc</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/19d059982da361b99eb16aed11883a7cddc46780"><pre>ocamlPackages.ocamlmerlin-mlx: remove unused input odoc</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1c00120c45b6543289b80aa6af65b92d896dcdcf"><pre>ocamlPackages.odig: remove unused input odoc</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c2061ec99fbc9a8230298e51c20ba6b6b3925271"><pre>ocamlPackages.dune-release: remove unused input odoc</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/dc0a9a19637dce7ed024595be3337fe899337b8f"><pre>ocamlPackages.odoc: split into multiple outputs</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bb3f30606fefc836df1037cfd900da91a977a676"><pre>ocamlPackages.odoc.bin: remove references to OCaml</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/ec9975fa12ead6e9d26cac9f8dd85e4e182b743f"><pre>ocamlPackages.ocp-indent: 1.9.0 -> 1.10.0</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c68db5435b6812736edd621d9b6e1444d5b0cd83"><pre>ocamlPackages.ocp-indent: 1.9.0 -> 1.10.0 (#559631)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/a9268a0c82cb915a8eaff74e97409b42855e0506"><pre>ocamlPackages.odoc: split into multiple outputs (#559002)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aaea627de08c837efcab44ca1655bfd826109c3a"><pre>camunda-modeler: 5.50.1 -> 5.51.0 (#557434)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aaea627de08c837efcab44ca1655bfd826109c3a"><pre>camunda-modeler: 5.50.1 -> 5.51.0 (#557434)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aaea627de08c837efcab44ca1655bfd826109c3a"><pre>camunda-modeler: 5.50.1 -> 5.51.0 (#557434)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aaea627de08c837efcab44ca1655bfd826109c3a"><pre>camunda-modeler: 5.50.1 -> 5.51.0 (#557434)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aaea627de08c837efcab44ca1655bfd826109c3a"><pre>camunda-modeler: 5.50.1 -> 5.51.0 (#557434)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aaea627de08c837efcab44ca1655bfd826109c3a"><pre>camunda-modeler: 5.50.1 -> 5.51.0 (#557434)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aaea627de08c837efcab44ca1655bfd826109c3a"><pre>camunda-modeler: 5.50.1 -> 5.51.0 (#557434)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/aaea627de08c837efcab44ca1655bfd826109c3a"><pre>camunda-modeler: 5.50.1 -> 5.51.0 (#557434)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/9485e5e151b6bcea0fef6980325ec8fb4194d30c...aaea627de08c837efcab44ca1655bfd826109c3a