### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1789066991,
-        "narHash": "sha256-mYXwtit5YUXIJu7Ov5Ln5Qe7hsi844NRlbU7306fdPs=",
+        "lastModified": 1789149629,
+        "narHash": "sha256-H6GwaZzZf+4npqv0tph94w9tZddSjFjmQrVsW0z78uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd9326274b99a087d554057e76312fe93be8bfbb",
+        "rev": "eaad089433ca2bb662274377d33df3d0e51ef28b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd9326274b99a087d554057e76312fe93be8bfbb",
+        "rev": "eaad089433ca2bb662274377d33df3d0e51ef28b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=bd9326274b99a087d554057e76312fe93be8bfbb";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=eaad089433ca2bb662274377d33df3d0e51ef28b";
   };
 
   outputs =

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -170,22 +170,22 @@ in
       (super.callPackage "${nixpkgs}/pkgs/servers/sql/postgresql/generic.nix" (
         import "${nixpkgs}/pkgs/servers/sql/postgresql/18.nix" // { inherit self; }
       )).override
-      {
-        # a new change does some shenanigans to get llvmStdenv + lld which breaks
-        # our cross-compilation
-        overrideCC = _: _: stdenv;
-        systemdSupport = false;
-        gssSupport = false;
-        openssl = self.openssl-oc;
-        jitSupport = false;
-        pamSupport = false;
-        perlSupport = false;
-        pythonSupport = false;
-        tclSupport = false;
-        lz4 = self.lz4-oc;
-        zstd = self.zstd-oc;
-        zlib = self.zlib-oc;
-      }
+        {
+          # a new change does some shenanigans to get llvmStdenv + lld which breaks
+          # our cross-compilation
+          overrideCC = _: _: stdenv;
+          systemdSupport = false;
+          gssSupport = false;
+          openssl = self.openssl-oc;
+          jitSupport = false;
+          pamSupport = false;
+          perlSupport = false;
+          pythonSupport = false;
+          tclSupport = false;
+          lz4 = self.lz4-oc;
+          zstd = self.zstd-oc;
+          zlib = self.zlib-oc;
+        }
     ).overrideAttrs
       (
         finalAttrs: o:

--- a/static/default.nix
+++ b/static/default.nix
@@ -47,6 +47,12 @@ self: super:
         propagatedBuildInputs = o.buildInputs;
       });
 
+  # SQLite's devtest target creates fresh builds without preserving the
+  # original cross-compilation configuration.
+  sqlite = super.sqlite.overrideAttrs (_: {
+    doCheck = false;
+  });
+
   sqlite-oc = (super.sqlite-oc.override { zlib = self.zlib-oc; }).overrideAttrs (o: {
     dontDisableStatic = true;
   });


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href="https://github.com/NixOS/nixpkgs/commit/8b34a1b0b8dbee9bcb2674d8136c6c0e94b3fdaf"><pre>abella: make compatible with OCaml 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/8b4b3fabf3c6d5969f0d34f7164be183144fb1bf"><pre>hol_light: use OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/1cf097327e228409ac8324c4f070eb6419265190"><pre>diffoscope: use OCaml 5.4</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/854009ea6a1d6e752828e46eab07a743e0ea07bd"><pre>ocaml: default to version 5.5</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/e2e4a69e5018272dce537182e614aa9e5bf42f69"><pre>ocaml: default to version 5.5 (#554609)</pre></a>
* <a href="https://github.com/NixOS/nixpkgs/commit/bac047125692620c3577cf6611e88bf4fa1550dd"><pre>hol_light: 0-unstable-2026-05-19 -> 0-unstable-2026-09-02

Build with the default OCaml again as upstream has added OCaml 5.5
support.
Drop the pa_j chooser patch as it was merged upstream.

Signed-off-by: Matthias J. Kannwischer <matthias@zerorisc.com></pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/bd9326274b99a087d554057e76312fe93be8bfbb...eaad089433ca2bb662274377d33df3d0e51ef28b