### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788861675,
-        "narHash": "sha256-8gy+zzaqfPS66V266KUUpz2UXH5I5wfDf/mDG6xunnQ=",
+        "lastModified": 1788897735,
+        "narHash": "sha256-OQfhKPJi7N4j2dTaAgmh7szHcFXcwIF89kccdIy8UzI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "003f062570b04be4890c4acdcd970365281fc955",
+        "rev": "c8d3b8cdb3959a35bb0af0de111b7d13caf79896",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "003f062570b04be4890c4acdcd970365281fc955",
+        "rev": "c8d3b8cdb3959a35bb0af0de111b7d13caf79896",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=003f062570b04be4890c4acdcd970365281fc955";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=c8d3b8cdb3959a35bb0af0de111b7d13caf79896";
   };
 
   outputs =


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/d8a628df371e38d77b7849ed6b83be2614a1b409"><pre>ocamlPackages.oxenstored: patch with XSA-512

            Xen Security Advisory CVE-2026-79604 / XSA-512
                               version 3

             oxenstored: Unbounded accumulation of watches

Oxenstored maintains two datastructures about watches; one global trie,
and one hashtable tracked per domain.  When a xenbus reconnect is
requested, watches are not cleared out of the global trie.

A guest can cause unbounded memory usage in oxenstored.  This can lead
to a system-wide DoS.

This is the XAPI oxenstored patch.

https://xenbits.xenproject.org/xsa/advisory-512.html

Signed-off-by: Fernando Rodrigues <alpha@sigmasquadron.net></pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/c8d3b8cdb3959a35bb0af0de111b7d13caf79896"><pre>goofcord: 2.2.1 → 2.3.0 (#549255)</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/003f062570b04be4890c4acdcd970365281fc955...c8d3b8cdb3959a35bb0af0de111b7d13caf79896